### PR TITLE
Verify builder container is removed before launching

### DIFF
--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -200,8 +200,7 @@ def _cleanup_builder(runtime: ContainerRuntime, build_name: str):
     # Verify the container is actually gone before proceeding
     if any(c.name == build_name for c in runtime.list_containers()):
         raise RuntimeError(
-            f"Cannot remove leftover builder container '{build_name}'. "
-            f"Please delete it manually."
+            f"Cannot remove leftover builder container '{build_name}'. Please delete it manually."
         )
 
 


### PR DESCRIPTION
## Summary
- When an image build is interrupted (e.g. Ctrl+C), the builder container can be left running. The old cleanup code silently swallowed `delete --force` failures, causing the next build attempt to crash with "Instance already exists".
- Extracts a `_cleanup_builder()` helper that attempts force-delete then **verifies the container is actually gone**, raising a clear error if removal failed.
- Used by both `build_image()` and `build_lean_toolchain_image()`.

## Test plan
- [x] `uv run pytest` passes (326 passed, 19 skipped)
- [ ] Manual: interrupt a `bubble open` during image build, retry — should succeed instead of crashing

🤖 Prepared with Claude Code