### PR TITLE
fix: source /etc/profile.d in --shell --command so GH_TOKEN reaches gh

### DIFF
--- a/bubble/images/scripts/base.sh
+++ b/bubble/images/scripts/base.sh
@@ -113,7 +113,11 @@ cat >> /home/user/.profile << 'PROFILEEOF'
 # bubble: auto-run build command if marker file exists.
 # Guard on SSH_CONNECTION to avoid triggering during provisioning
 # (su - user -c "..." sources .profile but doesn't set SSH_CONNECTION).
-if [ -n "$SSH_CONNECTION" ] && [ -f "$HOME/.bubble-fetch-cache" ]; then
+# Also skip non-interactive shells (e.g. `bubble --shell --command ...`
+# wraps the command in `bash -lc`, which sources .profile but has $- with
+# no `i`) so one-off commands don't accidentally consume the marker.
+case $- in *i*) _bubble_interactive=1 ;; *) _bubble_interactive= ;; esac
+if [ -n "$_bubble_interactive" ] && [ -n "$SSH_CONNECTION" ] && [ -f "$HOME/.bubble-fetch-cache" ]; then
     _bubble_cmd=$(cat "$HOME/.bubble-fetch-cache")
     rm -f "$HOME/.bubble-fetch-cache"
     if [ -n "$_bubble_cmd" ]; then
@@ -123,6 +127,7 @@ if [ -n "$SSH_CONNECTION" ] && [ -f "$HOME/.bubble-fetch-cache" ]; then
     fi
     unset _bubble_cmd
 fi
+unset _bubble_interactive
 PROFILEEOF
 chown user:user /home/user/.profile
 

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -163,9 +163,11 @@ def open_editor(
 
     If command is provided (only valid with editor="shell"), runs that command
     via SSH instead of opening an interactive session. The command string is
-    passed verbatim as a single SSH argument; the remote shell parses it with
-    `$SHELL -c`, so callers can write it exactly as they would after `ssh host`.
-    The command runs from remote_path, mirroring interactive --shell.
+    passed verbatim as a single SSH argument and wrapped in `bash -lc` on the
+    remote so `/etc/profile.d/*` is sourced (otherwise GH_TOKEN/GH_REPO/
+    GH_CONFIG_DIR set in /etc/profile.d/bubble-gh.sh would be missing for
+    non-login shells). The command runs from remote_path, mirroring the
+    interactive --shell.
     """
     if editor == "vscode":
         open_vscode(bubble_name, remote_path, workspace_file=workspace_file)
@@ -191,12 +193,18 @@ def open_editor(
     elif editor == "shell":
         ssh_cmd = ["ssh", f"bubble-{bubble_name}"]
         if command:
-            # Run the command from the project directory, mirroring the
-            # interactive shell's landing cwd. Without this, sshd executes
-            # the command in /home/user, surprising callers who expect to
-            # be in the repo (and breaking tools that rely on cwd, like
-            # git, gh, claude -p).
-            ssh_cmd.append(f"cd {shlex.quote(remote_path)} && exec {command}")
+            # Run via `bash -lc` so /etc/profile.d/* is sourced — non-login
+            # shells skip it, leaving GH_TOKEN/GH_REPO/GH_CONFIG_DIR (set in
+            # /etc/profile.d/bubble-gh.sh) and similar env knobs unset. ssh
+            # joins remaining argv with spaces and runs the result through
+            # the user's shell, so we package the command as a single
+            # already-quoted argument. The cd prefix mirrors the interactive
+            # shell's landing cwd so tools relying on cwd (git, gh, claude -p)
+            # see the project dir, not /home/user. The build-marker hook in
+            # ~/.profile gates itself on interactive shells so `--command`
+            # doesn't accidentally consume the marker.
+            inner = f"cd {shlex.quote(remote_path)} && exec {command}"
+            ssh_cmd.append(shlex.join(["bash", "-lc", inner]))
         subprocess.run(ssh_cmd)
 
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,5 +1,6 @@
 """Tests for editor support (emacs, neovim, vscode, shell)."""
 
+import shlex
 import subprocess
 
 from bubble.images.builder import IMAGES
@@ -151,29 +152,44 @@ class TestOpenEditorShell:
         assert calls == [["ssh", "bubble-test-bubble"]]
 
     def test_shell_with_command(self, monkeypatch):
-        """Shell editor with command should cd into remote_path and exec verbatim."""
+        """Shell editor wraps command in `bash -lc` and cd's into remote_path."""
         calls = []
         monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
         open_editor("shell", "test-bubble", "/home/user/proj", command="lake build")
-        assert calls == [["ssh", "bubble-test-bubble", "cd /home/user/proj && exec lake build"]]
+        assert calls == [
+            [
+                "ssh",
+                "bubble-test-bubble",
+                "bash -lc 'cd /home/user/proj && exec lake build'",
+            ]
+        ]
 
     def test_shell_with_command_default_cwd(self, monkeypatch):
         """When no remote_path is given, fall back to /home/user."""
         calls = []
         monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
         open_editor("shell", "test-bubble", command="pwd")
-        assert calls == [["ssh", "bubble-test-bubble", "cd /home/user && exec pwd"]]
+        assert calls == [["ssh", "bubble-test-bubble", "bash -lc 'cd /home/user && exec pwd'"]]
 
     def test_shell_with_quoted_command(self, monkeypatch):
-        """Quoted commands are passed verbatim through the cd-prefixed wrapper."""
+        """Quoted commands are passed verbatim through the bash -lc wrapper."""
         calls = []
         monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
-        open_editor("shell", "test-bubble", "/home/user/proj", command="bash -lc 'gh auth status'")
+        open_editor(
+            "shell",
+            "test-bubble",
+            "/home/user/proj",
+            command="bash -lc 'gh auth status'",
+        )
+        # The command string is dropped verbatim into the cd-prefixed wrapper,
+        # which is itself shlex-quoted as the single argument to bash -lc.
+        # Inner single quotes therefore appear as the standard `'\''` escape.
+        expected_inner = "cd /home/user/proj && exec bash -lc 'gh auth status'"
         assert calls == [
             [
                 "ssh",
                 "bubble-test-bubble",
-                "cd /home/user/proj && exec bash -lc 'gh auth status'",
+                "bash -lc " + shlex.quote(expected_inner),
             ]
         ]
 
@@ -193,3 +209,53 @@ class TestOpenEditorNativeShell:
         monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append((cmd, kw)))
         open_editor_native("shell", "/tmp/proj", command="bash -lc 'gh auth status'")
         assert calls == [(["bash", "-c", "bash -lc 'gh auth status'"], {"cwd": "/tmp/proj"})]
