### PR TITLE
Fix hook tests when git default branch is not master

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -36,7 +36,7 @@ def _make_hook_repo(tmp_path, work_name, files):
         env={**GIT_ENV, "HOME": str(tmp_path)},
     )
     subprocess.run(
-        [GIT, "-C", str(work), "push", "origin", "master"],
+        [GIT, "-C", str(work), "push", "origin", "HEAD"],
         capture_output=True,
         check=True,
     )
@@ -78,7 +78,7 @@ def _make_lean_bare_repo(tmp_path, repo_name, work_name, toolchain="leanprover/l
         env={**GIT_ENV, "HOME": str(tmp_path)},
     )
     subprocess.run(
-        [GIT, "-C", str(work), "push", "origin", "master"],
+        [GIT, "-C", str(work), "push", "origin", "HEAD"],
         capture_output=True,
         check=True,
     )


### PR DESCRIPTION
## Summary
- Replace hardcoded `git push origin master` with `git push origin HEAD` in test helpers
- Fixes test failures on machines where `init.defaultBranch` is set to `main` (or anything other than `master`)

## Test plan
- [x] All 442 tests pass (previously 26 tests errored in `test_hooks.py`)

🤖 Prepared with Claude Code