### PR TITLE
fix: prevent double 'open' prepend when -b flag is present

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -114,18 +114,19 @@ class BubbleGroup(click.Group):
         formatter.write("  For all target options run: bubble open --help\n")
 
     def parse_args(self, ctx, args):
-        """If no known command is found as the first positional arg, prepend 'open'.
+        """If no known command is found as the first arg, prepend 'open'.
 
         This supports both `bubble TARGET` and `bubble --ssh HOST TARGET`.
-        Only the first non-option token is checked, so that targets like
-        `list` or `pause` in later positions don't hijack routing.
+        We check args[0] (not the first non-option token) to avoid
+        misidentifying option values like `-b list` as the `list` command.
         Also handles `bubble -b branch_name` (options only, no target).
         """
         first_positional = next((a for a in args if not a.startswith("-")), None)
         has_branch_flag = "-b" in args or "--new-branch" in args
-        if args and (
-            (first_positional is not None and first_positional not in self.commands)
-            or has_branch_flag
+        if (
+            args
+            and args[0] not in self.commands
+            and (first_positional is not None or has_branch_flag)
         ):
             args = ["open"] + args
         return super().parse_args(ctx, args)

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1256,7 +1256,7 @@ class TestEditorConfigMounts:
         config = {"security": {"editor_data_write": "on"}}
         mounts = editor_config_mounts("neovim", config)
         assert len(mounts) == 2
-        assert mounts[0].readonly is True   # config
+        assert mounts[0].readonly is True  # config
         assert mounts[1].readonly is False  # data dir writable when on
 
     def test_skips_missing_data_dirs(self, tmp_path, monkeypatch):

--- a/tests/test_multi_target.py
+++ b/tests/test_multi_target.py
@@ -27,3 +27,29 @@ def test_single_target_allows_name():
     result = runner.invoke(main, ["open", "--name", "foo", "target1"])
     # It may fail for other reasons (no runtime), but NOT the multi-target error
     assert "--name cannot be used with multiple targets" not in (result.output or "")
+
+
+def test_explicit_open_with_branch_not_doubled():
+    """When 'open' is already in args, -b should not cause 'open' to be prepended again.
+
+    Regression test for https://github.com/kim-em/bubble/issues/259:
+    `bubble --ssh chonk -b branch leanprover/lean4` failed on the remote side
+    because parse_args prepended 'open' even when 'open' was already present,
+    resulting in 'open' being treated as a target.
+    """
+    runner = CliRunner()
+    result = runner.invoke(main, ["open", "-b", "my-branch", "target1"])
+    # Should NOT produce the multi-target error (only one target)
+    assert "--new-branch cannot be used with multiple targets" not in (result.output or "")
+
+
+def test_branch_value_matching_command_name():
+    """A -b value that matches a command name (e.g. 'list') should not hijack routing.
+
+    Regression test: `bubble -b list target1` should route to `open`, not `list`.
+    """
+    runner = CliRunner()
+    result = runner.invoke(main, ["-b", "list", "target1"])
+    # The `list` command doesn't have -b, so if routing went wrong we'd see
+    # "No such option: -b". Instead we should get routed to `open`.
+    assert "No such option" not in (result.output or "")


### PR DESCRIPTION
Fixes #259.

`BubbleGroup.parse_args()` used the first non-option token to decide whether to prepend `open`. When `remote_open()` already included `open` in the args, the `-b` flag caused `parse_args` to prepend it again, resulting in `['open', 'open', ...]` where the second `open` was treated as a target — triggering the spurious "multiple targets" error.

Fix: check `args[0]` directly instead of the first non-option token. This avoids both the double-prepend issue and an edge case where option values matching command names (e.g. `-b list`) could hijack routing.

🤖 Prepared with Claude Code