### PR TITLE
fix: pass --command string verbatim to ssh, no host-side splitting

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -251,7 +251,10 @@ forwarding doesn't work reliably through Colima on macOS.
 | `neovim` | `ssh bubble-<name> -t "cd /home/user/<repo> && nvim ."` |
 | `shell` | `ssh bubble-<name>` |
 
-For `--command CMD`: `ssh bubble-<name> <cmd args...>`
+For `--command CMD`: `ssh bubble-<name> <CMD>` — the `CMD` string is passed
+to ssh as a single argument, so it is parsed by the remote shell exactly
+as if typed after `ssh bubble-<name>` interactively. Quoting is preserved
+verbatim; no host-side `shlex.split` is performed.
 
 ### 1.10 Reattachment
 

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -775,12 +775,14 @@ def _open_single(
         if git_email is None:
             git_email = auto_email
 
-    # Parse --command into a list
-    command_args = shlex.split(command) if command else None
+    # Treat a whitespace-only --command as no command (matches old shlex.split
+    # behavior where "   " parsed to []).
+    if command is not None and not command.strip():
+        command = None
 
     # Resolve editor: shortcut flags > --editor > config > vscode
     valid_editors = ("vscode", "emacs", "neovim", "shell")
-    if command_args:
+    if command:
         editor = "shell"
     elif shell:
         editor = "shell"
@@ -825,7 +827,7 @@ def _open_single(
             sys.exit(1)
         if not machine_readable:
             notices.finish()
-        open_native(target, editor, no_interactive, custom_name, command=command_args)
+        open_native(target, editor, no_interactive, custom_name, command=command)
         return
 
     # Priority: --local > --ssh > --cloud > [cloud] default > [remote] default_host
@@ -875,7 +877,7 @@ def _open_single(
             config,
             git_name=git_name,
             git_email=git_email,
-            command=command_args,
+            command=command,
             ai_config=ai_config,
             claude_credentials=claude_credentials,
             codex_credentials=codex_credentials,
@@ -929,7 +931,7 @@ def _open_single(
             machine_readable_output("reattached", existing, project_dir=project_dir)
             return
         notices.finish()
-        _reattach(runtime, existing, editor, no_interactive, command=command_args)
+        _reattach(runtime, existing, editor, no_interactive, command=command)
         return
 
     # Parse and register target
@@ -977,7 +979,7 @@ def _open_single(
             )
             return
         notices.finish()
-        _reattach(runtime, existing, editor, no_interactive, command=command_args)
+        _reattach(runtime, existing, editor, no_interactive, command=command)
         return
 
     # Resolve git source, detect language, and build image
@@ -1143,7 +1145,7 @@ def _open_single(
             machine_readable,
             git_name=git_name,
             git_email=git_email,
-            command=command_args,
+            command=command,
             ai_prompt=ai_prompt,
         )
     except Exception:

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -107,12 +107,14 @@ def open_editor(
     bubble_name: str,
     remote_path: str = "/home/user",
     workspace_file: str | None = None,
-    command: list[str] | None = None,
+    command: str | None = None,
 ):
     """Open the specified editor connected to a bubble.
 
     If command is provided (only valid with editor="shell"), runs that command
-    via SSH instead of opening an interactive session.
+    via SSH instead of opening an interactive session. The command string is
+    passed verbatim as a single SSH argument; the remote shell parses it with
+    `$SHELL -c`, so callers can write it exactly as they would after `ssh host`.
     """
     if editor == "vscode":
         open_vscode(bubble_name, remote_path, workspace_file=workspace_file)
@@ -138,14 +140,16 @@ def open_editor(
     elif editor == "shell":
         ssh_cmd = ["ssh", f"bubble-{bubble_name}"]
         if command:
-            ssh_cmd += command
+            ssh_cmd.append(command)
         subprocess.run(ssh_cmd)
 
 
-def open_editor_native(editor: str, local_path: str, command: list[str] | None = None):
+def open_editor_native(editor: str, local_path: str, command: str | None = None):
     """Open the specified editor for a native (non-containerized) workspace.
 
     Opens VSCode directly on the local path, or spawns a shell in that directory.
+    If command is provided (only with editor="shell"), runs it via `bash -c`,
+    matching how the SSH shell editor passes the same string to the remote shell.
     """
     if editor == "vscode":
         try:
@@ -158,7 +162,7 @@ def open_editor_native(editor: str, local_path: str, command: list[str] | None =
             print(f"VSCode CLI not found or failed. Open manually: {local_path}")
     elif editor == "shell":
         if command:
-            subprocess.run(command, cwd=local_path)
+            subprocess.run(["bash", "-c", command], cwd=local_path)
         else:
             subprocess.run(
                 ["bash", "-c", f"cd {shlex.quote(local_path)} && exec $SHELL"],

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -4,7 +4,7 @@ import subprocess
 
 from bubble.images.builder import IMAGES
 from bubble.tools import EDITOR_TOOLS, TOOLS, resolve_tools
-from bubble.vscode import open_editor
+from bubble.vscode import open_editor, open_editor_native
 
 
 class TestEditorAsTools:
@@ -151,8 +151,32 @@ class TestOpenEditorShell:
         assert calls == [["ssh", "bubble-test-bubble"]]
 
     def test_shell_with_command(self, monkeypatch):
-        """Shell editor with command should SSH and pass the command."""
+        """Shell editor with command should SSH and pass the command verbatim."""
         calls = []
         monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
-        open_editor("shell", "test-bubble", command=["lake", "build"])
-        assert calls == [["ssh", "bubble-test-bubble", "lake", "build"]]
+        open_editor("shell", "test-bubble", command="lake build")
+        assert calls == [["ssh", "bubble-test-bubble", "lake build"]]
+
+    def test_shell_with_quoted_command(self, monkeypatch):
+        """Shell editor preserves quoting by passing the command as one ssh arg."""
+        calls = []
+        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        open_editor("shell", "test-bubble", command="bash -lc 'gh auth status'")
+        assert calls == [["ssh", "bubble-test-bubble", "bash -lc 'gh auth status'"]]
+
+
+class TestOpenEditorNativeShell:
+    def test_native_shell_no_command(self, monkeypatch):
+        """Native shell without command spawns an interactive $SHELL in cwd."""
+        calls = []
+        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append((cmd, kw)))
+        open_editor_native("shell", "/tmp/proj")
+        assert calls[0][0][:2] == ["bash", "-c"]
+        assert "exec $SHELL" in calls[0][0][2]
+
+    def test_native_shell_with_command(self, monkeypatch):
+        """Native shell with command runs it via `bash -c` in cwd."""
+        calls = []
+        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append((cmd, kw)))
+        open_editor_native("shell", "/tmp/proj", command="bash -lc 'gh auth status'")
+        assert calls == [(["bash", "-c", "bash -lc 'gh auth status'"], {"cwd": "/tmp/proj"})]


### PR DESCRIPTION
This PR fixes \`bubble open --command\` so that quoting is preserved end-to-end. Previously the host-side \`shlex.split\` would shred a value like \`bash -lc 'gh auth status'\` into \`["bash", "-lc", "gh auth status"]\`; ssh then joined those with spaces, and the remote shell parsed \`bash -lc gh auth status\` — three positional args instead of one COMMAND_STRING. Now the original string is passed to ssh as a single argv item, so the remote shell parses it exactly as if typed after \`ssh host\`. The native (non-containerized) shell path runs \`bash -c "\$command"\` so the same \`--command\` value behaves the same way locally and remotely. A whitespace-only \`--command\` is treated as no command, matching the old \`shlex.split("   ") == []\` behavior.

Closes #265

🤖 Prepared with Claude Code