### PR TITLE
Remove remaining test-only dead code

### DIFF
--- a/bubble/config.py
+++ b/bubble/config.py
@@ -286,11 +286,6 @@ def claude_config_mounts(include_credentials: bool = True) -> list[MountSpec]:
     return CLAUDE_CONFIG.config_mounts(include_credentials)
 
 
-def has_claude_credentials() -> bool:
-    """Check if the host has Claude credential files."""
-    return CLAUDE_CONFIG.has_credentials()
-
-
 # Editor config directories to mount into containers.
 # Config is read-only; data/state directories are mounted read-write so
 # plugin managers and caches can function.
@@ -437,11 +432,6 @@ CODEX_CONFIG = SafeConfigDir(
 def codex_config_mounts(include_credentials: bool = True) -> list[MountSpec]:
     """Return read-only mounts for Codex config files that exist on the host."""
     return CODEX_CONFIG.config_mounts(include_credentials)
-
-
-def has_codex_credentials() -> bool:
-    """Check if the host has Codex credential files."""
-    return CODEX_CONFIG.has_credentials()
 
 
 CLAUDE_PROJECTS_DIR = DATA_DIR / "claude-projects"

--- a/bubble/notices.py
+++ b/bubble/notices.py
@@ -46,11 +46,6 @@ class Notices:
     def __init__(self):
         self._printed = False
 
-    @property
-    def has_output(self) -> bool:
-        """Whether any notice group has been started."""
-        return self._printed
-
     def begin(self):
         """Start a new notice group, printing a separator if needed."""
         if self._printed:

--- a/bubble/tools.py
+++ b/bubble/tools.py
@@ -189,16 +189,6 @@ def tool_script(name: str) -> str:
     return preamble + "\n" + script
 
 
-def tool_network_domains(enabled_tools: list[str]) -> list[str]:
-    """Return extra network domains needed to install the given tools."""
-    domains = []
-    for name in enabled_tools:
-        for d in TOOLS[name].get("network_domains", []):
-            if d not in domains:
-                domains.append(d)
-    return domains
-
-
 def tool_runtime_domains(enabled_tools: list[str]) -> list[str]:
     """Return network domains needed at runtime by the given tools.
 

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -9,8 +9,6 @@ from bubble.config import (
     claude_config_mounts,
     codex_config_mounts,
     editor_config_mounts,
-    has_claude_credentials,
-    has_codex_credentials,
     parse_mounts,
 )
 
@@ -460,17 +458,6 @@ class TestClaudeConfigMounts:
 
         assert mounts == []
 
-    def test_has_claude_credentials(self, tmp_path, monkeypatch):
-        """has_claude_credentials() detects credential files."""
-        claude_dir = tmp_path / ".claude"
-        claude_dir.mkdir()
-        monkeypatch.setattr("bubble.config.CLAUDE_CONFIG.base_dir", claude_dir)
-
-        assert not has_claude_credentials()
-
-        (claude_dir / ".credentials.json").write_text("{}")
-        assert has_claude_credentials()
-
     def test_rejects_symlinks_escaping_claude_dir(self, tmp_path, monkeypatch):
         """Symlinks that escape ~/.claude are rejected."""
         claude_dir = tmp_path / ".claude"
@@ -794,17 +781,6 @@ class TestCodexConfigMounts:
         mounts = codex_config_mounts(include_credentials=False)
 
         assert mounts == []
-
-    def test_has_codex_credentials(self, tmp_path, monkeypatch):
-        """has_codex_credentials() detects credential files."""
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        monkeypatch.setattr("bubble.config.CODEX_CONFIG.base_dir", codex_dir)
-
-        assert not has_codex_credentials()
-
-        (codex_dir / "auth.json").write_text("{}")
-        assert has_codex_credentials()
 
     def test_rejects_symlinks_escaping_codex_dir(self, tmp_path, monkeypatch):
         """Symlinks that escape ~/.codex are rejected."""

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -10,7 +10,6 @@ def test_notices_first_begin_no_separator(capsys):
     n.begin()
     captured = capsys.readouterr()
     assert captured.err == ""
-    assert n.has_output is True
 
 
 def test_notices_second_begin_prints_separator(capsys):
@@ -36,11 +35,6 @@ def test_notices_finish_no_output(capsys):
     n.finish()
     captured = capsys.readouterr()
     assert captured.err == ""
-
-
-def test_notices_has_output_initially_false():
-    n = Notices()
-    assert n.has_output is False
 
 
 def test_notices_multiple_groups(capsys):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,7 +7,6 @@ from bubble.tools import (
     combined_tool_script,
     load_pins,
     resolve_tools,
-    tool_network_domains,
     tool_runtime_domains,
     tool_script,
     tools_hash,
@@ -120,29 +119,6 @@ def test_tool_script_reads_file():
     script = tool_script("claude")
     assert "claude" in script.lower()
     assert "#!/bin/bash" in script
-
-
-def test_tool_network_domains():
-    domains = tool_network_domains(["claude"])
-    assert "registry.npmjs.org" in domains
-
-
-def test_tool_network_domains_combined():
-    domains = tool_network_domains(["claude", "codex"])
-    assert "registry.npmjs.org" in domains
-    assert "nodejs.org" in domains
-
-
-def test_tool_network_domains_no_duplicates():
-    domains = tool_network_domains(["claude", "codex"])
-    assert domains.count("registry.npmjs.org") == 1
-
-
-def test_tool_network_domains_nodejs_org():
-    """Node.js tools should use nodejs.org for official tarball downloads."""
-    domains = tool_network_domains(["claude"])
-    assert "nodejs.org" in domains
-    assert "deb.nodesource.com" not in domains
 
 
 def test_tool_runtime_domains():


### PR DESCRIPTION
This PR removes four functions that had no production callers and existed only to be tested:

- `tool_network_domains()` from `tools.py` (counterpart `tool_runtime_domains()` is used in production; this one is not)
- `has_claude_credentials()` and `has_codex_credentials()` from `config.py` (thin wrappers around `SafeConfigDir.has_credentials()` which is kept)
- `Notices.has_output` property from `notices.py` (never checked outside tests)

Also removes all corresponding tests (4 `tool_network_domains` tests, 2 `has_*_credentials` tests, 2 `has_output` assertions).

Closes #196

🤖 Prepared with Claude Code