### PR TITLE
Remove .current-account from Claude credential mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 0.6.2 — 2026-03-12
+- Remove `.current-account` from Claude credential mounts (#91)
+  - Only `.credentials.json` is needed for Claude auth inside bubbles
+  - `.current-account` is local account-swapping machinery, not relevant for containers
 - SSH tunnel auth proxy for remote/cloud bubbles (#81)
   - Remote and cloud bubbles now use the same repo-scoped auth proxy as local bubbles
   - SSH reverse tunnel (`-R`) forwards the local auth proxy to the remote host
@@ -144,7 +147,7 @@
 - VS Code Server moved from `base` to `vscode.sh` script (shared by `base-vscode` and `lean-vscode`)
 - Lean VS Code extensions installed conditionally (only when elan is present in the image)
 - Mount `~/.claude` config read-only into containers by default (CLAUDE.md, settings.json, skills/, keybindings.json)
-- Credentials (`.credentials.json`, `.current-account`) opt-in via `--claude-credentials` for security
+- Credentials (`.credentials.json`) opt-in via `--claude-credentials` for security
 - Nag message reminds you about `--claude-credentials` when credentials exist on host
 - Writable per-bubble `projects/` directory (`~/.bubble/claude-projects/<name>/`) for persistent session memory
 - Session history and transient state are excluded by design

--- a/bubble/commands/settings.py
+++ b/bubble/commands/settings.py
@@ -86,9 +86,9 @@ def register_settings_commands(main):
     def claude_credentials_cmd(setting):
         """Set whether Claude credentials are mounted into bubbles.
 
-        When on, ~/.claude credentials (.credentials.json, .current-account)
-        are mounted read-only into containers by default. Override per-bubble
-        with --no-claude-credentials.
+        When on, ~/.claude credentials (.credentials.json) are mounted
+        read-only into containers by default. Override per-bubble with
+        --no-claude-credentials.
 
         Shows current setting if no argument given.
         """

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -217,7 +217,6 @@ _CLAUDE_CONFIG_ITEMS = [
 # Credential files — opt-in only (--claude-credentials).
 _CLAUDE_CREDENTIAL_ITEMS = [
     ".credentials.json",
-    ".current-account",
 ]
 
 
@@ -247,8 +246,8 @@ def claude_config_mounts(include_credentials: bool = False) -> list[MountSpec]:
     inside containers, giving Claude Code sessions access to global config.
 
     Args:
-        include_credentials: If True, also mount .credentials.json and
-            .current-account. Off by default for security.
+        include_credentials: If True, also mount .credentials.json.
+            Off by default for security.
     """
     mounts = []
     if not CLAUDE_CONFIG_DIR.is_dir():

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -376,7 +376,6 @@ class TestClaudeConfigMounts:
         (claude_dir / "keybindings.json").write_text("{}")
         (claude_dir / "commands").mkdir()
         (claude_dir / ".credentials.json").write_text("{}")
-        (claude_dir / ".current-account").write_text("acct")
 
         monkeypatch.setattr("bubble.config.CLAUDE_CONFIG_DIR", claude_dir)
 
@@ -391,7 +390,6 @@ class TestClaudeConfigMounts:
         assert "/home/user/.claude/commands" in targets
         # Credentials NOT included by default
         assert "/home/user/.claude/.credentials.json" not in targets
-        assert "/home/user/.claude/.current-account" not in targets
         assert all(m.readonly for m in mounts)
 
     def test_returns_all_with_credentials(self, tmp_path, monkeypatch):
@@ -404,16 +402,14 @@ class TestClaudeConfigMounts:
         (claude_dir / "keybindings.json").write_text("{}")
         (claude_dir / "commands").mkdir()
         (claude_dir / ".credentials.json").write_text("{}")
-        (claude_dir / ".current-account").write_text("acct")
 
         monkeypatch.setattr("bubble.config.CLAUDE_CONFIG_DIR", claude_dir)
 
         mounts = claude_config_mounts(include_credentials=True)
 
-        assert len(mounts) == 7
+        assert len(mounts) == 6
         targets = {m.target for m in mounts}
         assert "/home/user/.claude/.credentials.json" in targets
-        assert "/home/user/.claude/.current-account" in targets
 
     def test_skips_missing_files(self, tmp_path, monkeypatch):
         """Only existing files are mounted."""
@@ -441,7 +437,6 @@ class TestClaudeConfigMounts:
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
         (claude_dir / ".credentials.json").write_text("{}")
-        (claude_dir / ".current-account").write_text("acct")
 
         monkeypatch.setattr("bubble.config.CLAUDE_CONFIG_DIR", claude_dir)
 
@@ -454,7 +449,6 @@ class TestClaudeConfigMounts:
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
         (claude_dir / ".credentials.json").write_text("{}")
-        (claude_dir / ".current-account").write_text("acct")
 
         monkeypatch.setattr("bubble.config.CLAUDE_CONFIG_DIR", claude_dir)
 
@@ -462,7 +456,6 @@ class TestClaudeConfigMounts:
 
         targets = {m.target for m in mounts}
         assert "/home/user/.claude/.credentials.json" in targets
-        assert "/home/user/.claude/.current-account" in targets
         assert all(m.readonly for m in mounts)
 
     def test_has_claude_credentials(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Remove `.current-account` from `_CLAUDE_CREDENTIAL_ITEMS` in `config.py` — only `.credentials.json` is needed for Claude auth inside bubbles
- Update docstring in `settings.py` to reflect the change
- Update tests to remove `.current-account` references and adjust expected mount counts
- Add changelog entry

Closes #91

🤖 Prepared with Claude Code