### PR TITLE
Remove cloud_root security setting (redundant with cloud opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `security.codex_credentials` setting for security posture control
   - Same symlink-escape safety validation as Claude credential mounts
 - Fix security lockoff bypass: `security.{claude,codex}_credentials=off` now overrides config
+- Remove `cloud_root` security setting — redundant with cloud's explicit opt-in requirements (#103)
 
 ## 0.6.4 — 2026-03-12
 - Make GitHub auth proxy on-by-default via `security.github_auth` setting (#89)
@@ -148,7 +149,7 @@
 - `bubble config accept-risks` silences on-by-default warnings; `bubble config lockdown` disables off-by-default features
 - Security warnings printed to stderr for all `auto` settings during `bubble open`
 - `BUBBLE_QUIET_SECURITY=1` env var suppresses warnings for CI/automation
-- Settings: `shared_cache`, `user_mounts`, `network_github`, `relay`, `claude_credentials`, `host_key_trust`, `cloud_root`, `git_manifest_trust`
+- Settings: `shared_cache`, `user_mounts`, `network_github`, `relay`, `claude_credentials`, `host_key_trust`, `git_manifest_trust`
 - When `shared_cache=off`, shared mounts are read-only; when `network_github=off`, GitHub domains stripped from allowlist
 - When `user_mounts=off` or `claude_credentials=off`, corresponding CLI flags are rejected
 - Relay enable/disable migrated to `[security] relay` with backwards compatibility for `[relay] enabled`

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -603,13 +603,6 @@ def open_cmd(
 
             remote_host = RemoteHost.parse(ssh_host)
         elif cloud or config.get("cloud", {}).get("default", False):
-            if is_locked_off(config, "cloud_root"):
-                click.echo(
-                    "Error: cloud access rejected because security.cloud_root=off. "
-                    "Re-enable: bubble config set security.cloud_root on",
-                    err=True,
-                )
-                sys.exit(1)
             from .cloud import get_cloud_remote_host
 
             remote_host = get_cloud_remote_host(config)

--- a/bubble/commands/cloud_cmd.py
+++ b/bubble/commands/cloud_cmd.py
@@ -1,11 +1,8 @@
 """The 'cloud' command group: provision, destroy, stop, start, status, ssh, default."""
 
-import sys
-
 import click
 
 from ..config import load_config, save_config
-from ..security import is_locked_off
 
 
 def register_cloud_commands(main):
@@ -48,14 +45,6 @@ def register_cloud_commands(main):
 
             list_server_types(config, location=location)
             return
-
-        if is_locked_off(config, "cloud_root"):
-            click.echo(
-                "Error: cloud provisioning rejected because security.cloud_root=off. "
-                "Re-enable: bubble config set security.cloud_root on",
-                err=True,
-            )
-            sys.exit(1)
 
         from ..cloud import provision_server
 
@@ -113,14 +102,6 @@ def register_cloud_commands(main):
     @click.argument("args", nargs=-1)
     def cloud_ssh_cmd(args):
         """SSH directly to the cloud server."""
-        config = load_config()
-        if is_locked_off(config, "cloud_root"):
-            click.echo(
-                "Error: cloud SSH rejected because security.cloud_root=off. "
-                "Re-enable: bubble config set security.cloud_root on",
-                err=True,
-            )
-            sys.exit(1)
         from ..cloud import cloud_ssh
 
         cloud_ssh(list(args) if args else None)

--- a/bubble/security.py
+++ b/bubble/security.py
@@ -31,7 +31,6 @@ CATEGORIES = [
     ("Network", "Controls what containers can reach over the network"),
     ("Filesystem", "Controls what host paths containers can access"),
     ("Authentication", "Controls credential and API access from containers"),
-    ("Cloud", "Controls cloud server provisioning and access"),
     ("SSH", "Controls SSH connection security"),
 ]
 
@@ -83,12 +82,6 @@ SETTINGS: dict[str, SecuritySettingDef] = {
         auto_default="off",
         warning="relay allows containers to create new bubbles on the host",
         category="Authentication",
-    ),
-    "cloud_root": SecuritySettingDef(
-        description="Cloud server accessed as root with unencrypted key",
-        auto_default="on",
-        warning="cloud server provisioned/accessed as root with unencrypted SSH key",
-        category="Cloud",
     ),
     "host_key_trust": SecuritySettingDef(
         description="StrictHostKeyChecking disabled for container SSH",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -84,7 +84,6 @@ def test_is_enabled_auto_on():
     assert is_enabled(config, "shared_cache") is True  # auto_default = on
     assert is_enabled(config, "network_github") is True
     assert is_enabled(config, "host_key_trust") is True
-    assert is_enabled(config, "cloud_root") is True
     assert is_enabled(config, "git_manifest_trust") is True
     assert is_enabled(config, "user_mounts") is True
     assert is_enabled(config, "github_auth") is True


### PR DESCRIPTION
## Summary
- Remove `cloud_root` from `SECURITY_SETTINGS` and the "Cloud" category
- Remove `is_locked_off(config, "cloud_root")` checks from `bubble open --cloud`, `bubble cloud provision`, and `bubble cloud ssh`
- Bump version to 0.6.5

Cloud already requires explicit opt-in: `HETZNER_TOKEN` env var, `bubble cloud provision`, and optionally `[cloud] default = true`. The `cloud_root` security setting was a binary kill switch that duplicated this existing opt-in without offering a less-privileged mode.

Closes #103

🤖 Prepared with Claude Code