+
+
+class TestBuildMarkerProfileHook:
+    """The build-marker hook in /home/user/.profile (installed by base.sh)
+    must skip non-interactive shells. Otherwise `bubble --shell --command ...`
+    (which wraps in `bash -lc` per issue #268) would consume the marker
+    and start an unsolicited background build before the user's command runs.
+    """
+
+    def _profile_snippet(self):
+        """Extract the heredoc body from base.sh — the literal block between
+        `<< 'PROFILEEOF'` and `PROFILEEOF`."""
+        from pathlib import Path
+
+        src = Path(__file__).parent.parent / "bubble" / "images" / "scripts" / "base.sh"
+        text = src.read_text()
+        marker = "<< 'PROFILEEOF'\n"
+        start = text.index(marker) + len(marker)
+        end = text.index("\nPROFILEEOF\n", start)
+        return text[start:end]
+
+    def test_marker_consumed_by_interactive_login_shell(self, tmp_path):
+        snippet = self._profile_snippet()
+        marker = tmp_path / ".bubble-fetch-cache"
+        marker.write_text("true\n")
+        # bash -ilc → interactive + login. Set HOME and SSH_CONNECTION so the
+        # snippet thinks it's a real login.
+        result = subprocess.run(
+            ["bash", "-ilc", snippet],
+            env={"HOME": str(tmp_path), "SSH_CONNECTION": "x", "PATH": "/usr/bin:/bin"},
+            capture_output=True,
+            text=True,
+        )
+        assert "Build started in background" in result.stdout
+        assert not marker.exists(), "interactive shell should consume the marker"
+
+    def test_marker_preserved_by_non_interactive_login_shell(self, tmp_path):
+        snippet = self._profile_snippet()
+        marker = tmp_path / ".bubble-fetch-cache"
+        marker.write_text("true\n")
+        # bash -lc → login but not interactive. This is the `bash -lc` form
+        # used by open_editor("shell", ..., command=...).
+        result = subprocess.run(
+            ["bash", "-lc", snippet],
+            env={"HOME": str(tmp_path), "SSH_CONNECTION": "x", "PATH": "/usr/bin:/bin"},
+            capture_output=True,
+            text=True,
+        )
+        assert "Build started in background" not in result.stdout
+        assert marker.exists(), "non-interactive shell must not consume the marker"


### PR DESCRIPTION
This PR makes \`bubble --shell --command 'gh auth status'\` actually find the auth proxy's \`GH_TOKEN\`. Previously, ssh ran the command via the user's default shell in non-login mode, so \`/etc/profile.d/bubble-gh.sh\` (which exports \`GH_TOKEN\`, \`GH_REPO\`, and \`GH_CONFIG_DIR\` for the auth proxy) was never sourced and \`gh\` reported \"You are not logged into any GitHub hosts.\"

Wraps the command in \`bash -lc <quoted>\` inside \`open_editor\` so login startup files run. To prevent the build-marker hook in \`~/.profile\` from firing on one-off commands (which would otherwise consume the marker and start an unsolicited background build), the hook is now gated on interactive shells via \`case \$- in *i*)\`.

Closes https://github.com/kim-em/bubble/issues/268.

🤖 Prepared with Claude Code