### PR TITLE
Suppress --disable-workspace-trust warning on VS Code Remote CLI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -174,7 +174,7 @@ Container                              Host
 ## VS Code Integration Notes
 
 ### Workspace Trust
-The workspace trust dialog is a **local VS Code client** decision, not controlled by remote server settings. We pass `--disable-workspace-trust` when launching VS Code in `open_vscode()`. Writing to `.vscode-server/data/Machine/settings.json` or `User/settings.json` inside the container does NOT suppress the trust prompt.
+The workspace trust dialog is a **local VS Code client** decision, not controlled by remote server settings. We pass `--disable-workspace-trust` when launching VS Code in `open_vscode()` — this works on the desktop CLI but is unsupported by the VS Code Remote CLI helper, so we suppress stderr to avoid the warning. Writing to `.vscode-server/data/Machine/settings.json` or `User/settings.json` inside the container does NOT suppress the trust prompt.
 
 ### Clearing Trust State for Testing
 VS Code stores trusted workspace URIs in a SQLite database. To clear bubble-related trust entries:

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -135,6 +135,7 @@ def open_editor_native(editor: str, local_path: str, command: list[str] | None =
             subprocess.run(
                 ["code", "--disable-workspace-trust", "--folder-uri", f"file://{local_path}"],
                 check=True,
+                stderr=subprocess.DEVNULL,
             )
         except (subprocess.CalledProcessError, FileNotFoundError):
             print(f"VSCode CLI not found or failed. Open manually: {local_path}")
@@ -161,7 +162,11 @@ def open_vscode(
         uri = f"vscode-remote://ssh-remote+{host}{remote_path}"
         flag = "--folder-uri"
     try:
-        subprocess.run(["code", "--disable-workspace-trust", flag, uri], check=True)
+        subprocess.run(
+            ["code", "--disable-workspace-trust", flag, uri],
+            check=True,
+            stderr=subprocess.DEVNULL,
+        )
     except subprocess.CalledProcessError:
         if workspace_file:
             # Fall back to opening the folder if --file-uri fails
@@ -170,6 +175,7 @@ def open_vscode(
                 subprocess.run(
                     ["code", "--disable-workspace-trust", "--folder-uri", folder_uri],
                     check=True,
+                    stderr=subprocess.DEVNULL,
                 )
             except (FileNotFoundError, subprocess.CalledProcessError):
                 pass


### PR DESCRIPTION
## Summary

- The `--disable-workspace-trust` flag works on the desktop VS Code CLI but is unsupported by the VS Code Remote CLI helper, which prints `Ignoring option 'disable-workspace-trust': not supported for code.` to stderr
- Keep the flag (it still works on desktop installs) but suppress stderr on `code` subprocess calls to avoid the noise

🤖 Prepared with Claude Code