### PR TITLE
Validate version parameter in build_lean_toolchain_image()

### DIFF
--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -549,6 +549,9 @@ def build_image(
         print(f"{image_name} image built successfully.")
 
 
+_LEAN_VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+(-rc\d+)?$")
+
+
 def build_lean_toolchain_image(
     runtime: ContainerRuntime,
     version: str,
@@ -561,6 +564,9 @@ def build_lean_toolchain_image(
     Launches from the base lean image and installs one specific toolchain.
     With ``force=True``, deletes and rebuilds even if the image exists.
     """
+    if not _LEAN_VERSION_RE.fullmatch(version):
+        raise ValueError(f"Invalid Lean toolchain version: {version!r}")
+
     # Ensure base lean image exists
     if not runtime.image_exists(base_lean_image):
         if base_lean_image in IMAGES:

--- a/tests/test_build_lock.py
+++ b/tests/test_build_lock.py
@@ -3,10 +3,13 @@
 import threading
 import time
 
+import pytest
+
 from bubble.images.builder import (
     _ancestor_chain,
     _build_lock,
     build_image,
+    build_lean_toolchain_image,
     is_build_locked,
 )
 
@@ -108,11 +111,37 @@ def test_is_build_locked_true_when_held():
     t.join(timeout=5)
 
 
+def test_build_lean_toolchain_rejects_invalid_version(mock_runtime):
+    """build_lean_toolchain_image rejects versions that don't match the expected pattern."""
+    for bad in [
+        "nightly-2024-01-01",
+        "v4.16.0; rm -rf /",
+        "../../../etc/passwd",
+        "leanprover/lean4:v4.16.0",
+        "v4",
+        "v4.16",
+        "",
+        "hello",
+    ]:
+        with pytest.raises(ValueError, match="Invalid Lean toolchain version"):
+            build_lean_toolchain_image(mock_runtime, bad)
+
+
+def test_build_lean_toolchain_accepts_valid_version(mock_runtime, monkeypatch, tmp_data_dir):
+    """build_lean_toolchain_image accepts stable and RC versions."""
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
+    mock_runtime._images.add("lean")
+
+    build_lean_toolchain_image(mock_runtime, "v4.16.0")
+    assert mock_runtime.image_exists("lean-v4.16.0")
+
+    build_lean_toolchain_image(mock_runtime, "v4.16.0-rc2")
+    assert mock_runtime.image_exists("lean-v4.16.0-rc2")
+
+
 def test_build_lean_toolchain_lock(mock_runtime, monkeypatch, tmp_data_dir):
     """Lean toolchain builds also use build locks."""
     monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
-
-    from bubble.images.builder import build_lean_toolchain_image
 
     mock_runtime._images.add("lean")
 


### PR DESCRIPTION
This PR adds input validation at the `build_lean_toolchain_image()` function boundary, rejecting versions that don't match the `v\d+\.\d+\.\d+(-rc\d+)?` pattern. Previously, callers were trusted to pass safe values, but the function itself had no guard.

- Adds `_LEAN_VERSION_RE` compiled regex and a `ValueError` check at the top of `build_lean_toolchain_image()`
- Adds tests for both rejection of invalid versions and acceptance of valid ones

Closes #185

🤖 Prepared with Claude Code