### PR TITLE
Fix dubious ownership error for Lake dependency pre-population

### DIFF
--- a/bubble/hooks/lean.py
+++ b/bubble/hooks/lean.py
@@ -227,7 +227,8 @@ class LeanHook(Hook):
                         "-",
                         "user",
                         "-c",
-                        f"git -c safe.directory={q_bare} clone --reference {q_bare} file://{q_bare} {q_pkg}",
+                        f"git -c safe.directory={q_bare} clone"
+                        f" --reference {q_bare} file://{q_bare} {q_pkg}",
                     ],
                 )
 


### PR DESCRIPTION
## Summary

- Bare repos mounted at `/shared/git/` inside containers are root-owned, but `git clone` runs as `user`, triggering git's `safe.directory` ownership check
- Fix: use per-command `git -c safe.directory=<path>` to scope the trust to just the clone operation, rather than persisting it in global gitconfig

🤖 Prepared with Claude Code