### PR TITLE
Add trailing newline to auth proxy error responses

### DIFF
--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -596,7 +596,7 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
         """Send a plain-text error response."""
         self.send_response(code)
         self.send_header("Content-Type", "text/plain")
-        body = message.encode("utf-8")
+        body = (message + "\n").encode("utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)


### PR DESCRIPTION
## Summary
- Add `\n` to error response bodies so `gh` CLI doesn't concatenate its error on the same line
- Before: `Repository mismatch: foo/bar != baz/quxgh: HTTP 403`
- After: `Repository mismatch: foo/bar != baz/qux` (newline) `gh: HTTP 403`

🤖 Prepared with Claude Code