### PR TITLE
Use shlex.quote() for shell-interpolated env vars in builder.py

### DIFF
--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl
 import hashlib
 import re
+import shlex
 import subprocess
 import time
 from contextlib import ExitStack, contextmanager
@@ -409,7 +410,7 @@ def _install_tools_if_base(
         # Inject VS Code commit hash for the vscode tool script
         vscode_commit = get_vscode_commit()
         if vscode_commit and "vscode" in enabled:
-            script = f"export VSCODE_COMMIT='{vscode_commit}'\n" + script
+            script = f"export VSCODE_COMMIT={shlex.quote(vscode_commit)}\n" + script
         print(f"  Installing tools: {', '.join(enabled)}")
         with heartbeat("  still installing tools..."):
             runtime.exec(build_name, ["bash", "-c", script])
@@ -603,7 +604,7 @@ def build_lean_toolchain_image(
             _wait_for_container(runtime, build_name)
 
             script = (SCRIPTS_DIR / "lean-toolchain.sh").read_text()
-            script = f"export LEAN_TOOLCHAIN='{version}'\n" + script
+            script = f"export LEAN_TOOLCHAIN={shlex.quote(version)}\n" + script
             with heartbeat(f"  still building {alias} image..."):
                 runtime.exec(build_name, ["bash", "-c", script])
 


### PR DESCRIPTION
This PR replaces manual single-quoting with `shlex.quote()` for the `VSCODE_COMMIT` and `LEAN_TOOLCHAIN` shell variable exports in `builder.py`. The `VSCODE_COMMIT` case is the more important fix since it comes from external `code --version` output with no validation regex. The `LEAN_TOOLCHAIN` case is defense-in-depth (the regex in `lean.py` already prevents injection).

Fixes #138

🤖 Prepared with Claude Code