### PR TITLE
Fix gh CLI failing to resolve repos inside bubbles

### DIFF
--- a/bubble/images/scripts/tools/gh.sh
+++ b/bubble/images/scripts/tools/gh.sh
@@ -31,4 +31,14 @@ http_unix_socket: /bubble/gh-proxy.sock
 GHCONF
 chown 1001:1001 /etc/bubble/gh/config.yml
 
+# Tell gh that github.com is a known host.  Without this, overriding
+# GH_CONFIG_DIR wipes the default host list and gh can't resolve repos
+# from git remotes ("none of the git remotes ... point to a known GitHub
+# host").  GH_TOKEN handles auth; this just registers the host.
+cat > /etc/bubble/gh/hosts.yml <<'GHHOSTS'
+github.com:
+  git_protocol: https
+GHHOSTS
+chown 1001:1001 /etc/bubble/gh/hosts.yml
+
 echo "gh installed: $(gh --version 2>/dev/null | head -1 || echo 'unknown version')"


### PR DESCRIPTION
## Summary
- Add `hosts.yml` to the bubble-managed gh config directory (`/etc/bubble/gh/`) so gh recognizes `github.com` as a known host
- Without this, overriding `GH_CONFIG_DIR` wipes the default host list and `gh issue view`, `gh pr view`, etc. fail with "none of the git remotes configured for this repository point to a known GitHub host"
- `GH_TOKEN` handles auth; `hosts.yml` just registers the host for remote URL matching

🤖 Prepared with Claude Code