### PR TITLE
Add --native flag for non-containerized workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 - `bubble skill install/uninstall/status` commands for managing the Claude Code skill
 - Skill file bundled with the package at `bubble/data/skill.md`
 - Auto-install the skill on first `bubble open` when Claude Code is detected
+- Native mode: `bubble --native <target>` creates non-containerized workspaces
+- Clones into `~/.bubble/native/<name>/` with shared git objects
+- Prints prominent warning about lack of isolation
+- `bubble list` shows native workspaces with location "native"
+- `bubble pop` supports native workspaces with dirty-check confirmation
+- `bubble pause` rejects native workspaces (no container state to freeze)
+- Cleanness checking for native workspaces (dirty worktree, unpushed commits)
 
 ## 0.5.7 — 2026-02-17
 - Remote-aware `bubble list`: shows cloud and SSH-remote bubbles from registry

--- a/bubble/clean.py
+++ b/bubble/clean.py
@@ -163,6 +163,139 @@ def _parse_check_output(output: str) -> CleanStatus:
     return CleanStatus(clean=False, error="unexpected output")
 
 
+def check_native_clean(native_path: str, name: str) -> CleanStatus:
+    """Check if a native workspace is clean (safe to pop without data loss).
+
+    Runs git checks directly on the local filesystem path.
+    """
+    import subprocess
+    from pathlib import Path
+
+    path = Path(native_path)
+    if not path.exists():
+        return CleanStatus(clean=False, error="path not found")
+
+    git_dir = path / ".git"
+    if not git_dir.exists():
+        return CleanStatus(clean=False, error="not a git repo")
+
+    reasons = []
+
+    # Check for dirty working tree
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return CleanStatus(clean=False, error="check failed")
+        if result.stdout.strip():
+            reasons.append("dirty_worktree")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return CleanStatus(clean=False, error="check failed")
+
+    # Check for stashes
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "stash", "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return CleanStatus(clean=False, error="check failed")
+        if result.stdout.strip():
+            reasons.append("stashes")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return CleanStatus(clean=False, error="check failed")
+
+    # Check for unpushed commits on all branches
+    info = get_bubble_info(name)
+    initial_commit = info.get("commit", "") if info else ""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(path),
+                "for-each-ref",
+                "--format=%(refname:short)",
+                "refs/heads/",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return CleanStatus(clean=False, error="check failed")
+        for branch in result.stdout.strip().splitlines():
+            branch = branch.strip()
+            if not branch:
+                continue
+            # Check if branch has a tracking upstream configured.
+            # Use git-config (not rev-parse) to distinguish "no upstream"
+            # from "upstream configured but can't resolve" (fail-closed).
+            has_remote = subprocess.run(
+                ["git", "-C", str(path), "config", "--get", f"branch.{branch}.remote"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if has_remote.returncode == 0 and has_remote.stdout.strip():
+                # Upstream configured; resolve the actual ref
+                upstream = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(path),
+                        "rev-parse",
+                        "--verify",
+                        f"{branch}@{{upstream}}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if upstream.returncode != 0:
+                    return CleanStatus(clean=False, error="check failed")
+                ahead = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(path),
+                        "rev-list",
+                        "--count",
+                        f"{upstream.stdout.strip()}..{branch}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if ahead.returncode != 0:
+                    return CleanStatus(clean=False, error="check failed")
+                if int(ahead.stdout.strip() or "0") > 0:
+                    reasons.append(f"unpushed:{branch}")
+            elif initial_commit:
+                branch_head = subprocess.run(
+                    ["git", "-C", str(path), "rev-parse", branch],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if branch_head.returncode != 0:
+                    return CleanStatus(clean=False, error="check failed")
+                if branch_head.stdout.strip() != initial_commit:
+                    reasons.append(f"unpushed:{branch}")
+            else:
+                reasons.append(f"untracked_branch:{branch}")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return CleanStatus(clean=False, error="check failed")
+
+    return CleanStatus(clean=len(reasons) == 0, reasons=reasons)
+
+
 def format_reasons(reasons: list[str]) -> list[str]:
     """Translate machine-readable reasons into human-readable strings."""
     result = []

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -14,9 +14,10 @@ from pathlib import Path
 import click
 
 from . import __version__
-from .clean import CleanStatus, check_clean, format_reasons
+from .clean import CleanStatus, check_clean, check_native_clean, format_reasons
 from .config import (
     DATA_DIR,
+    NATIVE_DIR,
     ensure_dirs,
     load_config,
     parse_mounts,
@@ -39,7 +40,13 @@ from .repo_registry import RepoRegistry
 from .runtime.base import ContainerRuntime
 from .runtime.incus import IncusRuntime
 from .target import TargetParseError, parse_target
-from .vscode import SSH_CONFIG_FILE, add_ssh_config, open_editor, remove_ssh_config
+from .vscode import (
+    SSH_CONFIG_FILE,
+    add_ssh_config,
+    open_editor,
+    open_editor_native,
+    remove_ssh_config,
+)
 
 
 def _is_command_available(cmd: str) -> bool:
@@ -1405,6 +1412,11 @@ def _open_remote(
     default=None,
     help="Run a command via SSH instead of interactive shell",
 )
+@click.option(
+    "--native",
+    is_flag=True,
+    help="Non-containerized workspace (local clone, no isolation)",
+)
 @click.option("--path", "force_path", is_flag=True, help="Interpret target as a local path")
 @click.option(
     "--no-clone", is_flag=True, hidden=True, help="Fail if bare repo doesn't exist (used by relay)"
@@ -1436,6 +1448,7 @@ def open_cmd(
     network,
     custom_name,
     command,
+    native,
     force_path,
     no_clone,
     git_name,
@@ -1484,6 +1497,26 @@ def open_cmd(
         if editor not in ("vscode", "shell"):
             click.echo(f"Warning: unknown editor '{editor}' in config, using vscode.", err=True)
             editor = "vscode"
+
+    # Native mode: skip all container/remote logic
+    if native:
+        incompatible = []
+        if ssh_host:
+            incompatible.append("--ssh")
+        if cloud:
+            incompatible.append("--cloud")
+        if not network:
+            incompatible.append("--no-network")
+        if machine_readable:
+            incompatible.append("--machine-readable")
+        if incompatible:
+            click.echo(
+                f"--native cannot be combined with {', '.join(incompatible)}",
+                err=True,
+            )
+            sys.exit(1)
+        _open_native(target, editor, no_interactive, custom_name, command=command_args)
+        return
 
     # Priority: --local > --ssh > --cloud > [cloud] default > [remote] default_host
     remote_host = None
@@ -1649,6 +1682,273 @@ def open_cmd(
         raise
 
 
+def _find_existing_native(name: str) -> dict | None:
+    """Check if a native workspace already exists in the registry."""
+    info = get_bubble_info(name)
+    if info and info.get("native"):
+        return info
+    return None
+
+
+def _open_native(
+    target,
+    editor,
+    no_interactive,
+    custom_name,
+    command=None,
+):
+    """Open a native (non-containerized) workspace."""
+    registry = RepoRegistry()
+    try:
+        t = parse_target(target, registry)
+    except TargetParseError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
+    registry.register(t.owner, t.repo)
+
+    name = _generate_bubble_name(t, custom_name)
+
+    # Check for existing native workspace
+    existing = _find_existing_native(name)
+    if existing:
+        native_path = existing.get("native_path", "")
+        if native_path and Path(native_path).exists():
+            click.echo()
+            click.echo(
+                "WARNING: NATIVE MODE -- no containerization!\n"
+                "This workspace runs directly on your machine with full filesystem\n"
+                "and network access. Use bubble without --native for isolation."
+            )
+            click.echo()
+            click.echo(f"Reattaching to native workspace '{name}' at {native_path}")
+            if not no_interactive:
+                open_editor_native(editor, native_path, command=command)
+            return
+
+    ensure_dirs()
+
+    # Deduplicate name against all registered bubbles (native + container)
+    reg = load_registry()
+    existing_names = set(reg.get("bubbles", {}).keys())
+    name = deduplicate_name(name, existing_names)
+
+    workspace_path = NATIVE_DIR / name
+    if workspace_path.exists():
+        click.echo(f"Native workspace directory already exists: {workspace_path}", err=True)
+        sys.exit(1)
+
+    # Print warning
+    click.echo()
+    click.echo(
+        "WARNING: NATIVE MODE -- no containerization!\n"
+        "This workspace runs directly on your machine with full filesystem\n"
+        "and network access. Use bubble without --native for isolation."
+    )
+    click.echo()
+
+    # Resolve reference source and clone
+    url = github_url(t.org_repo)
+    try:
+        if t.local_path:
+            ref_path = t.local_path
+            click.echo("Cloning from local path (using shared objects)...")
+        else:
+            ref_path = str(init_bare_repo(t.org_repo))
+            if t.kind == "pr":
+                click.echo(f"Fetching PR #{t.ref}...")
+                try:
+                    fetch_ref(t.org_repo, f"refs/pull/{t.ref}/head:refs/pull/{t.ref}/head")
+                except Exception:
+                    pass
+            click.echo(f"Cloning {t.org_repo} (using shared objects)...")
+
+        subprocess.run(
+            ["git", "clone", "--reference", ref_path, url, str(workspace_path)],
+            check=True,
+        )
+
+        # Checkout appropriate ref
+        checkout_branch = ""
+        if t.kind == "pr":
+            click.echo(f"Checking out PR #{t.ref}...")
+            pr_meta = _get_pr_metadata(t.owner, t.repo, t.ref)
+            pr_checkout_ok = False
+            if pr_meta:
+                head_ref, head_repo, clone_url = pr_meta
+                is_fork = head_repo.lower() != t.org_repo.lower()
+                try:
+                    if is_fork:
+                        fork_owner = head_repo.split("/")[0]
+                        subprocess.run(
+                            [
+                                "git",
+                                "-C",
+                                str(workspace_path),
+                                "remote",
+                                "add",
+                                fork_owner,
+                                clone_url,
+                            ],
+                            capture_output=True,
+                        )
+                        subprocess.run(
+                            [
+                                "git",
+                                "-C",
+                                str(workspace_path),
+                                "fetch",
+                                fork_owner,
+                                f"+refs/heads/{head_ref}:refs/remotes/{fork_owner}/{head_ref}",
+                            ],
+                            check=True,
+                        )
+                        subprocess.run(
+                            [
+                                "git",
+                                "-C",
+                                str(workspace_path),
+                                "checkout",
+                                "-b",
+                                head_ref,
+                                "--track",
+                                f"{fork_owner}/{head_ref}",
+                            ],
+                            check=True,
+                        )
+                    else:
+                        subprocess.run(
+                            [
+                                "git",
+                                "-C",
+                                str(workspace_path),
+                                "fetch",
+                                "origin",
+                                f"+refs/heads/{head_ref}:refs/remotes/origin/{head_ref}",
+                            ],
+                            check=True,
+                        )
+                        subprocess.run(
+                            [
+                                "git",
+                                "-C",
+                                str(workspace_path),
+                                "checkout",
+                                "-b",
+                                head_ref,
+                                "--track",
+                                f"origin/{head_ref}",
+                            ],
+                            check=True,
+                        )
+                    checkout_branch = head_ref
+                    pr_checkout_ok = True
+                except subprocess.CalledProcessError:
+                    pass
+
+            if not pr_checkout_ok:
+                checkout_branch = f"pr-{t.ref}"
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(workspace_path),
+                        "fetch",
+                        "origin",
+                        f"pull/{t.ref}/head:{checkout_branch}",
+                    ],
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "-C", str(workspace_path), "checkout", checkout_branch],
+                    check=True,
+                )
+        elif t.kind == "branch":
+            click.echo(f"Checking out branch '{t.ref}'...")
+            checkout_branch = t.ref
+            if t.local_path:
+                # Always fetch from local repo to pick up potentially unpushed commits.
+                # Use + refspec to force-update if origin already has an older version.
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(workspace_path),
+                        "fetch",
+                        t.local_path,
+                        f"+refs/heads/{t.ref}:refs/heads/{t.ref}",
+                    ],
+                    capture_output=True,
+                )
+            try:
+                subprocess.run(
+                    ["git", "-C", str(workspace_path), "switch", t.ref],
+                    check=True,
+                    capture_output=True,
+                )
+            except subprocess.CalledProcessError:
+                if t.local_path:
+                    # Branch wasn't on origin either; fetch and retry
+                    subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(workspace_path),
+                            "fetch",
+                            t.local_path,
+                            f"{t.ref}:{t.ref}",
+                        ],
+                        check=True,
+                    )
+                    subprocess.run(
+                        ["git", "-C", str(workspace_path), "switch", t.ref],
+                        check=True,
+                    )
+                else:
+                    raise
+        elif t.kind == "commit":
+            click.echo(f"Checking out commit {t.ref[:12]}...")
+            subprocess.run(
+                ["git", "-C", str(workspace_path), "checkout", t.ref],
+                check=True,
+            )
+
+        # Get commit hash
+        commit = ""
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(workspace_path), "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+            )
+            commit = result.stdout.strip()
+        except Exception:
+            pass
+
+        register_bubble(
+            name,
+            t.org_repo,
+            branch=checkout_branch or (t.ref if t.kind == "branch" else ""),
+            commit=commit,
+            pr=int(t.ref) if t.kind == "pr" else 0,
+            native=True,
+            native_path=str(workspace_path),
+        )
+    except subprocess.CalledProcessError as e:
+        if workspace_path.exists():
+            shutil.rmtree(workspace_path)
+        click.echo(f"Failed to create native workspace: {e}", err=True)
+        sys.exit(1)
+
+    click.echo(f"Native workspace '{name}' created at {workspace_path}")
+
+    if not no_interactive:
+        if editor == "shell":
+            click.echo("Opening shell...")
+        else:
+            click.echo("Opening VSCode...")
+        open_editor_native(editor, str(workspace_path), command=command)
+
+
 def _reattach(
     runtime: ContainerRuntime, name: str, editor: str, no_interactive: bool, command=None
 ):
@@ -1757,6 +2057,29 @@ def _remote_entries_from_registry() -> list[dict]:
                 "remote_host_spec": host_spec,
             }
         )
