### PR TITLE
Forward Codex/OpenAI credentials into containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.5 — 2026-03-12
+- Forward Codex/OpenAI credentials into containers (#96)
+  - `--codex-credentials` / `--no-codex-credentials` flag on `bubble open`
+  - `[codex] credentials` config option (`bubble codex credentials on/off`)
+  - Mounts `~/.codex/auth.json` (credentials, opt-in) and `~/.codex/config.toml` (config) read-only
+  - `security.codex_credentials` setting for security posture control
+  - Same symlink-escape safety validation as Claude credential mounts
+- Fix security lockoff bypass: `security.{claude,codex}_credentials=off` now overrides config
+
 ## 0.6.4 — 2026-03-12
 - Make GitHub auth proxy on-by-default via `security.github_auth` setting (#89)
   - New `github_auth` security setting (auto defaults to on) controls repo-scoped auth proxy

--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -12,6 +12,7 @@ from . import __version__
 from .clone import clone_and_checkout
 from .config import (
     claude_config_mounts,
+    codex_config_mounts,
     editor_config_mounts,
     ensure_dirs,
     load_config,
@@ -456,6 +457,11 @@ def _reattach(runtime, name, editor, no_interactive, command=None):
     help="Mount ~/.claude credentials into container (default: from config or disabled)",
 )
 @click.option(
+    "--codex-credentials/--no-codex-credentials",
+    default=None,
+    help="Mount ~/.codex credentials into container (default: from config or disabled)",
+)
+@click.option(
     "--claude-prompt-stdin",
     is_flag=True,
     hidden=True,
@@ -485,6 +491,7 @@ def open_cmd(
     mounts,
     claude_config,
     claude_credentials,
+    codex_credentials,
     claude_prompt_stdin,
 ):
     """Open a bubble for a target (GitHub URL, repo, local path, or PR number)."""
@@ -509,6 +516,15 @@ def open_cmd(
         click.echo(
             "Error: --claude-credentials rejected because security.claude_credentials=off. "
             "Re-enable: bubble config set security.claude_credentials on",
+            err=True,
+        )
+        sys.exit(1)
+
+    # Enforce security: reject --codex-credentials when locked off
+    if codex_credentials and is_locked_off(config, "codex_credentials"):
+        click.echo(
+            "Error: --codex-credentials rejected because security.codex_credentials=off. "
+            "Re-enable: bubble config set security.codex_credentials on",
             err=True,
         )
         sys.exit(1)
@@ -634,9 +650,16 @@ def open_cmd(
     if claude_credentials is None:
         claude_credentials = config.get("claude", {}).get("credentials", False)
 
+    # Resolve codex_credentials: CLI flag > config > default (False)
+    if codex_credentials is None:
+        codex_credentials = config.get("codex", {}).get("credentials", False)
+
     # Claude Code config mounts (opt-out via --no-claude-config)
-    # When security.claude_credentials=on, always include credentials
-    include_creds = claude_credentials or is_enabled(config, "claude_credentials")
+    # When security.claude_credentials=on, always include credentials.
+    # When security.claude_credentials=off, never include (overrides config).
+    include_creds = (claude_credentials or is_enabled(config, "claude_credentials")) and not (
+        is_locked_off(config, "claude_credentials")
+    )
     cc_mounts = []
     if claude_config:
         cc_mounts = claude_config_mounts(include_credentials=include_creds)
@@ -646,6 +669,16 @@ def open_cmd(
         # Hint about symlinking ~/.bubble/claude-projects/ to ~/.claude/projects/
         if not machine_readable:
             maybe_symlink_claude_projects(config)
+
+    # Codex config mounts
+    # When security.codex_credentials=off, never include (overrides config).
+    include_codex_creds = (codex_credentials or is_enabled(config, "codex_credentials")) and not (
+        is_locked_off(config, "codex_credentials")
+    )
+    cx_mounts = codex_config_mounts(include_credentials=include_codex_creds)
+    if cx_mounts:
+        user_targets = {Path(m.target) for m in mount_specs}
+        cx_mounts = [m for m in cx_mounts if not mount_overlaps(Path(m.target), user_targets)]
 
     # Editor config mounts (emacs/neovim only — suppress if user mounts overlap)
     ec_mounts = editor_config_mounts(editor)
@@ -766,6 +799,7 @@ def open_cmd(
             network=network,
             user_mounts=mount_specs,
             claude_mounts=cc_mounts,
+            codex_mounts=cx_mounts,
             editor_mounts=ec_mounts,
         )
         checkout_branch = clone_and_checkout(runtime, name, t, mount_name, short)

--- a/bubble/commands/settings.py
+++ b/bubble/commands/settings.py
@@ -118,6 +118,49 @@ def register_settings_commands(main):
         creds = config.get("claude", {}).get("credentials", False)
         click.echo(f"  credentials: {'on' if creds else 'off'}")
 
+    # --- codex ---
+
+    @main.group("codex")
+    def codex_group():
+        """Manage Codex/OpenAI settings."""
+
+    @codex_group.command("credentials")
+    @click.argument("setting", required=False, type=click.Choice(["on", "off"]))
+    def codex_credentials_cmd(setting):
+        """Set whether Codex credentials are mounted into bubbles.
+
+        When on, ~/.codex credentials (auth.json) are mounted
+        read-only into containers by default. Override per-bubble with
+        --no-codex-credentials.
+
+        Shows current setting if no argument given.
+        """
+        config = load_config()
+        if setting is None:
+            current = config.get("codex", {}).get("credentials", False)
+            state = "on" if current else "off"
+            click.echo(f"Codex credentials: {state}")
+            if current:
+                click.echo("Credentials are mounted into bubbles by default.")
+                click.echo("Override with: bubble open --no-codex-credentials <target>")
+            else:
+                click.echo("Use --codex-credentials flag or: bubble codex credentials on")
+            return
+        config.setdefault("codex", {})["credentials"] = setting == "on"
+        save_config(config)
+        if setting == "on":
+            click.echo("Codex credentials enabled. Mounted into all new bubbles by default.")
+            click.echo("Override with: bubble open --no-codex-credentials <target>")
+        else:
+            click.echo("Codex credentials disabled.")
+
+    @codex_group.command("status")
+    def codex_status_cmd():
+        """Show current Codex settings."""
+        config = load_config()
+        creds = config.get("codex", {}).get("credentials", False)
+        click.echo(f"  credentials: {'on' if creds else 'off'}")
+
     # --- tools ---
 
     @main.group("tools")

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -64,6 +64,9 @@ DEFAULT_CONFIG = {
     "claude": {
         "credentials": False,
     },
+    "codex": {
+        "credentials": False,
+    },
     "security": {},
     "tools": {},
 }
@@ -401,6 +404,69 @@ def parse_mounts(config: dict, cli_mounts: tuple[str, ...] = ()) -> list[MountSp
             raise ValueError(f"Duplicate mount target: {m.target}")
         seen.add(m.target)
     return mounts
+
+
+CODEX_CONFIG_DIR = Path.home() / ".codex"
+
+# Specific items from ~/.codex to mount read-only into containers.
+_CODEX_CONFIG_ITEMS = [
+    "config.toml",
+]
+
+# Credential files — opt-in only (--codex-credentials).
+_CODEX_CREDENTIAL_ITEMS = [
+    "auth.json",
+]
+
+
+def _safe_codex_path(item: str) -> Path | None:
+    """Return resolved path for a codex config item, or None if unsafe.
+
+    Rejects symlinks that escape ~/.codex to prevent exposing arbitrary
+    host files into containers.
+    """
+    source = CODEX_CONFIG_DIR / item
+    if not source.exists():
+        return None
+    resolved = source.resolve()
+    codex_resolved = CODEX_CONFIG_DIR.resolve()
+    # Ensure the resolved path is inside ~/.codex
+    try:
+        resolved.relative_to(codex_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
+def codex_config_mounts(include_credentials: bool = False) -> list[MountSpec]:
+    """Return read-only mounts for Codex config files that exist on the host.
+
+    Mounts specific files from ~/.codex into /home/user/.codex/
+    inside containers, giving Codex sessions access to config and auth.
+
+    Args:
+        include_credentials: If True, also mount auth.json.
+            Off by default for security.
+    """
+    mounts = []
+    if not CODEX_CONFIG_DIR.is_dir():
+        return mounts
+    items = list(_CODEX_CONFIG_ITEMS)
+    if include_credentials:
+        items.extend(_CODEX_CREDENTIAL_ITEMS)
+    for item in items:
+        resolved = _safe_codex_path(item)
+        if resolved is not None:
+            target = f"/home/user/.codex/{item}"
+            mounts.append(MountSpec(source=str(resolved), target=target, readonly=True))
+    return mounts
+
+
+def has_codex_credentials() -> bool:
+    """Check if the host has Codex credential files."""
+    if not CODEX_CONFIG_DIR.is_dir():
+        return False
+    return any((CODEX_CONFIG_DIR / item).exists() for item in _CODEX_CREDENTIAL_ITEMS)
 
 
 CLAUDE_PROJECTS_DIR = DATA_DIR / "claude-projects"

--- a/bubble/provisioning.py
+++ b/bubble/provisioning.py
@@ -41,6 +41,7 @@ def provision_container(
     network=False,
     user_mounts=None,
     claude_mounts=None,
+    codex_mounts=None,
     editor_mounts=None,
 ):
     """Launch container, wait for readiness, apply network allowlist, mount git repos."""
@@ -145,6 +146,21 @@ def provision_container(
                 "claude-projects",
                 str(projects_dir),
                 "/home/user/.claude/projects",
+            )
+
+    # Mount Codex config (read-only individual files from ~/.codex)
+    if codex_mounts:
+        runtime.exec(
+            name,
+            ["bash", "-c", "mkdir -p /home/user/.codex && chown user:user /home/user/.codex"],
+        )
+        for i, m in enumerate(codex_mounts):
+            runtime.add_disk(
+                name,
+                f"codex-config-{i}",
+                m.source,
+                m.target,
+                readonly=m.readonly,
             )
 
     # Mount editor config directories (read-only config, read-write data/state)

--- a/bubble/security.py
+++ b/bubble/security.py
@@ -66,6 +66,12 @@ SETTINGS: dict[str, SecuritySettingDef] = {
         warning="credentials give containers access to Claude API auth",
         category="Authentication",
     ),
+    "codex_credentials": SecuritySettingDef(
+        description="Mount ~/.codex credentials into containers",
+        auto_default="off",
+        warning="credentials give containers access to OpenAI/Codex API auth",
+        category="Authentication",
+    ),
     "github_auth": SecuritySettingDef(
         description="Repo-scoped GitHub auth via host proxy",
         auto_default="on",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,6 +169,107 @@ def test_load_raw_config_legacy_no_claude(tmp_data_dir):
     assert merged["claude"]["credentials"] is False
 
 
+def test_default_config_has_codex_credentials_false(tmp_data_dir):
+    from bubble.config import load_config
+
+    config = load_config()
+    assert config["codex"]["credentials"] is False
+
+
+def test_codex_credentials_roundtrip(tmp_data_dir):
+    from bubble.config import load_config, save_config
+
+    config = load_config()
+    config["codex"]["credentials"] = True
+    save_config(config)
+
+    reloaded = load_config()
+    assert reloaded["codex"]["credentials"] is True
+
+
+def test_codex_credentials_on_cli(tmp_data_dir):
+    from click.testing import CliRunner
+
+    from bubble.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["codex", "credentials", "on"])
+    assert result.exit_code == 0
+    assert "enabled" in result.output
+
+    from bubble.config import load_config
+
+    config = load_config()
+    assert config["codex"]["credentials"] is True
+
+
+def test_codex_credentials_off_cli(tmp_data_dir):
+    from click.testing import CliRunner
+
+    from bubble.cli import main
+
+    runner = CliRunner()
+    # First enable
+    runner.invoke(main, ["codex", "credentials", "on"])
+    # Then disable
+    result = runner.invoke(main, ["codex", "credentials", "off"])
+    assert result.exit_code == 0
+    assert "disabled" in result.output
+
+    from bubble.config import load_config
+
+    config = load_config()
+    assert config["codex"]["credentials"] is False
+
+
+def test_codex_credentials_show_current(tmp_data_dir):
+    from click.testing import CliRunner
+
+    from bubble.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["codex", "credentials"])
+    assert result.exit_code == 0
+    assert "off" in result.output
+
+
+def test_codex_status_cli(tmp_data_dir):
+    from click.testing import CliRunner
+
+    from bubble.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["codex", "status"])
+    assert result.exit_code == 0
+    assert "credentials: off" in result.output
+
+    # Enable and check again
+    runner.invoke(main, ["codex", "credentials", "on"])
+    result = runner.invoke(main, ["codex", "status"])
+    assert result.exit_code == 0
+    assert "credentials: on" in result.output
+
+
+def test_load_raw_config_legacy_no_codex(tmp_data_dir):
+    """Legacy config file without [codex] section should show no explicit setting."""
+    import tomli_w
+
+    import bubble.config as config
+
+    legacy = {
+        "editor": "vscode",
+        "runtime": {"backend": "incus"},
+    }
+    with open(config.CONFIG_FILE, "wb") as f:
+        tomli_w.dump(legacy, f)
+
+    raw = load_raw_config()
+    assert "codex" not in raw
+    # But merged config should still have defaults
+    merged = config.load_config()
+    assert merged["codex"]["credentials"] is False
+
+
 def test_deep_merge_does_not_mutate_default(tmp_data_dir):
     """Verify _deep_merge doesn't mutate DEFAULT_CONFIG nested dicts."""
     from bubble.config import DEFAULT_CONFIG

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -7,8 +7,10 @@ import pytest
 from bubble.config import (
     MountSpec,
     claude_config_mounts,
+    codex_config_mounts,
     editor_config_mounts,
     has_claude_credentials,
+    has_codex_credentials,
     parse_mounts,
 )
 
@@ -707,6 +709,251 @@ class TestClaudeConfigProvisioning:
         disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
         projects_calls = [c for c in disk_calls if c[2] == "claude-projects"]
         assert len(projects_calls) == 0
+
+
+class TestCodexConfigMounts:
+    """Test automatic ~/.codex config mounting."""
+
+    def test_returns_existing_config(self, tmp_path, monkeypatch):
+        """Mounts returned for config items that exist (no credentials by default)."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text("[settings]")
+        (codex_dir / "auth.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts()
+
+        assert len(mounts) == 1
+        targets = {m.target for m in mounts}
+        assert "/home/user/.codex/config.toml" in targets
+        # Credentials NOT included by default
+        assert "/home/user/.codex/auth.json" not in targets
+        assert all(m.readonly for m in mounts)
+
+    def test_returns_all_with_credentials(self, tmp_path, monkeypatch):
+        """All items returned when include_credentials=True."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text("[settings]")
+        (codex_dir / "auth.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts(include_credentials=True)
+
+        assert len(mounts) == 2
+        targets = {m.target for m in mounts}
+        assert "/home/user/.codex/config.toml" in targets
+        assert "/home/user/.codex/auth.json" in targets
+
+    def test_skips_missing_files(self, tmp_path, monkeypatch):
+        """Only existing files are mounted."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text("[settings]")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts(include_credentials=True)
+
+        assert len(mounts) == 1
+        assert mounts[0].target == "/home/user/.codex/config.toml"
+
+    def test_no_codex_dir(self, tmp_path, monkeypatch):
+        """Returns empty when ~/.codex doesn't exist."""
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", tmp_path / "nonexistent")
+
+        mounts = codex_config_mounts()
+
+        assert mounts == []
+
+    def test_credentials_excluded_by_default(self, tmp_path, monkeypatch):
+        """Credential files are NOT mounted by default."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts()
+
+        assert mounts == []
+
+    def test_credentials_included_when_requested(self, tmp_path, monkeypatch):
+        """Credential files are mounted when include_credentials=True."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts(include_credentials=True)
+
+        targets = {m.target for m in mounts}
+        assert "/home/user/.codex/auth.json" in targets
+        assert all(m.readonly for m in mounts)
+
+    def test_has_codex_credentials(self, tmp_path, monkeypatch):
+        """has_codex_credentials() detects credential files."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        assert not has_codex_credentials()
+
+        (codex_dir / "auth.json").write_text("{}")
+        assert has_codex_credentials()
+
+    def test_rejects_symlinks_escaping_codex_dir(self, tmp_path, monkeypatch):
+        """Symlinks that escape ~/.codex are rejected."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        # Create a file outside ~/.codex
+        secret = tmp_path / "secret.txt"
+        secret.write_text("sensitive data")
+        # Symlink from inside ~/.codex to outside
+        (codex_dir / "config.toml").symlink_to(secret)
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts()
+
+        assert mounts == []
+
+    def test_allows_symlinks_within_codex_dir(self, tmp_path, monkeypatch):
+        """Symlinks within ~/.codex are allowed."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        real = codex_dir / "real-config.toml"
+        real.write_text("[settings]")
+        (codex_dir / "config.toml").symlink_to(real)
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts()
+
+        assert len(mounts) == 1
+        assert mounts[0].target == "/home/user/.codex/config.toml"
+
+    def test_sources_are_absolute(self, tmp_path, monkeypatch):
+        """Mount sources use absolute paths."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text("[settings]")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG_DIR", codex_dir)
+
+        mounts = codex_config_mounts()
+
+        assert Path(mounts[0].source).is_absolute()
+
+
+class TestCodexConfigProvisioning:
+    """Test that codex config mounts are applied during container provisioning."""
+
+    def test_codex_mounts_applied(self, mock_runtime, tmp_path, tmp_data_dir):
+        """Verify add_disk calls with codex-config device names."""
+        from bubble.provisioning import provision_container as _provision_container
+
+        ref_path = tmp_path / "repo.git"
+        ref_path.mkdir()
+
+        codex_mounts = [
+            MountSpec(
+                source="/home/testuser/.codex/config.toml",
+                target="/home/user/.codex/config.toml",
+                readonly=True,
+            ),
+            MountSpec(
+                source="/home/testuser/.codex/auth.json",
+                target="/home/user/.codex/auth.json",
+                readonly=True,
+            ),
+        ]
+
+        _provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            {},
+            codex_mounts=codex_mounts,
+        )
+
+        disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
+        codex_disk_calls = [c for c in disk_calls if "codex-config" in c[2]]
+        assert len(codex_disk_calls) == 2
+        assert codex_disk_calls[0] == (
+            "add_disk",
+            "test-container",
+            "codex-config-0",
+            "/home/testuser/.codex/config.toml",
+            "/home/user/.codex/config.toml",
+            True,
+        )
+        assert codex_disk_calls[1] == (
+            "add_disk",
+            "test-container",
+            "codex-config-1",
+            "/home/testuser/.codex/auth.json",
+            "/home/user/.codex/auth.json",
+            True,
+        )
+
+    def test_creates_codex_dir_in_container(self, mock_runtime, tmp_path, tmp_data_dir):
+        """Verify .codex directory is created before mounting."""
+        from bubble.provisioning import provision_container as _provision_container
+
+        ref_path = tmp_path / "repo.git"
+        ref_path.mkdir()
+
+        codex_mounts = [
+            MountSpec(
+                source="/home/testuser/.codex/auth.json",
+                target="/home/user/.codex/auth.json",
+                readonly=True,
+            ),
+        ]
+
+        _provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            {},
+            codex_mounts=codex_mounts,
+        )
+
+        exec_calls = [c for c in mock_runtime.calls if c[0] == "exec"]
+        mkdir_calls = [c for c in exec_calls if ".codex" in " ".join(c[2])]
+        assert len(mkdir_calls) == 1
+        assert "mkdir -p /home/user/.codex" in " ".join(mkdir_calls[0][2])
+        assert "chown user:user" in " ".join(mkdir_calls[0][2])
+
+    def test_no_codex_mounts(self, mock_runtime, tmp_path, tmp_data_dir):
+        """No codex mount calls when codex_mounts is empty."""
+        from bubble.provisioning import provision_container as _provision_container
+
+        ref_path = tmp_path / "repo.git"
+        ref_path.mkdir()
+
+        _provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            {},
+            codex_mounts=[],
+        )
+
+        disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
+        codex_disk_calls = [c for c in disk_calls if "codex" in c[2]]
+        assert len(codex_disk_calls) == 0
 
 
 class TestMountOverlaps:


### PR DESCRIPTION
## Summary

- Add opt-in Codex credential forwarding (`~/.codex/auth.json` and `~/.codex/config.toml`) into containers, following the exact same pattern as existing Claude credential mounts
- New `--codex-credentials` / `--no-codex-credentials` flag on `bubble open`
- New `[codex] credentials` config option with CLI commands (`bubble codex credentials on/off`, `bubble codex status`)
- New `security.codex_credentials` setting (default: off) for security posture control
- Symlink-escape safety validation prevents exposing arbitrary host files

## Test plan

- [x] Existing tests pass (88 tests unchanged)
- [x] New config tests: default value, roundtrip, CLI on/off/show/status, legacy config compat (7 tests)
- [x] New mount tests: config mounts, credential inclusion/exclusion, symlink safety, missing dir handling (10 tests)
- [x] New provisioning tests: device naming, directory creation, empty mount list (3 tests)
- [x] Lint and format clean (`ruff check` + `ruff format`)

Closes #96

🤖 Prepared with Claude Code