### PR TITLE
Stream colima start output in real time via PTY

### DIFF
--- a/bubble/runtime/colima.py
+++ b/bubble/runtime/colima.py
@@ -121,13 +121,9 @@ def start_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
                 shutil.rmtree(lima_dir)
             result = _run_colima_start(args)
             if result.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    result.returncode, args, output=result.stdout
-                )
+                raise subprocess.CalledProcessError(result.returncode, args, output=result.stdout)
         else:
-            raise subprocess.CalledProcessError(
-                result.returncode, args, output=result.stdout
-            )
+            raise subprocess.CalledProcessError(result.returncode, args, output=result.stdout)
 
 
 def ensure_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):


### PR DESCRIPTION
## Summary
- First-time colima VM startup was completely silent (output captured but not displayed), making it look hung
- Use a PTY so colima sees a terminal and doesn't block-buffer, streaming progress to stderr in real time
- Preserve captured output in `CalledProcessError` exceptions for diagnostics

🤖 Prepared with Claude Code