### PR TITLE
Rename _wait_for_container to wait_for_container

### DIFF
--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -200,7 +200,7 @@ def _fix_dns_with_proxy(runtime: ContainerRuntime, name: str) -> bool:
         return False
 
 
-def _wait_for_container(runtime: ContainerRuntime, name: str, timeout: int = 60):
+def wait_for_container(runtime: ContainerRuntime, name: str, timeout: int = 60):
     """Wait for a container to be ready, including network (IPv4 + DNS).
 
     Handles systems where the firewall blocks bridge DHCP and/or DNS
@@ -501,7 +501,7 @@ def build_image(
         # Launch from parent
         runtime.launch(build_name, parent)
         try:
-            _wait_for_container(runtime, build_name)
+            wait_for_container(runtime, build_name)
 
             # Run setup script
             script = (SCRIPTS_DIR / spec["script"]).read_text()
@@ -600,7 +600,7 @@ def build_lean_toolchain_image(
 
         runtime.launch(build_name, base_lean_image)
         try:
-            _wait_for_container(runtime, build_name)
+            wait_for_container(runtime, build_name)
 
             script = (SCRIPTS_DIR / "lean-toolchain.sh").read_text()
             script = f"export LEAN_TOOLCHAIN='{version}'\n" + script

--- a/bubble/provisioning.py
+++ b/bubble/provisioning.py
@@ -52,10 +52,10 @@ def provision_container(
     click.echo(" done.")
 
     detail("Waiting for network...", nl=False)
-    from .images.builder import _wait_for_container
+    from .images.builder import wait_for_container
 
     try:
-        _wait_for_container(runtime, name)
+        wait_for_container(runtime, name)
         click.echo(" done.")
     except RuntimeError:
         click.echo(" timeout (continuing anyway).")

--- a/tests/test_build_lock.py
+++ b/tests/test_build_lock.py
@@ -15,7 +15,7 @@ def test_build_lock_prevents_concurrent_builds(mock_runtime, monkeypatch, tmp_da
     """A concurrent build_image call for the same image should skip if the first completes."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.config import load_config, save_config
 
@@ -110,7 +110,7 @@ def test_is_build_locked_true_when_held():
 
 def test_build_lean_toolchain_lock(mock_runtime, monkeypatch, tmp_data_dir):
     """Lean toolchain builds also use build locks."""
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.images.builder import build_lean_toolchain_image
 
@@ -247,14 +247,14 @@ def test_derived_build_holds_parent_lock(mock_runtime, monkeypatch, tmp_data_dir
     mock_runtime._images = {"base"}  # base exists, lean does not
 
     def build_lean():
-        monkeypatch.setattr("bubble.images.builder._wait_for_container", slow_derived_wait)
+        monkeypatch.setattr("bubble.images.builder.wait_for_container", slow_derived_wait)
         build_image(mock_runtime, "lean")
         order.append("lean-published")
 
     def rebuild_base():
         derived_building.wait(timeout=5)
         parent_started.set()
-        monkeypatch.setattr("bubble.images.builder._wait_for_container", slow_parent_wait)
+        monkeypatch.setattr("bubble.images.builder.wait_for_container", slow_parent_wait)
         # Delete old base to force rebuild
         mock_runtime._images.discard("base")
         build_image(mock_runtime, "base")
@@ -343,14 +343,14 @@ def test_grandchild_build_holds_ancestor_locks(mock_runtime, monkeypatch, tmp_da
     mock_runtime._images = {"base", "lean"}
 
     def build_grandchild():
-        monkeypatch.setattr("bubble.images.builder._wait_for_container", slow_derived_wait)
+        monkeypatch.setattr("bubble.images.builder.wait_for_container", slow_derived_wait)
         build_image(mock_runtime, "lean-extra")
         order.append("lean-extra-published")
 
     def rebuild_base():
         derived_building.wait(timeout=5)
         parent_started.set()
-        monkeypatch.setattr("bubble.images.builder._wait_for_container", slow_parent_wait)
+        monkeypatch.setattr("bubble.images.builder.wait_for_container", slow_parent_wait)
         mock_runtime._images.discard("base")
         build_image(mock_runtime, "base")
         order.append("base-published")

--- a/tests/test_customize.py
+++ b/tests/test_customize.py
@@ -32,7 +32,7 @@ def test_build_image_runs_customize_script(mock_runtime, monkeypatch, tmp_data_d
     """Building any image runs the customize script as the final step."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.config import load_config, save_config
 
@@ -57,7 +57,7 @@ def test_build_image_skips_customize_when_absent(mock_runtime, monkeypatch, tmp_
     """No customize exec when script doesn't exist."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.config import load_config, save_config
 
@@ -78,7 +78,7 @@ def test_customize_hash_file_written(mock_runtime, monkeypatch, tmp_data_dir):
     """Hash file is written after building with a customize script."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.config import load_config, save_config
 
@@ -102,7 +102,7 @@ def test_customize_hash_file_removed_when_no_script(mock_runtime, monkeypatch, t
     """Hash file is removed when customize script doesn't exist."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.config import load_config, save_config
 
@@ -123,7 +123,7 @@ def test_customize_hash_file_removed_when_no_script(mock_runtime, monkeypatch, t
 
 def test_build_lean_toolchain_runs_customize(mock_runtime, monkeypatch, tmp_data_dir):
     """Lean toolchain image build also runs the customize script."""
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     mock_runtime._images.add("lean")
 
@@ -141,7 +141,7 @@ def test_nonbase_image_runs_customize(mock_runtime, monkeypatch, tmp_data_dir):
     """Non-base images (e.g. lean) also run the customize script."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     mock_runtime._images.add("base")
 
@@ -163,7 +163,7 @@ def test_nonbase_image_does_not_write_hash(mock_runtime, monkeypatch, tmp_data_d
     """
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     mock_runtime._images.add("base")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -346,7 +346,7 @@ def test_build_image_installs_tools(mock_runtime, monkeypatch, tmp_data_dir):
     """Verify that building the base image runs tool install scripts."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.images.builder import build_image
 
@@ -366,7 +366,7 @@ def test_build_image_no_tools_when_none_enabled(mock_runtime, monkeypatch, tmp_d
     """Verify that no tool script runs when all tools resolve to skip."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     # Explicitly set all tools to "no" and editor to "shell" to skip everything
     from bubble.config import load_config, save_config
@@ -390,7 +390,7 @@ def test_build_nonbase_image_skips_tools(mock_runtime, monkeypatch, tmp_data_dir
     """Verify that non-base images don't install tools (they inherit from base)."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: True)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.images.builder import build_image
 
@@ -407,7 +407,7 @@ def test_tools_hash_file_written(mock_runtime, monkeypatch, tmp_data_dir):
     """Verify that the tools hash file is written after building base."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.images.builder import TOOLS_HASH_FILE, build_image
 
@@ -435,7 +435,7 @@ def test_build_base_purges_derived_images(mock_runtime, monkeypatch, tmp_data_di
     """Verify that building base with tools deletes all derived images recursively."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.images.builder import build_image
 
@@ -455,7 +455,7 @@ def test_build_base_purges_dynamic_toolchain_images(mock_runtime, monkeypatch, t
     """Verify that building base also purges dynamic toolchain images (lean-v4.x.y)."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder._wait_for_container", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
 
     from bubble.images.builder import build_image
 


### PR DESCRIPTION
This PR drops the underscore prefix from `_wait_for_container` in `builder.py` since `provisioning.py` imports it as public API. All call sites and test monkeypatches updated.

Fixes #129

🤖 Prepared with Claude Code