### PR TITLE
Add heartbeat messages for slow image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.22 — 2026-03-12
+- Add heartbeat messages for slow image builds (#145)
+  - Prints `still building...` / `still installing tools...` to stderr every 10s after 5s of silence
+  - Automatically disabled for non-TTY output (piped, `--machine-readable`, CI)
+
 ## 0.6.21 — 2026-03-12
 - Hide `skill`, `claude`, `codex` from top-level help; hide `config security`, `config lockdown`, `config accept-risks` as deprecated aliases (#142)
   - All commands remain fully functional, just not listed in `--help`

--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 from ..config import DATA_DIR, load_config
 from ..runtime.base import ContainerRuntime
+from ..spinner import heartbeat
 from ..tools import combined_tool_script, resolve_tools, tools_hash
 
 VSCODE_COMMIT_FILE = DATA_DIR / "vscode-commit"
@@ -410,7 +411,8 @@ def _install_tools_if_base(
         if vscode_commit and "vscode" in enabled:
             script = f"export VSCODE_COMMIT='{vscode_commit}'\n" + script
         print(f"  Installing tools: {', '.join(enabled)}")
-        runtime.exec(build_name, ["bash", "-c", script])
+        with heartbeat("  still installing tools..."):
+            runtime.exec(build_name, ["bash", "-c", script])
     return enabled
 
 
@@ -503,7 +505,8 @@ def build_image(
 
             # Run setup script
             script = (SCRIPTS_DIR / spec["script"]).read_text()
-            runtime.exec(build_name, ["bash", "-c", script])
+            with heartbeat(f"  still building {image_name} image..."):
+                runtime.exec(build_name, ["bash", "-c", script])
 
             # Install configured tools (only on base image — derived images inherit them)
             enabled_tools = _install_tools_if_base(runtime, build_name, image_name)
@@ -601,7 +604,8 @@ def build_lean_toolchain_image(
 
             script = (SCRIPTS_DIR / "lean-toolchain.sh").read_text()
             script = f"export LEAN_TOOLCHAIN='{version}'\n" + script
-            runtime.exec(build_name, ["bash", "-c", script])
+            with heartbeat(f"  still building {alias} image..."):
+                runtime.exec(build_name, ["bash", "-c", script])
 
             # Run user customization script as the final build step
             _run_customize_script(runtime, build_name)

--- a/bubble/spinner.py
+++ b/bubble/spinner.py
@@ -1,0 +1,46 @@
+"""Heartbeat messages for slow, silent operations.
+
+Prints periodic status messages to stderr when an operation produces no
+output for several seconds.  Automatically disabled when stderr is not a
+TTY (piped output, CI, ``--machine-readable``).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from contextlib import contextmanager
+
+
+@contextmanager
+def heartbeat(
+    message: str = "  still working...",
+    delay: float = 5.0,
+    interval: float = 10.0,
+):
+    """Print periodic heartbeat messages to stderr during slow operations.
+
+    After *delay* seconds of silence, prints *message* every *interval*
+    seconds until the context exits.  Does nothing when stderr is not a TTY.
+    """
+    if not sys.stderr.isatty():
+        yield
+        return
+
+    stop = threading.Event()
+
+    def _worker():
+        if stop.wait(delay):
+            return
+        while True:
+            print(message, file=sys.stderr, flush=True)
+            if stop.wait(interval):
+                return
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        t.join(timeout=1.0)

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -1,0 +1,65 @@
+"""Tests for the heartbeat spinner module."""
+
+import io
+import sys
+import time
+
+from bubble.spinner import heartbeat
+
+
+class TestHeartbeat:
+    def test_no_output_when_fast(self, monkeypatch):
+        """No heartbeat message if operation finishes before delay."""
+        buf = io.TextIOWrapper(io.BytesIO(), write_through=True)
+        monkeypatch.setattr(sys, "stderr", buf)
+        # Pretend stderr is a TTY
+        monkeypatch.setattr(buf, "isatty", lambda: True)
+
+        with heartbeat(delay=10.0, interval=10.0):
+            pass  # instant
+
+        buf.seek(0)
+        assert buf.read() == ""
+
+    def test_prints_after_delay(self, monkeypatch):
+        """Heartbeat message appears after the delay elapses."""
+        buf = io.TextIOWrapper(io.BytesIO(), write_through=True)
+        monkeypatch.setattr(sys, "stderr", buf)
+        monkeypatch.setattr(buf, "isatty", lambda: True)
+
+        with heartbeat(message="working...", delay=0.1, interval=0.1):
+            time.sleep(0.35)
+
+        buf.seek(0)
+        output = buf.read()
+        assert "working..." in output
+
+    def test_disabled_when_not_tty(self, monkeypatch):
+        """No output when stderr is not a TTY."""
+        buf = io.TextIOWrapper(io.BytesIO(), write_through=True)
+        monkeypatch.setattr(sys, "stderr", buf)
+        # isatty returns False by default for BytesIO-backed streams
+
+        with heartbeat(message="working...", delay=0.1, interval=0.1):
+            time.sleep(0.35)
+
+        buf.seek(0)
+        assert buf.read() == ""
+
+    def test_stops_on_exit(self, monkeypatch):
+        """Heartbeat stops printing after context exits."""
+        buf = io.TextIOWrapper(io.BytesIO(), write_through=True)
+        monkeypatch.setattr(sys, "stderr", buf)
+        monkeypatch.setattr(buf, "isatty", lambda: True)
+
+        with heartbeat(message="tick", delay=0.05, interval=0.05):
+            time.sleep(0.2)
+
+        buf.seek(0)
+        count_during = buf.read().count("tick")
+
+        # Sleep more after context exit — count should not grow
+        time.sleep(0.2)
+        buf.seek(0)
+        count_after = buf.read().count("tick")
+        assert count_after == count_during


### PR DESCRIPTION
## Summary
- Adds a `heartbeat()` context manager in `bubble/spinner.py` that prints periodic status messages to stderr during slow, silent operations
- Wraps image build script execution and tool installation in builder.py with heartbeat messages (e.g. `still building base image...`, `still installing tools...`)
- Automatically disabled when stderr is not a TTY (piped output, `--machine-readable`, CI)
- Does not add spinners to Colima start (already streams live output) or remote operations (already stream line-by-line)

## Test plan
- [x] `test_no_output_when_fast` — no message if operation finishes before delay
- [x] `test_prints_after_delay` — message appears after delay elapses
- [x] `test_disabled_when_not_tty` — no output when stderr is not a TTY
- [x] `test_stops_on_exit` — heartbeat stops when context exits
- [x] All 752 existing tests pass (1 pre-existing failure in unrelated network test)

Closes #145

🤖 Prepared with Claude Code