### PR TITLE
feat: granular --claude-config/--codex-config flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.16 — 2026-05-07
+- Granular Claude/Codex config mounts (#264)
+  - `--claude-config/--no-claude-config` and `--codex-config/--no-codex-config` flags on `bubble open`
+  - `[claude] config` / `[codex] config` keys in `~/.bubble/config.toml`
+  - Allows mounting credentials without exposing personal `~/.claude` config items (CLAUDE.md, skills, commands, settings.json, keybindings.json) — useful for autonomous agents that need to authenticate but should not be biased by the host user's preferences
+  - `SafeConfigDir.config_mounts` gains `include_config_items` parameter (default `True`, preserves existing behavior)
+  - Flags forwarded to remote/cloud bubbles
+
 ## 0.7.1 — 2026-03-12
 - Deprecate `config security`, `config lockdown`, `config accept-risks` in favor of `security` subcommands (#150)
   - Add deprecation warnings (to stderr) when deprecated commands are used

--- a/SPEC.md
+++ b/SPEC.md
@@ -59,6 +59,8 @@ equivalent to `bubble open <url>`.
 | `--ai-config/--no-ai-config` | flag | enabled | Mount AI provider configs read-only |
 | `--claude-credentials/--no-claude-credentials` | flag | enabled | Mount Claude credentials |
 | `--codex-credentials/--no-codex-credentials` | flag | enabled | Mount Codex credentials |
+| `--claude-config/--no-claude-config` | flag | enabled | Mount Claude config items (CLAUDE.md, skills, commands, ...) |
+| `--codex-config/--no-codex-config` | flag | enabled | Mount Codex config items |
 | `--ssh HOST` | string | | Run on remote host |
 | `--cloud` | flag | | Run on Hetzner Cloud server |
 | `--local` | flag | | Force local execution |

--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.15"
+__version__ = "0.7.16"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -307,6 +307,8 @@ def _open_remote(
     ai_config=True,
     claude_credentials=None,
     codex_credentials=None,
+    claude_config=None,
+    codex_config=None,
     new_branch=None,
     base_ref=None,
 ):
@@ -327,6 +329,8 @@ def _open_remote(
             ai_config=ai_config,
             claude_credentials=claude_credentials,
             codex_credentials=codex_credentials,
+            claude_config=claude_config,
+            codex_config=codex_config,
             new_branch=new_branch,
             base_ref=base_ref,
             ai_prompt=ai_prompt,
@@ -565,6 +569,23 @@ def _reattach(runtime, name, editor, no_interactive, command=None):
     help="Mount ~/.codex credentials into container (default: from config or enabled)",
 )
 @click.option(
+    "--claude-config/--no-claude-config",
+    default=None,
+    help=(
+        "Mount ~/.claude config items (CLAUDE.md, skills, commands, etc.) into"
+        " container. Independent of --claude-credentials so agents can"
+        " authenticate without seeing personal config (default: from config or enabled)."
+    ),
+)
+@click.option(
+    "--codex-config/--no-codex-config",
+    default=None,
+    help=(
+        "Mount ~/.codex config items into container, independent of"
+        " --codex-credentials (default: from config or enabled)."
+    ),
+)
+@click.option(
     "--ai-prompt-stdin",
     is_flag=True,
     hidden=True,
@@ -601,6 +622,8 @@ def open_cmd(
     ai_config,
     claude_credentials,
     codex_credentials,
+    claude_config,
+    codex_config,
     ai_prompt_stdin,
     skip_auth_setup,
 ):
@@ -661,6 +684,8 @@ def open_cmd(
                 ai_config=ai_config,
                 claude_credentials=claude_credentials,
                 codex_credentials=codex_credentials,
+                claude_config=claude_config,
+                codex_config=codex_config,
                 ai_prompt_stdin=ai_prompt_stdin,
                 skip_auth_setup=skip_auth_setup,
             )
@@ -716,6 +741,8 @@ def _open_single(
     ai_config,
     claude_credentials,
     codex_credentials,
+    claude_config,
+    codex_config,
     ai_prompt_stdin,
     skip_auth_setup=False,
 ):
@@ -854,6 +881,12 @@ def _open_single(
     if codex_credentials is None:
         codex_credentials = config.get("codex", {}).get("credentials", True)
 
+    # Resolve claude_config / codex_config: CLI flag > config > default (True)
+    if claude_config is None:
+        claude_config = config.get("claude", {}).get("config", True)
+    if codex_config is None:
+        codex_config = config.get("codex", {}).get("config", True)
+
     if remote_host:
         if mount_specs:
             click.echo(
@@ -879,6 +912,8 @@ def _open_single(
             ai_config=ai_config,
             claude_credentials=claude_credentials,
             codex_credentials=codex_credentials,
+            claude_config=claude_config,
+            codex_config=codex_config,
             new_branch=new_branch,
             base_ref=base_ref,
         )
@@ -891,11 +926,15 @@ def _open_single(
     include_creds = should_include_credentials(claude_credentials, config, "claude_credentials")
     cc_mounts = []
     if ai_config:
-        cc_mounts = claude_config_mounts(include_credentials=include_creds)
+        cc_mounts = claude_config_mounts(
+            include_credentials=include_creds,
+            include_config_items=bool(claude_config),
+        )
         # Suppress auto mounts that overlap with user mounts (exact or ancestry)
         cc_mounts = [m for m in cc_mounts if not mount_overlaps(Path(m.target), user_targets)]
         # Hint about symlinking ~/.bubble/ai-projects/ to ~/.claude/projects/
-        if not machine_readable:
+        # Only relevant when config items are mounted (projects symlink lives in ~/.claude).
+        if not machine_readable and claude_config:
             maybe_symlink_ai_projects(config, notices=notices)
 
     # Codex config mounts (also gated by --no-ai-config)
@@ -904,7 +943,10 @@ def _open_single(
         include_codex_creds = should_include_credentials(
             codex_credentials, config, "codex_credentials"
         )
-        cx_mounts = codex_config_mounts(include_credentials=include_codex_creds)
+        cx_mounts = codex_config_mounts(
+            include_credentials=include_codex_creds,
+            include_config_items=bool(codex_config),
+        )
         if cx_mounts:
             cx_mounts = [m for m in cx_mounts if not mount_overlaps(Path(m.target), user_targets)]
 

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -250,16 +250,23 @@ class SafeConfigDir:
             return None
         return resolved
 
-    def config_mounts(self, include_credentials: bool = True) -> list[MountSpec]:
+    def config_mounts(
+        self,
+        include_credentials: bool = True,
+        include_config_items: bool = True,
+    ) -> list[MountSpec]:
         """Return read-only mounts for config files that exist on the host.
 
         Args:
             include_credentials: If True, also mount credential files.
+            include_config_items: If True, mount config items (CLAUDE.md,
+                settings.json, skills, etc.). Set False to give the container
+                credentials without exposing personal config.
         """
         mounts = []
         if not self.base_dir.is_dir():
             return mounts
-        items = list(self.config_items)
+        items = list(self.config_items) if include_config_items else []
         if include_credentials:
             items.extend(self.credential_items)
         for item in items:
@@ -286,9 +293,15 @@ CLAUDE_CONFIG = SafeConfigDir(
 )
 
 
-def claude_config_mounts(include_credentials: bool = True) -> list[MountSpec]:
+def claude_config_mounts(
+    include_credentials: bool = True,
+    include_config_items: bool = True,
+) -> list[MountSpec]:
     """Return read-only mounts for Claude Code config files that exist on the host."""
-    return CLAUDE_CONFIG.config_mounts(include_credentials)
+    return CLAUDE_CONFIG.config_mounts(
+        include_credentials=include_credentials,
+        include_config_items=include_config_items,
+    )
 
 
 # Editor config directories to mount into containers.
@@ -440,9 +453,15 @@ CODEX_CONFIG = SafeConfigDir(
 )
 
 
-def codex_config_mounts(include_credentials: bool = True) -> list[MountSpec]:
+def codex_config_mounts(
+    include_credentials: bool = True,
+    include_config_items: bool = True,
+) -> list[MountSpec]:
     """Return read-only mounts for Codex config files that exist on the host."""
-    return CODEX_CONFIG.config_mounts(include_credentials)
+    return CODEX_CONFIG.config_mounts(
+        include_credentials=include_credentials,
+        include_config_items=include_config_items,
+    )
 
 
 AI_PROJECTS_DIR = DATA_DIR / "ai-projects"

--- a/bubble/remote.py
+++ b/bubble/remote.py
@@ -409,6 +409,8 @@ def remote_open(
     ai_config: bool = True,
     claude_credentials: bool | None = None,
     codex_credentials: bool | None = None,
+    claude_config: bool | None = None,
+    codex_config: bool | None = None,
     new_branch: str | None = None,
     base_ref: str | None = None,
     ai_prompt: str = "",
@@ -436,6 +438,14 @@ def remote_open(
         args.append("--codex-credentials")
     elif codex_credentials is False:
         args.append("--no-codex-credentials")
+    if claude_config is True:
+        args.append("--claude-config")
+    elif claude_config is False:
+        args.append("--no-claude-config")
+    if codex_config is True:
+        args.append("--codex-config")
+    elif codex_config is False:
+        args.append("--no-codex-config")
     if custom_name:
         args += ["--name", custom_name]
     if git_name:

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -458,6 +458,37 @@ class TestClaudeConfigMounts:
 
         assert mounts == []
 
+    def test_config_items_excluded_credentials_kept(self, tmp_path, monkeypatch):
+        """include_config_items=False skips config but still mounts credentials."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "CLAUDE.md").write_text("# personal")
+        (claude_dir / "settings.json").write_text("{}")
+        (claude_dir / "skills").mkdir()
+        (claude_dir / "keybindings.json").write_text("{}")
+        (claude_dir / "commands").mkdir()
+        (claude_dir / ".credentials.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CLAUDE_CONFIG.base_dir", claude_dir)
+
+        mounts = claude_config_mounts(include_credentials=True, include_config_items=False)
+
+        assert len(mounts) == 1
+        assert mounts[0].target == "/home/user/.claude/.credentials.json"
+
+    def test_config_items_and_credentials_both_excluded(self, tmp_path, monkeypatch):
+        """include_config_items=False and include_credentials=False yields no mounts."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "CLAUDE.md").write_text("# personal")
+        (claude_dir / ".credentials.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CLAUDE_CONFIG.base_dir", claude_dir)
+
+        mounts = claude_config_mounts(include_credentials=False, include_config_items=False)
+
+        assert mounts == []
+
     def test_rejects_symlinks_escaping_claude_dir(self, tmp_path, monkeypatch):
         """Symlinks that escape ~/.claude are rejected."""
         claude_dir = tmp_path / ".claude"
@@ -781,6 +812,20 @@ class TestCodexConfigMounts:
         mounts = codex_config_mounts(include_credentials=False)
 
         assert mounts == []
+
+    def test_config_items_excluded_credentials_kept(self, tmp_path, monkeypatch):
+        """include_config_items=False skips config but still mounts credentials."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text("[settings]")
+        (codex_dir / "auth.json").write_text("{}")
+
+        monkeypatch.setattr("bubble.config.CODEX_CONFIG.base_dir", codex_dir)
+
+        mounts = codex_config_mounts(include_credentials=True, include_config_items=False)
+
+        assert len(mounts) == 1
+        assert mounts[0].target == "/home/user/.codex/auth.json"
 
     def test_rejects_symlinks_escaping_codex_dir(self, tmp_path, monkeypatch):
         """Symlinks that escape ~/.codex are rejected."""

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -285,6 +285,32 @@ class TestRemoteOpenFlagForwarding:
         assert "--codex-credentials" not in cmd_str
         assert "--no-codex-credentials" not in cmd_str
 
+    def test_claude_config_forwarded(self):
+        cmd_str = self._run_remote_open(claude_config=True)
+        assert "--claude-config" in cmd_str
+
+    def test_no_claude_config_forwarded(self):
+        cmd_str = self._run_remote_open(claude_config=False)
+        assert "--no-claude-config" in cmd_str
+
+    def test_claude_config_none_not_forwarded(self):
+        cmd_str = self._run_remote_open(claude_config=None)
+        assert "--claude-config" not in cmd_str
+        assert "--no-claude-config" not in cmd_str
+
+    def test_codex_config_forwarded(self):
+        cmd_str = self._run_remote_open(codex_config=True)
+        assert "--codex-config" in cmd_str
+
+    def test_no_codex_config_forwarded(self):
+        cmd_str = self._run_remote_open(codex_config=False)
+        assert "--no-codex-config" in cmd_str
+
+    def test_codex_config_none_not_forwarded(self):
+        cmd_str = self._run_remote_open(codex_config=None)
+        assert "--codex-config" not in cmd_str
+        assert "--no-codex-config" not in cmd_str
+
     def test_skip_auth_setup_always_forwarded(self):
         """Remote open always passes --skip-auth-setup so the remote doesn't
         redundantly start its own auth proxy (issue #260)."""


### PR DESCRIPTION
This PR adds `--claude-config/--no-claude-config` and `--codex-config/--no-codex-config` flags to `bubble open`, decoupling whether `~/.claude` (and `~/.codex`) config items are mounted from whether their credentials are mounted. The motivation is autonomous agents — e.g. running Claude Code inside a bubble via `pod` — that need to authenticate as the user but should not inherit personal `CLAUDE.md`, skills, commands, or settings, since those bias agent outputs and leak personal preferences.

`SafeConfigDir.config_mounts` gains an `include_config_items` parameter (default `True`), threaded through `claude_config_mounts` and `codex_config_mounts`. The new CLI flags resolve as `CLI > [claude]/[codex] config > True`, mirroring the existing credentials flag, and are forwarded to remote/cloud bubbles via `remote_open`. The `--no-ai-config` flag still suppresses everything, so default behaviour is unchanged.

Closes https://github.com/kim-em/bubble/issues/264

🤖 Prepared with Claude Code