### PR TITLE
Make GitHub auth proxy on-by-default via security setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.4 — 2026-03-12
+- Make GitHub auth proxy on-by-default via `security.github_auth` setting (#89)
+  - New `github_auth` security setting (auto defaults to on) controls repo-scoped auth proxy
+  - Removed `--gh-token` CLI flag and `[github] token` config — auth proxy is now always enabled
+  - Removed "Tip: use --gh-token" nag message (no longer needed)
+  - Removed `bubble gh token on/off` command; use `bubble security set github_auth off` to disable
+  - Backwards compatible: `[github] token = false` in config maps to `security.github_auth = off`
+
 ## 0.6.3 — 2026-03-12
 - Don't prompt interactively during `bubble open` (#88)
   - `maybe_symlink_claude_projects()` now prints an informational message instead of blocking on a `[y/N]` prompt

--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -254,7 +254,6 @@ def _open_remote(
     claude_config=True,
     new_branch=None,
     base_ref=None,
-    gh_token=False,
 ):
     """Open a bubble on a remote host, then connect locally."""
     from .remote import remote_open
@@ -288,7 +287,7 @@ def _open_remote(
     inject_local_ssh_keys(remote_host, name)
 
     # Set up GitHub auth via tunneled auth proxy
-    if gh_token:
+    if is_enabled(config, "github_auth"):
         from .github_token import setup_gh_token
 
         owner, repo = "", ""
@@ -457,11 +456,6 @@ def _reattach(runtime, name, editor, no_interactive, command=None):
     help="Mount ~/.claude credentials into container (default: from config or disabled)",
 )
 @click.option(
-    "--gh-token/--no-gh-token",
-    default=None,
-    help="Inject GitHub auth token into container (default: from config or disabled)",
-)
-@click.option(
     "--claude-prompt-stdin",
     is_flag=True,
     hidden=True,
@@ -491,7 +485,6 @@ def open_cmd(
     mounts,
     claude_config,
     claude_credentials,
-    gh_token,
     claude_prompt_stdin,
 ):
     """Open a bubble for a target (GitHub URL, repo, local path, or PR number)."""
@@ -611,10 +604,6 @@ def open_cmd(
 
                 remote_host = RemoteHost.parse(default)
 
-    # Resolve --gh-token: CLI flag > config > disabled
-    if gh_token is None:
-        gh_token = config.get("github", {}).get("token", False)
-
     if remote_host:
         if mount_specs:
             click.echo(
@@ -638,7 +627,6 @@ def open_cmd(
             claude_config=claude_config,
             new_branch=new_branch,
             base_ref=base_ref,
-            gh_token=gh_token,
         )
         return
 
@@ -664,16 +652,6 @@ def open_cmd(
     if ec_mounts:
         user_targets = {Path(m.target) for m in mount_specs}
         ec_mounts = [m for m in ec_mounts if not mount_overlaps(Path(m.target), user_targets)]
-
-    # Nag about gh token if not enabled
-    if not gh_token and not machine_readable:
-        from .github_token import has_gh_auth
-
-        if has_gh_auth():
-            click.echo(
-                "Tip: use --gh-token to inject GitHub auth into this bubble.",
-                err=True,
-            )
 
     # Local flow
     runtime = get_runtime(config)
@@ -827,7 +805,6 @@ def open_cmd(
             git_email=git_email,
             command=command_args,
             claude_prompt=claude_prompt,
-            gh_token=gh_token,
         )
     except Exception:
         # Clean up partially-provisioned container on failure

--- a/bubble/commands/settings.py
+++ b/bubble/commands/settings.py
@@ -227,38 +227,28 @@ def register_settings_commands(main):
     def gh_group():
         """Manage GitHub integration settings."""
 
-    @gh_group.command("token")
-    @click.argument("value", type=click.Choice(["on", "off"]))
-    def gh_token_cmd(value):
-        """Enable or disable GitHub token injection into bubbles."""
-        config = load_config()
-        if "github" not in config:
-            config["github"] = {}
-        config["github"]["token"] = value == "on"
-        save_config(config)
-        if value == "on":
-            click.echo("GitHub token injection enabled for new bubbles.")
-        else:
-            click.echo("GitHub token injection disabled.")
-
     @gh_group.command("status")
     def gh_status():
         """Show GitHub integration status."""
         from ..automation import is_auth_proxy_installed
         from ..github_token import has_gh_auth
+        from ..security import is_enabled as sec_is_enabled
 
         config = load_config()
-        token_enabled = config.get("github", {}).get("token", False)
+        github_auth = get_setting(config, "github_auth")
+        enabled = sec_is_enabled(config, "github_auth")
         host_auth = has_gh_auth()
         proxy_installed = is_auth_proxy_installed()
 
-        click.echo(f"Token injection:  {'enabled' if token_enabled else 'disabled'}")
+        click.echo(f"GitHub auth:      {github_auth} (effectively {'on' if enabled else 'off'})")
         click.echo(f"Host gh auth:     {'authenticated' if host_auth else 'not authenticated'}")
         click.echo(f"Auth proxy:       {'installed' if proxy_installed else 'not installed'}")
         if not host_auth:
             click.echo("\nRun 'gh auth login' to authenticate on the host first.")
-        elif not token_enabled:
-            click.echo("\nRun 'bubble gh token on' to enable token injection by default.")
+        elif not enabled:
+            click.echo(
+                "\nRun 'bubble security set github_auth on' to enable GitHub auth in bubbles."
+            )
 
     @gh_group.group("proxy")
     def gh_proxy_group():

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -29,7 +29,6 @@ def finalize_bubble(
     git_email="",
     command=None,
     claude_prompt="",
-    gh_token=False,
 ):
     """Post-clone setup: hooks, SSH, registration, and attach."""
     q_short = shlex.quote(short)
@@ -37,8 +36,8 @@ def finalize_bubble(
     if hook:
         hook.post_clone(runtime, name, project_dir)
 
-    # Inject GitHub token if requested
-    if gh_token:
+    # Set up repo-scoped GitHub auth via host proxy (security.github_auth)
+    if is_enabled(config, "github_auth"):
         from .github_token import setup_gh_token
 
         setup_gh_token(runtime, name, owner=t.owner, repo=t.repo, machine_readable=machine_readable)

--- a/bubble/security.py
+++ b/bubble/security.py
@@ -66,6 +66,12 @@ SETTINGS: dict[str, SecuritySettingDef] = {
         warning="credentials give containers access to Claude API auth",
         category="Authentication",
     ),
+    "github_auth": SecuritySettingDef(
+        description="Repo-scoped GitHub auth via host proxy",
+        auto_default="on",
+        warning="containers get repo-scoped GitHub push access via auth proxy",
+        category="Authentication",
+    ),
     "relay": SecuritySettingDef(
         description="Bubble-in-bubble relay daemon",
         auto_default="off",
@@ -115,6 +121,15 @@ def get_setting(config: dict, name: str) -> str:
     if name == "relay" and value == "auto":
         if config.get("relay", {}).get("enabled", False):
             return "on"
+
+    # Backwards compat: if github_auth is auto but [github] token was
+    # explicitly set, respect that choice.
+    if name == "github_auth" and value == "auto":
+        gh_token = config.get("github", {}).get("token")
+        if gh_token is True:
+            return "on"
+        if gh_token is False:
+            return "off"
 
     return value
 

--- a/tests/test_github_token.py
+++ b/tests/test_github_token.py
@@ -198,34 +198,6 @@ def test_setup_auth_proxy_remote_git_config_failure_cleans_token():
 # CLI tests
 
 
-def test_gh_token_on_cli(tmp_data_dir):
-    from bubble.cli import main
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["gh", "token", "on"])
-    assert result.exit_code == 0
-    assert "enabled" in result.output
-
-    from bubble.config import load_config
-
-    config = load_config()
-    assert config["github"]["token"] is True
-
-
-def test_gh_token_off_cli(tmp_data_dir):
-    from bubble.cli import main
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["gh", "token", "off"])
-    assert result.exit_code == 0
-    assert "disabled" in result.output
-
-    from bubble.config import load_config
-
-    config = load_config()
-    assert config["github"]["token"] is False
-
-
 def test_gh_status_cli_not_authed(tmp_data_dir):
     from bubble.cli import main
 
@@ -248,12 +220,13 @@ def test_gh_status_cli_authed(tmp_data_dir):
     assert "authenticated" in result.output
 
 
-def test_gh_token_config_roundtrip(tmp_data_dir):
-    from bubble.config import load_config, save_config
+def test_gh_status_shows_security_setting(tmp_data_dir):
+    from bubble.cli import main
 
-    config = load_config()
-    config["github"] = {"token": True}
-    save_config(config)
-
-    reloaded = load_config()
-    assert reloaded["github"]["token"] is True
+    runner = CliRunner()
+    with patch("bubble.github_token.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        result = runner.invoke(main, ["gh", "status"])
+    assert result.exit_code == 0
+    assert "GitHub auth:" in result.output
+    assert "effectively on" in result.output

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -54,6 +54,24 @@ def test_get_setting_relay_explicit_overrides_backwards_compat():
     assert get_setting(config, "relay") == "off"
 
 
+def test_get_setting_github_auth_backwards_compat_on():
+    """When github_auth is auto but [github] token = true, treat as on."""
+    config = {"github": {"token": True}}
+    assert get_setting(config, "github_auth") == "on"
+
+
+def test_get_setting_github_auth_backwards_compat_off():
+    """When github_auth is auto but [github] token = false, treat as off."""
+    config = {"github": {"token": False}}
+    assert get_setting(config, "github_auth") == "off"
+
+
+def test_get_setting_github_auth_explicit_overrides_backwards_compat():
+    """Explicit security.github_auth takes precedence over [github] token."""
+    config = {"security": {"github_auth": "on"}, "github": {"token": False}}
+    assert get_setting(config, "github_auth") == "on"
+
+
 def test_get_setting_unknown_raises():
     import pytest
 
@@ -69,6 +87,7 @@ def test_is_enabled_auto_on():
     assert is_enabled(config, "cloud_root") is True
     assert is_enabled(config, "git_manifest_trust") is True
     assert is_enabled(config, "user_mounts") is True
+    assert is_enabled(config, "github_auth") is True
 
 
 def test_is_enabled_auto_off():


### PR DESCRIPTION
## Summary

- Adds a `github_auth` security setting (auto defaults to on) that controls the repo-scoped auth proxy, replacing the opt-in `--gh-token` CLI flag
- Removes the `--gh-token/--no-gh-token` flag, `[github] token` config, `bubble gh token on/off` command, and the nag tip
- Backwards compatible: existing `[github] token = false` in config maps to `security.github_auth = off`

Users who don't know about `--gh-token` previously got containers with no GitHub push access. Since the proxy is already secure by design (per-container tokens, repo-scoped, token stays on host), it should be on by default.

Closes #89

## Test plan

- [x] All 694 tests pass (3 skipped for Incus integration)
- [x] New security setting tests: backwards compat for `[github] token` config
- [x] Updated `bubble gh status` shows security setting state
- [x] Linting passes

🤖 Prepared with Claude Code