### PR TITLE
Rename HETZNER_TOKEN to HCLOUD_TOKEN

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -114,7 +114,7 @@ Bubbles can run on a remote machine instead of locally. The `--ssh HOST` flag (o
 
 **Priority chain for remote host resolution:** `--local` > `--ssh HOST` > `--cloud` > `[cloud] default` > `[remote] default_host`
 
-**State:** `~/.bubble/cloud.json` tracks server ID, IP, SSH key ID. Token comes from `HETZNER_TOKEN` env var (never stored).
+**State:** `~/.bubble/cloud.json` tracks server ID, IP, SSH key ID. Token comes from `HCLOUD_TOKEN` env var (never stored).
 
 ### User Customization Script
 Users can place a `customize.sh` script at `~/.bubble/customize.sh` to run custom setup in all container images. The script runs as root as the final step when building any image (base, lean, lean-v4.X.Y). This lets users add tools, dotfiles, shell config, etc. without forking image scripts. The script's content hash is tracked in `~/.bubble/customize-hash`; on `bubble open`, if the hash differs from the stored value, a background rebuild of the base image is triggered (same pattern as VS Code commit hash drift). Code is in `builder.py` (`customize_hash()`, `_run_customize_script()`).

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Run bubbles on auto-provisioned Hetzner Cloud servers. The server shuts down aut
 2. Go to your project → Security → API Tokens → Generate API Token (read/write)
 3. Set the token in your environment:
    ```bash
-   export HETZNER_TOKEN="your-token-here"
+   export HCLOUD_TOKEN="your-token-here"
    ```
 4. Install the cloud dependency:
    ```bash
@@ -327,7 +327,7 @@ location = "fsn1"            # datacenter: fsn1, nbg1, hel1, ash, hil
 idle_timeout = 900           # seconds before idle shutdown (default: 900 = 15min)
 ```
 
-The `HETZNER_TOKEN` environment variable is always required — the token is never stored on disk.
+The `HCLOUD_TOKEN` environment variable is always required — the token is never stored on disk.
 
 ## Bubble-in-Bubble
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -777,7 +777,7 @@ entry has a `remote_host` field. The command is forwarded via
 
 ### 8.1 Requirements
 
-- `HETZNER_TOKEN` environment variable (never stored)
+- `HCLOUD_TOKEN` environment variable (never stored)
 - `hcloud` Python package (optional dependency)
 
 ### 8.2 Commands

--- a/bubble/cloud.py
+++ b/bubble/cloud.py
@@ -115,10 +115,10 @@ def _clear_state():
 
 def _get_token() -> str:
     """Get Hetzner API token from environment."""
-    token = os.environ.get("HETZNER_TOKEN", "")
+    token = os.environ.get("HCLOUD_TOKEN", "")
     if not token:
         raise click.ClickException(
-            "HETZNER_TOKEN environment variable is required.\n"
+            "HCLOUD_TOKEN environment variable is required.\n"
             "Get one from: https://console.hetzner.cloud/projects → API tokens"
         )
     return token


### PR DESCRIPTION
## Summary
- Rename `HETZNER_TOKEN` env var to `HCLOUD_TOKEN` for consistency with the `hcloud` CLI
- Update code, README, SPEC, and CLAUDE.md references

Closes #217

🤖 Prepared with Claude Code