### PR TITLE
Fix incus not connecting to Colima VM on macOS

### DIFF
--- a/bubble/runtime/colima.py
+++ b/bubble/runtime/colima.py
@@ -141,13 +141,9 @@ def start_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
                 shutil.rmtree(lima_dir)
             result = _run_colima_start(args)
             if result.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    result.returncode, args, output=result.stdout
-                )
+                raise subprocess.CalledProcessError(result.returncode, args, output=result.stdout)
         else:
-            raise subprocess.CalledProcessError(
-                result.returncode, args, output=result.stdout
-            )
+            raise subprocess.CalledProcessError(result.returncode, args, output=result.stdout)
 
 
 def _ensure_incus_remote():


### PR DESCRIPTION
## Summary
- Fix `is_colima_running()` returning false when `colima status` fails due to empty runtime field in colima 0.10.x — fall back to `colima list --json`
- Auto-configure incus client to connect to Colima's socket (`~/.colima/default/incus.sock`) by adding and switching to a `colima` remote

Without this fix, `incus` commands fail with "This client hasn't been configured to use a remote server yet" because nothing pointed the incus client at the Colima VM's socket.

## Test plan
- [x] `uv run pytest` passes (416 passed, pre-existing hook test excluded)
- [ ] `bubble <target>` works on a fresh macOS setup with colima 0.10.x

🤖 Prepared with Claude Code