### PR TITLE
Fix cleanup falsely reporting extra files for build.log and bin/

### DIFF
--- a/bubble/clean.py
+++ b/bubble/clean.py
@@ -70,7 +70,9 @@ REASONS=""
 EXPECTED=$(echo {q_repo} | tr '[:upper:]' '[:lower:]')
 
 # Check 1: no unexpected non-hidden items in home
-ITEMS=$(ls /home/user/ 2>/dev/null || true)
+# Filter out known infrastructure files (build.log from background builds,
+# bin/ from tool installation)
+ITEMS=$(ls /home/user/ 2>/dev/null | grep -v -x -e 'build.log' -e 'bin' || true)
 if [ -n "$EXPECTED" ]; then
   if [ "$(echo "$ITEMS" | tr '[:upper:]' '[:lower:]')" != "$EXPECTED" ]; then
     CLEAN=false


### PR DESCRIPTION
This PR filters out known infrastructure files (`build.log` from background Lean toolchain builds, `bin/` from tool installation) when checking for unexpected files in container home directories. These were causing every container to report "extra files in home" in `bubble list -c` / `bubble cleanup`.

🤖 Prepared with Claude Code