+    return entries
+
+
+def _native_entries_from_registry(show_clean: bool = False) -> list[dict]:
+    """Build list entries for native workspaces from the registry."""
+    registry = load_registry()
+    entries = []
+    for name, info in registry.get("bubbles", {}).items():
+        if not info.get("native"):
+            continue
+        native_path = info.get("native_path", "")
+        state = "exists" if native_path and Path(native_path).is_dir() else "missing"
+        entry = {
+            "name": name,
+            "state": state,
+            "location": "native",
+            "created_at": _parse_iso(info.get("created_at")),
+            "last_used_at": None,
+            "native_path": native_path,
+        }
+        if show_clean and state == "exists":
+            entry["clean_status"] = check_native_clean(native_path, name)
+        entries.append(entry)
     return entries
 
 
@@ -1917,6 +2240,13 @@ def list_bubbles(as_json, verbose, show_clean, query_cloud, ssh_host, local_only
 
         entries.extend(remote_entries)
 
+    # --- Native workspaces from registry (always local) ---
+    native_entries = _native_entries_from_registry(show_clean=show_clean)
+    native_entries = [e for e in native_entries if e["name"] not in local_names]
+    entries.extend(native_entries)
+    if native_entries:
+        has_remote = True  # Force showing location column
+
     # --- Output ---
     if as_json:
         data = []
@@ -2012,8 +2342,11 @@ def list_bubbles(as_json, verbose, show_clean, query_cloud, ssh_host, local_only
 @click.argument("name")
 def pause(name):
     """Pause (freeze) a bubble."""
-    # Auto-route to remote host if the bubble is registered there
     info = get_bubble_info(name)
+    if info and info.get("native"):
+        click.echo("Native workspaces don't support pause/resume (no container state).", err=True)
+        sys.exit(1)
+    # Auto-route to remote host if the bubble is registered there
     if info and info.get("remote_host"):
         from .remote import RemoteHost, apply_cloud_ssh_options, remote_command
 
@@ -2056,6 +2389,40 @@ def pop(name, force):
         remove_ssh_config(name)
         unregister_bubble(name)
         click.echo(f"Bubble '{name}' popped on {host.ssh_destination}.")
+        return
+
+    # Handle native workspaces
+    if info and info.get("native"):
+        native_path = info.get("native_path", "")
+        if not force and native_path and Path(native_path).is_dir():
+            cs = check_native_clean(native_path, name)
+            if cs.clean:
+                click.echo(f"Native workspace '{name}' is clean. ", nl=False)
+            elif cs.error:
+                click.confirm(
+                    f"Cannot verify cleanness ({cs.error}). "
+                    f"Permanently pop native workspace '{name}'?",
+                    abort=True,
+                )
+            else:
+                reasons = format_reasons(cs.reasons)
+                click.echo("Warning: workspace has unsaved work:")
+                for r in reasons:
+                    click.echo(f"  - {r}")
+                click.confirm(f"Permanently pop native workspace '{name}'?", abort=True)
+
+        if native_path and Path(native_path).is_dir():
+            resolved = Path(native_path).resolve()
+            native_dir_resolved = NATIVE_DIR.resolve()
+            if not str(resolved).startswith(str(native_dir_resolved) + os.sep):
+                click.echo(
+                    f"Refusing to delete: path '{native_path}' is not under {NATIVE_DIR}",
+                    err=True,
+                )
+                sys.exit(1)
+            shutil.rmtree(resolved)
+        unregister_bubble(name)
+        click.echo(f"Native workspace '{name}' popped.")
         return
 
     config = load_config()

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -21,6 +21,7 @@ REPOS_FILE = DATA_DIR / "repos.json"
 CLOUD_STATE_FILE = DATA_DIR / "cloud.json"
 CLOUD_KEY_FILE = DATA_DIR / "cloud_key"
 CLOUD_KNOWN_HOSTS = DATA_DIR / "known_hosts"
+NATIVE_DIR = DATA_DIR / "native"
 
 DEFAULT_CONFIG = {
     "editor": "vscode",
@@ -62,7 +63,7 @@ DEFAULT_CONFIG = {
 
 def ensure_dirs():
     """Create data directories if they don't exist."""
-    for d in [DATA_DIR, GIT_DIR]:
+    for d in [DATA_DIR, GIT_DIR, NATIVE_DIR]:
         d.mkdir(parents=True, exist_ok=True)
 
 

--- a/bubble/lifecycle.py
+++ b/bubble/lifecycle.py
@@ -43,8 +43,10 @@ def register_bubble(
     branch: str = "",
     commit: str = "",
     pr: int = 0,
-    base_image: str = "base",
+    base_image: str = "",
     remote_host: str = "",
+    native: bool = False,
+    native_path: str = "",
 ):
     """Record a bubble's creation in the registry."""
     with _registry_lock():
@@ -54,11 +56,15 @@ def register_bubble(
             "branch": branch,
             "commit": commit,
             "pr": pr,
-            "base_image": base_image,
             "created_at": datetime.now(timezone.utc).isoformat(),
         }
+        if base_image:
+            entry["base_image"] = base_image
         if remote_host:
             entry["remote_host"] = remote_host
+        if native:
+            entry["native"] = True
+            entry["native_path"] = native_path
         registry["bubbles"][name] = entry
         _save_registry(registry)
 

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -125,6 +125,28 @@ def open_editor(
         subprocess.run(ssh_cmd)
 
 
+def open_editor_native(editor: str, local_path: str, command: list[str] | None = None):
+    """Open the specified editor for a native (non-containerized) workspace.
+
+    Opens VSCode directly on the local path, or spawns a shell in that directory.
+    """
+    if editor == "vscode":
+        try:
+            subprocess.run(
+                ["code", "--disable-workspace-trust", "--folder-uri", f"file://{local_path}"],
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            print(f"VSCode CLI not found or failed. Open manually: {local_path}")
+    elif editor == "shell":
+        if command:
+            subprocess.run(command, cwd=local_path)
+        else:
+            subprocess.run(
+                ["bash", "-c", f"cd {shlex.quote(local_path)} && exec $SHELL"],
+            )
+
+
 def open_vscode(
     bubble_name: str,
     remote_path: str = "/home/user",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,8 @@ def tmp_data_dir(tmp_path, monkeypatch):
     config_file = data_dir / "config.toml"
     repos_file = data_dir / "repos.json"
 
+    native_dir = data_dir / "native"
+    native_dir.mkdir()
     cloud_state_file = data_dir / "cloud.json"
     cloud_key_file = data_dir / "cloud_key"
     cloud_known_hosts = data_dir / "known_hosts"
@@ -115,6 +117,7 @@ def tmp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "REGISTRY_FILE", registry_file)
     monkeypatch.setattr(config, "GIT_DIR", git_dir)
     monkeypatch.setattr(config, "REPOS_FILE", repos_file)
+    monkeypatch.setattr(config, "NATIVE_DIR", native_dir)
     monkeypatch.setattr(config, "CLOUD_STATE_FILE", cloud_state_file)
     monkeypatch.setattr(config, "CLOUD_KEY_FILE", cloud_key_file)
     monkeypatch.setattr(config, "CLOUD_KNOWN_HOSTS", cloud_known_hosts)

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -1,0 +1,198 @@
+"""Tests for native (non-containerized) workspace support."""
+
+import json
+import subprocess
+
+from bubble.clean import check_native_clean
+from bubble.lifecycle import get_bubble_info, register_bubble, unregister_bubble
+
+
+class TestNativeRegistry:
+    def test_register_native_bubble(self, tmp_data_dir):
+        register_bubble(
+            "test-native",
+            "org/repo",
+            branch="main",
+            commit="abc123",
+            native=True,
+            native_path="/tmp/bubble/native/test-native",
+        )
+        info = get_bubble_info("test-native")
+        assert info is not None
+        assert info["native"] is True
+        assert info["native_path"] == "/tmp/bubble/native/test-native"
+        assert info["org_repo"] == "org/repo"
+        assert info["branch"] == "main"
+
+    def test_register_native_with_pr(self, tmp_data_dir):
+        register_bubble(
+            "test-native-pr",
+            "org/repo",
+            pr=42,
+            native=True,
+            native_path="/tmp/bubble/native/test-native-pr",
+        )
+        info = get_bubble_info("test-native-pr")
+        assert info["pr"] == 42
+        assert info["native"] is True
+
+    def test_non_native_has_no_native_flag(self, tmp_data_dir):
+        register_bubble("test-container", "org/repo")
+        info = get_bubble_info("test-container")
+        assert "native" not in info
+        assert "native_path" not in info
+
+    def test_unregister_native(self, tmp_data_dir):
+        register_bubble(
+            "to-remove",
+            "org/repo",
+            native=True,
+            native_path="/tmp/test",
+        )
+        assert get_bubble_info("to-remove") is not None
+        unregister_bubble("to-remove")
+        assert get_bubble_info("to-remove") is None
+
+    def test_registry_json_structure(self, tmp_data_dir):
+        register_bubble(
+            "native-1",
+            "org/repo1",
+            native=True,
+            native_path="/tmp/native-1",
+        )
+        register_bubble("container-1", "org/repo2")
+
+        import bubble.config as config
+
+        content = config.REGISTRY_FILE.read_text()
+        data = json.loads(content)
+        assert "native-1" in data["bubbles"]
+        assert data["bubbles"]["native-1"]["native"] is True
+        assert "container-1" in data["bubbles"]
+        assert "native" not in data["bubbles"]["container-1"]
+
+
+class TestNativeClean:
+    def test_missing_path(self, tmp_data_dir):
+        register_bubble(
+            "missing",
+            "org/repo",
+            native=True,
+            native_path="/nonexistent/path",
+        )
+        cs = check_native_clean("/nonexistent/path", "missing")
+        assert not cs.clean
+        assert cs.error == "path not found"
+
+    def test_not_a_git_repo(self, tmp_path, tmp_data_dir):
+        workspace = tmp_path / "not-git"
+        workspace.mkdir()
+        register_bubble(
+            "no-git",
+            "org/repo",
+            native=True,
+            native_path=str(workspace),
+        )
+        cs = check_native_clean(str(workspace), "no-git")
+        assert not cs.clean
+        assert cs.error == "not a git repo"
+
+    def test_clean_repo(self, tmp_path, tmp_data_dir):
+        workspace = tmp_path / "clean-repo"
+        workspace.mkdir()
+        try:
+            subprocess.run(
+                ["git", "init", str(workspace)],
+                check=True,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            import pytest
+
+            pytest.skip("git not available")
+        subprocess.run(
+            ["git", "-C", str(workspace), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(workspace), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        # Create an initial commit so HEAD exists
+        (workspace / "file.txt").write_text("hello")
+        subprocess.run(
+            ["git", "-C", str(workspace), "add", "file.txt"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(workspace), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+
+        commit = subprocess.run(
+            ["git", "-C", str(workspace), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        register_bubble(
+            "clean-test",
+            "org/repo",
+            commit=commit,
+            native=True,
+            native_path=str(workspace),
+        )
+        cs = check_native_clean(str(workspace), "clean-test")
+        assert cs.clean
+        assert cs.reasons == []
+
+    def test_dirty_repo(self, tmp_path, tmp_data_dir):
+        workspace = tmp_path / "dirty-repo"
+        workspace.mkdir()
+        try:
+            subprocess.run(
+                ["git", "init", str(workspace)],
+                check=True,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            import pytest
+
+            pytest.skip("git not available")
+        subprocess.run(
+            ["git", "-C", str(workspace), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(workspace), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (workspace / "file.txt").write_text("hello")
+        subprocess.run(
+            ["git", "-C", str(workspace), "add", "file.txt"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(workspace), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        # Make it dirty
+        (workspace / "file.txt").write_text("modified")
+
+        register_bubble(
+            "dirty-test",
+            "org/repo",
+            native=True,
+            native_path=str(workspace),
+        )
+        cs = check_native_clean(str(workspace), "dirty-test")
+        assert not cs.clean
+        assert "dirty_worktree" in cs.reasons


### PR DESCRIPTION
## Summary
- Implements `bubble --native <target>` to create workspaces without containerization
- Clones into `~/.bubble/native/<name>/` using shared git objects, skipping all container/image/network setup
- Prints prominent warning about lack of isolation on every use
- `bubble list` shows native workspaces (location: "native"), `bubble pop` cleans them up with dirty checks, `bubble pause` rejects them

Closes #5

## Test plan
- [x] 9 new tests in `tests/test_native.py` covering registry, clean/dirty detection
- [x] All 221 existing non-git-dependent tests still pass
- [ ] Manual: `bubble --native owner/repo` clones and opens editor
- [ ] Manual: `bubble list` shows native entries
- [ ] Manual: `bubble pop <native-name>` removes workspace

🤖 Prepared with Claude Code