### PR TITLE
fix: pass user PATH to systemd services so gh CLI is discoverable

### DIFF
--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -1234,23 +1234,45 @@ def _get_github_token() -> str:
     the stored access token has expired, then reads the (now-current)
     token via ``gh auth token``.
     """
+    import shutil
     import subprocess
+
+    gh_path = shutil.which("gh")
+    if not gh_path:
+        raise RuntimeError(
+            "Cannot find 'gh' CLI on PATH. Install gh (https://cli.github.com) "
+            "and ensure it is on your PATH.\n"
+            f"Current PATH: {os.environ.get('PATH', '(not set)')}"
+        )
 
     # Trigger OAuth refresh (gh auth token alone returns the stale token)
     try:
         subprocess.run(
-            ["gh", "auth", "status"],
+            [gh_path, "auth", "status"],
             capture_output=True,
             timeout=15,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except subprocess.TimeoutExpired:
         pass  # Best-effort; get_host_gh_token may still succeed
 
     from .github_token import get_host_gh_token
 
     token = get_host_gh_token()
     if not token:
-        raise RuntimeError("No GitHub token available. Run 'gh auth login' first.")
+        # Try to get more diagnostic info
+        try:
+            result = subprocess.run(
+                [gh_path, "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            detail_msg = f"gh auth token exited {result.returncode}"
+            if result.stderr.strip():
+                detail_msg += f": {result.stderr.strip()}"
+        except Exception as e:
+            detail_msg = f"gh auth token failed: {e}"
+        raise RuntimeError(f"No GitHub token available. {detail_msg}\nRun 'gh auth login' first.")
     return token
 
 

--- a/bubble/automation.py
+++ b/bubble/automation.py
@@ -66,6 +66,22 @@ def _bubble_path() -> str:
     return path if path else "bubble"
 
 
+def _systemd_path_env() -> str:
+    """Return an Environment=PATH=... line for systemd service files.
+
+    Captures the user's current PATH so that tools like gh, incus, etc.
+    are discoverable when the service runs under systemd (which provides
+    only a minimal default PATH).
+
+    Escapes '%' as '%%' since systemd treats '%' as a specifier prefix
+    in unit files (e.g., %h = home directory).
+    """
+    path = os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")
+    # Escape % for systemd specifier syntax
+    path = path.replace("%", "%%")
+    return f"Environment=PATH={path}"
+
+
 # ---------------------------------------------------------------------------
 # macOS: launchd
 # ---------------------------------------------------------------------------
@@ -199,6 +215,7 @@ def _install_systemd() -> list[str]:
         [Service]
         Type=oneshot
         ExecStart={bubble} git update
+        {_systemd_path_env()}
     """)
     )
 
@@ -229,6 +246,7 @@ def _install_systemd() -> list[str]:
         [Service]
         Type=oneshot
         ExecStart={bubble} images build base
+        {_systemd_path_env()}
     """)
     )
 
@@ -342,6 +360,7 @@ def _install_relay_systemd() -> str:
         ExecStart={bubble} relay daemon
         Restart=always
         RestartSec=5
+        {_systemd_path_env()}
 
         [Install]
         WantedBy=default.target
@@ -432,6 +451,7 @@ def _install_auth_proxy_systemd() -> str:
         ExecStart={bubble} gh proxy daemon
         Restart=always
         RestartSec=5
+        {_systemd_path_env()}
 
         [Install]
         WantedBy=default.target

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1256,7 +1256,7 @@ class TestEditorConfigMounts:
         config = {"security": {"editor_data_write": "on"}}
         mounts = editor_config_mounts("neovim", config)
         assert len(mounts) == 2
-        assert mounts[0].readonly is True   # config
+        assert mounts[0].readonly is True  # config
         assert mounts[1].readonly is False  # data dir writable when on
 
     def test_skips_missing_data_dirs(self, tmp_path, monkeypatch):

--- a/tests/test_systemd_path.py
+++ b/tests/test_systemd_path.py
@@ -1,0 +1,26 @@
+"""Tests for systemd PATH environment injection."""
+
+from unittest.mock import patch
+
+from bubble.automation import _systemd_path_env
+
+
+def test_systemd_path_env_uses_current_path():
+    """PATH from the current environment is captured."""
+    with patch.dict("os.environ", {"PATH": "/usr/local/bin:/usr/bin:/bin"}):
+        result = _systemd_path_env()
+        assert result == "Environment=PATH=/usr/local/bin:/usr/bin:/bin"
+
+
+def test_systemd_path_env_escapes_percent():
+    """Percent signs are escaped for systemd specifier syntax."""
+    with patch.dict("os.environ", {"PATH": "/home/user/%n/bin:/usr/bin"}):
+        result = _systemd_path_env()
+        assert result == "Environment=PATH=/home/user/%%n/bin:/usr/bin"
+
+
+def test_systemd_path_env_fallback():
+    """Falls back to sensible default when PATH is unset."""
+    with patch.dict("os.environ", {}, clear=True):
+        result = _systemd_path_env()
+        assert result == "Environment=PATH=/usr/local/bin:/usr/bin:/bin"


### PR DESCRIPTION
## Summary

- Systemd user services now capture the installer's PATH (with `%` escaped as `%%`), matching what the macOS launchd plist already does. This fixes the auth proxy daemon failing to find `gh` on Linux.
- Improved error reporting in `_get_github_token()` to distinguish "gh not found on PATH" from "gh returned an error", with diagnostic details.
- Added tests for the PATH escaping logic.

Fixes #258

🤖 Prepared with Claude Code