### PR TITLE
Add OAuth auth domains to Codex network allowlist

### DIFF
--- a/bubble/tools.py
+++ b/bubble/tools.py
@@ -33,7 +33,12 @@ TOOLS = {
         "script": "codex.sh",
         "host_cmd": "codex",
         "network_domains": ["registry.npmjs.org", "nodejs.org"],
-        "runtime_domains": ["api.openai.com"],
+        "runtime_domains": [
+            "api.openai.com",
+            "auth0.openai.com",
+            "auth.openai.com",
+            "chatgpt.com",
+        ],
         "priority": 50,
     },
     "elan": {


### PR DESCRIPTION
This PR adds the missing OAuth/backend domains to the Codex tool's `runtime_domains` in `bubble/tools.py`. Without these, Codex with ChatGPT OAuth auth hangs inside network-allowlisted bubbles because token refresh and API calls are blocked.

**Domains added** (verified from [Codex source code](https://github.com/openai/codex)):
- `auth.openai.com` — OAuth issuer (`DEFAULT_ISSUER`) and token refresh endpoint (`REFRESH_TOKEN_URL`) in `codex-rs/core/src/auth.rs`
- `auth0.openai.com` — Actual token endpoint per OIDC discovery at `auth.openai.com/.well-known/openid-configuration`
- `chatgpt.com` — Backend API (`chatgpt_base_url` defaults to `chatgpt.com/backend-api/`) used for model listing and response generation in ChatGPT auth mode

Users with `OPENAI_API_KEY` (API key auth) are unaffected since they only need `api.openai.com`.

Fixes #233

🤖 Prepared with Claude Code