### PR TITLE
Fix gh config.yml ownership in container images

### DIFF
--- a/bubble/images/scripts/tools/gh.sh
+++ b/bubble/images/scripts/tools/gh.sh
@@ -29,5 +29,6 @@ chown 1001:1001 /etc/bubble/gh
 cat > /etc/bubble/gh/config.yml <<'GHCONF'
 http_unix_socket: /bubble/gh-proxy.sock
 GHCONF
+chown 1001:1001 /etc/bubble/gh/config.yml
 
 echo "gh installed: $(gh --version 2>/dev/null | head -1 || echo 'unknown version')"


### PR DESCRIPTION
This PR chowns `/etc/bubble/gh/config.yml` to 1001:1001 after creation in `gh.sh`, matching the directory ownership. Without this, `gh` fails on config migration because the file is owned by root while the container user is uid 1001.

Fixes #225

🤖 Prepared with Claude Code