### PR TITLE
Fix auth proxy daemon startup and container connectivity

### DIFF
--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -987,18 +987,22 @@ def _get_github_token() -> str:
     return token
 
 
-def run_daemon():
+def run_daemon(port: int = 0):
     """Run the auth proxy daemon.
 
     Listens on TCP (both macOS and Linux — HTTP needs TCP).
+
+    Args:
+        port: Port to listen on. 0 means use config or default.
     """
     _setup_logging()
     DATA_DIR.mkdir(parents=True, exist_ok=True)
 
-    from .config import load_config
+    if not port:
+        from .config import load_config
 
-    config = load_config()
-    port = config.get("auth_proxy", {}).get("port", DEFAULT_PORT)
+        config = load_config()
+        port = config.get("auth_proxy", {}).get("port", DEFAULT_PORT)
 
     # Get GitHub token
     github_token = _get_github_token()

--- a/bubble/automation.py
+++ b/bubble/automation.py
@@ -6,6 +6,7 @@ Supports:
 - Fallback: cron jobs
 """
 
+import os
 import platform
 import plistlib
 import subprocess
@@ -123,6 +124,8 @@ def _write_launchd_plist(label: str, job: dict) -> str:
         "ProgramArguments": [bubble] + job["args"],
         "StandardOutPath": job["log"],
         "StandardErrorPath": job["log"],
+        # Inherit the current PATH so that tools like gh are discoverable.
+        "EnvironmentVariables": {"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
     }
     plist.update(job["extra"])
 

--- a/bubble/github_token.py
+++ b/bubble/github_token.py
@@ -236,8 +236,8 @@ def _setup_gh_proxy(
             connect=connect_addr,
             listen=f"unix:{_CONTAINER_GH_SOCKET}",
             bind="container",
-            uid="1000",
-            gid="1000",
+            uid="1001",
+            gid="1001",
             mode="0660",
         )
     except Exception as e:
@@ -404,8 +404,8 @@ def _setup_gh_proxy_remote(
                 f"connect={connect_addr}",
                 f"listen=unix:{_CONTAINER_GH_SOCKET}",
                 "bind=container",
-                "uid=1000",
-                "gid=1000",
+                "uid=1001",
+                "gid=1001",
                 "mode=0660",
             ],
             timeout=15,

--- a/bubble/images/scripts/tools/gh.sh
+++ b/bubble/images/scripts/tools/gh.sh
@@ -22,6 +22,7 @@ apt-get install -y -qq gh
 # GH_CONFIG_DIR is set at container creation time (not image build time)
 # because the auth token is per-container.
 mkdir -p /etc/bubble/gh
+chown 1001:1001 /etc/bubble/gh
 
 # Pre-populate config.yml with http_unix_socket pointing to the
 # auth proxy socket exposed by Incus proxy device.


### PR DESCRIPTION
## Summary
- Fix `run_daemon()` missing `port` parameter (caused `TypeError` on every daemon start)
- Add PATH to launchd plist so `gh auth token` can find `gh` in `/opt/homebrew/bin/`
- Fix UID mismatch: socket device and gh config dir used UID 1000 (ubuntu) instead of 1001 (user)

## Test plan
- [x] All 936 tests pass
- [x] Verified auth proxy starts and serves requests (HTTP 401 on unauthenticated)
- [x] Verified `gh api repos/kim-em/bubble` works inside a bubble
- [x] Verified `gh pr checks` works inside a bubble
- [x] Verified GraphQL queries work inside a bubble

🤖 Prepared with Claude Code