### PR TITLE
Minor doc fixes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -180,7 +180,7 @@ The workspace trust dialog is a **local VS Code client** decision, not controlle
 VS Code stores trusted workspace URIs in a SQLite database. To clear bubble-related trust entries:
 ```python
 import json, sqlite3
-db = "/Users/kim/Library/Application Support/Code/User/globalStorage/state.vscdb"
+db = "/Users/<USERNAME>/Library/Application Support/Code/User/globalStorage/state.vscdb"
 conn = sqlite3.connect(db)
 cur = conn.cursor()
 cur.execute("SELECT value FROM ItemTable WHERE key = 'content.trust.model.key'")

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bubble 123                   # opens PR #123 for the current repo
 # List your bubbles
 bubble list
 
-# Drop into SSH session instead of VSCode
+# Drop into an SSH session instead of VSCode
 bubble leanprover/lean4 --shell
 
 # Run on a remote host


### PR DESCRIPTION
## Summary
- Anonymize hardcoded `/Users/kim/` path in CLAUDE.md VS Code trust snippet
- Fix grammar: "Drop into SSH" → "Drop into an SSH" in README.md

🤖 Prepared with Claude Code