### PR TITLE
Dynamic column widths in bubble list output

### DIFF
--- a/bubble/commands/list_cmd.py
+++ b/bubble/commands/list_cmd.py
@@ -45,23 +45,29 @@ def _format_age(dt: "datetime | None") -> str:  # noqa: F821
     return f"{months}mo ago"
 
 
+def _char_width(ch: str) -> int:
+    """Return the display width of a single character."""
+    if unicodedata.combining(ch) or ch in ("\u200b", "\u200c", "\u200d", "\ufe0f", "\ufe0e"):
+        return 0
+    cat = unicodedata.east_asian_width(ch)
+    return 2 if cat in ("W", "F") else 1
+
+
 def _display_width(s: str) -> int:
     """Return the display width of *s*, counting wide Unicode chars as 2."""
-    w = 0
-    for ch in s:
-        cat = unicodedata.east_asian_width(ch)
-        w += 2 if cat in ("W", "F") else 1
-    return w
+    return sum(_char_width(ch) for ch in s)
 
 
 def _truncate(s: str, max_width: int) -> str:
     """Truncate *s* to *max_width* display columns, adding ``...`` if needed."""
     if _display_width(s) <= max_width:
         return s
+    if max_width <= 3:
+        return "." * max_width
     result: list[str] = []
     w = 0
     for ch in s:
-        cw = 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+        cw = _char_width(ch)
         if w + cw + 3 > max_width:  # leave room for "..."
             break
         result.append(ch)
@@ -386,17 +392,21 @@ def register_list_command(main):
         DISK_W = 10
         IPV4_W = 16
 
-        # Clamp name column if total exceeds terminal width
+        # Clamp dynamic columns if total exceeds terminal width
         term_w = shutil.get_terminal_size((80, 24)).columns
         fixed = STATE_W + 2 * TIME_W + 3  # separating spaces
         if show_location:
-            fixed += loc_w + 1
+            fixed += 1  # space before LOCATION (loc_w added separately)
         if verbose:
             fixed += DISK_W + IPV4_W + 2
         if show_clean:
             fixed += 8  # rough allowance for STATUS
-        if name_w + fixed > term_w:
-            name_w = max(len("NAME"), term_w - fixed)
+        avail = term_w - fixed
+        if name_w + loc_w > avail:
+            # Shrink name first, then location if needed
+            name_w = max(len("NAME"), avail - loc_w)
+            if name_w + loc_w > avail:
+                loc_w = max(len("LOCATION") if show_location else 0, avail - name_w)
 
         # Truncate values to their column widths
         names = [_truncate(e["name"], name_w) for e in entries]

--- a/tests/test_list_columns.py
+++ b/tests/test_list_columns.py
@@ -17,6 +17,18 @@ class TestDisplayWidth:
     def test_mixed(self):
         assert _display_width("hi\u4e16") == 4  # 2 + 2
 
+    def test_combining_marks(self):
+        # e + combining acute accent renders as 1 cell
+        assert _display_width("e\u0301") == 1
+
+    def test_zwj_sequence(self):
+        # ZWJ characters should be zero-width
+        assert _display_width("\u200d") == 0
+
+    def test_variation_selectors(self):
+        # Variation selectors (U+FE0E, U+FE0F) are zero-width
+        assert _display_width("\u2603\ufe0f") == 1  # snowman + VS16
+
 
 class TestTruncate:
     def test_short_string_unchanged(self):
@@ -36,10 +48,23 @@ class TestTruncate:
         assert _display_width(result) <= 5
         assert result.endswith("...")
 
-    def test_max_width_less_than_four(self):
-        # With max_width=3, can only fit "..."
+    def test_max_width_3(self):
         result = _truncate("abcdef", 3)
         assert result == "..."
+        assert _display_width(result) == 3
+
+    def test_max_width_2(self):
+        result = _truncate("abcdef", 2)
+        assert result == ".."
+        assert _display_width(result) == 2
+
+    def test_max_width_1(self):
+        result = _truncate("abcdef", 1)
+        assert result == "."
+
+    def test_max_width_0(self):
+        result = _truncate("abcdef", 0)
+        assert result == ""
 
 
 class TestPad:


### PR DESCRIPTION
This PR makes the `name` and `location` columns in `bubble list` adaptive instead of hardcoded, so long container names no longer break alignment.

- `name` column: dynamic width capped at 50 chars, truncated with `...` beyond that
- `location` column: dynamic width capped at 30 chars, same truncation
- Fixed-width columns (`state`, `age`) remain stable
- Total width clamped to terminal via `shutil.get_terminal_size()`
- Uses Unicode display width (`unicodedata.east_asian_width`) for correct wide-char handling

`bubble list --json` is unaffected.

Closes #146

🤖 Prepared with Claude Code