### PR TITLE
Show lifecycle hints after bubble creation

### DIFF
--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -92,7 +92,9 @@ def finalize_bubble(
     maybe_install_skill()
 
     click.echo(f"Bubble '{name}' created successfully.")
-    click.echo(f"  SSH: ssh bubble-{name}")
+    click.echo(f"  SSH:  ssh bubble-{name}")
+    click.echo("  List: bubble list")
+    click.echo(f"  Pop:  bubble pop {name}")
 
     if not no_interactive:
         echo_editor_opening(editor)


### PR DESCRIPTION
## Summary
- After creating a bubble, display `List:` and `Pop:` hints alongside the existing `SSH:` line
- Aligns column spacing so all three hints are visually consistent
- Shown on every creation (no state tracking needed — output is brief enough to not be noisy)

Closes #140

🤖 Prepared with Claude Code