### PR TITLE
Add PythonHook: detect pyproject.toml, pre-bake uv and ruff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 0.6.3 — 2026-03-12
+- Add PythonHook: detect `pyproject.toml`, select `python` image with `uv` and `ruff` pre-baked (#93)
+  - Auto-runs `uv sync` on first login for dependency installation
+  - Runtime network allowlist includes `pypi.org` and `files.pythonhosted.org`
 - Don't prompt interactively during `bubble open` (#88)
   - `maybe_symlink_claude_projects()` now prints an informational message instead of blocking on a `[y/N]` prompt
   - New `bubble config symlink-claude-projects` command to perform the symlink manually

--- a/bubble/hooks/__init__.py
+++ b/bubble/hooks/__init__.py
@@ -73,8 +73,9 @@ class Hook(ABC):
 def discover_hooks() -> list[Hook]:
     """Return all registered hooks in priority order."""
     from .lean import LeanHook
+    from .python import PythonHook
 
-    return [LeanHook()]
+    return [LeanHook(), PythonHook()]
 
 
 def select_hook(bare_repo_path: Path, ref: str) -> Hook | None:

--- a/bubble/hooks/python.py
+++ b/bubble/hooks/python.py
@@ -1,0 +1,55 @@
+"""Python language hook."""
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import click
+
+from ..runtime.base import ContainerRuntime
+from . import Hook
+
+
+class PythonHook(Hook):
+    """Hook for Python projects (detected by pyproject.toml file)."""
+
+    def name(self) -> str:
+        return "Python"
+
+    def detect(self, bare_repo_path: Path, ref: str) -> bool:
+        """Check for pyproject.toml file at the given ref in the bare repo."""
+        try:
+            subprocess.run(
+                ["git", "-C", str(bare_repo_path), "show", f"{ref}:pyproject.toml"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+
+    def image_name(self) -> str:
+        return "python"
+
+    def post_clone(self, runtime: ContainerRuntime, container: str, project_dir: str):
+        """Set up auto-sync for Python projects using uv."""
+        q_dir = shlex.quote(project_dir)
+        cmd = f"cd {q_dir} && uv sync"
+        runtime.exec(
+            container,
+            [
+                "su",
+                "-",
+                "user",
+                "-c",
+                f"printf '%s' {shlex.quote(cmd)} > ~/.bubble-fetch-cache",
+            ],
+        )
+        click.echo("Python dependency sync will start automatically.")
+
+    def network_domains(self) -> list[str]:
+        return [
+            "pypi.org",
+            "files.pythonhosted.org",
+        ]

--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -75,6 +75,7 @@ def is_build_locked(image_name: str) -> bool:
 IMAGES = {
     "base": {"script": "base.sh", "parent": "images:ubuntu/24.04"},
     "lean": {"script": "lean.sh", "parent": "base"},
+    "python": {"script": "python.sh", "parent": "base"},
 }
 
 

--- a/bubble/images/scripts/python.sh
+++ b/bubble/images/scripts/python.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install uv (Python package manager from Astral)
+echo "Installing uv..."
+curl -LsSf https://astral.sh/uv/install.sh | su - user -c 'bash'
+
+# Add uv to PATH for all sessions
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/user/.bashrc
+echo 'export PATH="/home/user/.local/bin:$PATH"' >> /etc/profile.d/uv.sh
+
+# Install ruff via uv
+echo "Installing ruff..."
+su - user -c 'export PATH="$HOME/.local/bin:$PATH" && uv tool install ruff'
+
+echo "Python image setup complete."

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -74,8 +74,8 @@ class TestEditorToolResolution:
 class TestImageRegistry:
     """Verify the simplified IMAGES registry (no editor variants)."""
 
-    def test_only_base_and_lean(self):
-        assert set(IMAGES.keys()) == {"base", "lean"}
+    def test_only_base_lean_and_python(self):
+        assert set(IMAGES.keys()) == {"base", "lean", "python"}
 
     def test_base_exists(self):
         assert IMAGES["base"]["script"] == "base.sh"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -7,6 +7,7 @@ import pytest
 
 from bubble.hooks import discover_hooks, select_hook
 from bubble.hooks.lean import LeanHook, _parse_lean_version
+from bubble.hooks.python import PythonHook
 
 GIT = shutil.which("git")
 if GIT is None:
@@ -222,11 +223,63 @@ class TestLean4Detection:
         assert hook.workspace_file("/home/user/mathlib4") is None
 
 
+@pytest.fixture
+def python_repo(tmp_path):
+    """Create a bare git repo with a pyproject.toml file."""
+    toml = '[project]\nname = "example"\n'
+    return _make_hook_repo(tmp_path, "pyproject", {"pyproject.toml": toml})
+
+
+class TestPythonHook:
+    def test_detect_python_repo(self, python_repo):
+        hook = PythonHook()
+        assert hook.detect(python_repo, "HEAD") is True
+
+    def test_detect_non_python_repo(self, non_lean_repo):
+        hook = PythonHook()
+        assert hook.detect(non_lean_repo, "HEAD") is False
+
+    def test_detect_nonexistent_ref(self, python_repo):
+        hook = PythonHook()
+        assert hook.detect(python_repo, "nonexistent-ref") is False
+
+    def test_name(self):
+        hook = PythonHook()
+        assert hook.name() == "Python"
+
+    def test_image_name(self):
+        hook = PythonHook()
+        assert hook.image_name() == "python"
+
+    def test_network_domains(self):
+        hook = PythonHook()
+        domains = hook.network_domains()
+        assert "pypi.org" in domains
+        assert "files.pythonhosted.org" in domains
+
+    def test_post_clone_writes_uv_sync(self, python_repo, mock_runtime):
+        hook = PythonHook()
+        hook.detect(python_repo, "HEAD")
+        hook.post_clone(mock_runtime, "test-container", "/home/user/project")
+        exec_calls = [c for c in mock_runtime.calls if c[0] == "exec"]
+        marker_calls = [c for c in exec_calls if ".bubble-fetch-cache" in " ".join(c[2])]
+        assert len(marker_calls) == 1
+        cmd_str = " ".join(marker_calls[0][2])
+        assert "uv sync" in cmd_str
+        assert "cd" in cmd_str
+        assert "/home/user/project" in cmd_str
+
+
 class TestSelectHook:
     def test_selects_lean_for_lean_repo(self, lean_repo):
         hook = select_hook(lean_repo, "HEAD")
         assert hook is not None
         assert hook.name() == "Lean 4"
+
+    def test_selects_python_for_python_repo(self, python_repo):
+        hook = select_hook(python_repo, "HEAD")
+        assert hook is not None
+        assert hook.name() == "Python"
 
     def test_returns_none_for_non_lean_repo(self, non_lean_repo):
         hook = select_hook(non_lean_repo, "HEAD")
@@ -237,5 +290,6 @@ class TestDiscoverHooks:
     def test_returns_list(self):
         hooks = discover_hooks()
         assert isinstance(hooks, list)
-        assert len(hooks) >= 1
+        assert len(hooks) >= 2
         assert any(h.name() == "Lean 4" for h in hooks)
+        assert any(h.name() == "Python" for h in hooks)


### PR DESCRIPTION
## Summary

- Add `PythonHook` that detects Python projects via `pyproject.toml` in the repo root
- New `python` image (derived from `base`) with `uv` and `ruff` pre-installed
- Auto-runs `uv sync` on first login via the `.bubble-fetch-cache` mechanism
- Runtime network allowlist includes `pypi.org` and `files.pythonhosted.org`

Closes #93

## Test plan

- [x] All 679 existing tests pass
- [x] New tests for `PythonHook`: detection, image name, network domains, post-clone marker
- [x] `TestSelectHook` updated to verify Python repo selection
- [x] `TestDiscoverHooks` updated to verify Python hook is registered
- [x] Linting passes (`ruff check` + `ruff format`)

🤖 Prepared with Claude Code