### PR TITLE
feat: add --ephemeral flag to pop the bubble after --command exits

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -322,6 +322,7 @@ def _open_remote(
     codex_config=None,
     new_branch=None,
     base_ref=None,
+    ephemeral=False,
 ):
     """Open a bubble on a remote host, then connect locally."""
     from .remote import remote_open
@@ -426,10 +427,16 @@ def _open_remote(
 
     if not no_interactive:
         echo_editor_opening(editor)
-        open_editor(editor, name, project_dir, workspace_file=workspace_file, command=command)
+        exit_code = open_editor(
+            editor, name, project_dir, workspace_file=workspace_file, command=command
+        )
+        if ephemeral and command:
+            from .finalization import _ephemeral_pop_and_exit
+
+            _ephemeral_pop_and_exit(name, exit_code)
 
 
-def _reattach(runtime, name, editor, no_interactive, command=None):
+def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=False):
     """Re-attach to an existing container."""
     ensure_running(runtime, name)
 
@@ -479,7 +486,11 @@ def _reattach(runtime, name, editor, no_interactive, command=None):
             pass  # Can't check status, skip pull
 
     echo_editor_opening(editor)
-    open_editor(editor, name, project_dir, command=command)
+    exit_code = open_editor(editor, name, project_dir, command=command)
+    if ephemeral and command:
+        from .finalization import _ephemeral_pop_and_exit
+
+        _ephemeral_pop_and_exit(name, exit_code)
 
 
 # The "open" command is hidden from help because users invoke it implicitly via
@@ -524,6 +535,12 @@ def _reattach(runtime, name, editor, no_interactive, command=None):
     type=str,
     default=None,
     help="Run a command via SSH instead of interactive shell",
+)
+@click.option(
+    "--ephemeral",
+    is_flag=True,
+    default=False,
+    help="With --command, pop the bubble after the command exits (propagating its exit code).",
 )
 @click.option(
     "--native",
@@ -634,6 +651,7 @@ def open_cmd(
     network,
     custom_name,
     command,
+    ephemeral,
     native,
     force_path,
     new_branch,
@@ -708,6 +726,7 @@ def open_cmd(
                 network=network,
                 custom_name=custom_name,
                 command=command,
+                ephemeral=ephemeral,
                 native=native,
                 force_path=force_path,
                 new_branch=new_branch,
@@ -766,6 +785,7 @@ def _open_single(
     network,
     custom_name,
     command,
+    ephemeral,
     native,
     force_path,
     new_branch,
@@ -859,6 +879,15 @@ def _open_single(
     if command is not None and not command.strip():
         command = None
 
+    # --ephemeral requires --command (the bubble must have a finite lifetime)
+    if ephemeral and not command:
+        click.echo("Error: --ephemeral requires --command", err=True)
+        sys.exit(1)
+    # --ephemeral with --no-interactive is a no-op (no command runs)
+    if ephemeral and no_interactive:
+        click.echo("Error: --ephemeral cannot be combined with --no-interactive", err=True)
+        sys.exit(1)
+
     # Resolve editor: shortcut flags > --editor > config > vscode
     valid_editors = ("vscode", "emacs", "neovim", "shell")
     if command:
@@ -906,7 +935,14 @@ def _open_single(
             sys.exit(1)
         if not machine_readable:
             notices.finish()
-        open_native(target, editor, no_interactive, custom_name, command=command)
+        open_native(
+            target,
+            editor,
+            no_interactive,
+            custom_name,
+            command=command,
+            ephemeral=ephemeral,
+        )
         return
 
     # Priority: --local > --ssh > --cloud > [cloud] default > [remote] default_host
@@ -970,6 +1006,7 @@ def _open_single(
             codex_config=codex_config,
             new_branch=new_branch,
             base_ref=base_ref,
+            ephemeral=ephemeral,
         )
         return
 
@@ -1025,7 +1062,7 @@ def _open_single(
             machine_readable_output("reattached", existing, project_dir=project_dir)
             return
         notices.finish()
-        _reattach(runtime, existing, editor, no_interactive, command=command)
+        _reattach(runtime, existing, editor, no_interactive, command=command, ephemeral=ephemeral)
         return
 
     # Parse and register target
@@ -1073,7 +1110,7 @@ def _open_single(
             )
             return
         notices.finish()
-        _reattach(runtime, existing, editor, no_interactive, command=command)
+        _reattach(runtime, existing, editor, no_interactive, command=command, ephemeral=ephemeral)
         return
 
     # Resolve git source, detect language, and build image
@@ -1241,6 +1278,7 @@ def _open_single(
             git_email=git_email,
             command=command,
             ai_prompt=ai_prompt,
+            ephemeral=ephemeral,
         )
     except Exception:
         # Clean up partially-provisioned container on failure

--- a/bubble/commands/lifecycle.py
+++ b/bubble/commands/lifecycle.py
@@ -16,6 +16,97 @@ from ..setup import get_runtime
 from ..vscode import remove_ssh_config
 
 
+def destroy_bubble(name: str, info: dict | None = None, on_progress=None) -> tuple[bool, str]:
+    """Destroy a bubble unconditionally (no confirmation, no cleanness check).
+
+    Routes to the right backend (remote / native / local container) based on
+    the registry entry. Returns (success, error_message).
+
+    On success (including "already gone"), cleans up the local SSH config,
+    tokens, and registry entry. On failure, leaves local state intact so the
+    user can retry cleanup with `bubble pop -f`.
+
+    `on_progress` is an optional callable that receives status strings (e.g.
+    "Container busy, retrying (1/3)...") so the CLI can stream progress.
+
+    Used by `bubble pop -f` and by --ephemeral after a --command exits.
+    """
+    if info is None:
+        info = get_bubble_info(name)
+
+    # Remote-hosted bubble: destroy on the remote, then clean up locally
+    if info and info.get("remote_host"):
+        from ..remote import RemoteHost, apply_cloud_ssh_options, remote_command
+
+        host = RemoteHost.parse(info["remote_host"])
+        apply_cloud_ssh_options(host)
+        try:
+            result = remote_command(host, ["pop", "-f", name])
+        except Exception as e:
+            return False, f"Failed to pop on {host.ssh_destination}: {e}"
+        if result.returncode != 0:
+            return False, (
+                f"Failed to pop on {host.ssh_destination}: "
+                f"{(result.stderr or '').strip() or 'remote pop returned nonzero'}"
+            )
+        remove_ssh_config(name)
+        _cleanup_tokens(name, remote_host_spec=info["remote_host"])
+        unregister_bubble(name)
+        return True, ""
+
+    # Native workspace: rmtree under NATIVE_DIR (refuse paths outside the root)
+    if info and info.get("native"):
+        native_path = info.get("native_path", "")
+        if native_path and Path(native_path).is_dir():
+            resolved = Path(native_path).resolve()
+            native_dir_resolved = NATIVE_DIR.resolve()
+            if not str(resolved).startswith(str(native_dir_resolved) + os.sep):
+                return False, (
+                    f"Refusing to delete: path '{native_path}' is not under {NATIVE_DIR}"
+                )
+            try:
+                shutil.rmtree(resolved)
+            except OSError as e:
+                return False, f"Failed to remove native workspace: {e}"
+        _cleanup_tokens(name)
+        unregister_bubble(name)
+        return True, ""
+
+    # Local container
+    config = load_config()
+    runtime = get_runtime(config, ensure_ready=False)
+    last_error = ""
+    deleted = False
+    for attempt in range(3):
+        try:
+            runtime.delete(name, force=True)
+            deleted = True
+            break
+        except subprocess.CalledProcessError as e:
+            msg = ((e.stderr or "") + " " + (e.stdout or "")).strip()
+            last_error = msg or str(e)
+            if "not found" in msg.lower() or "does not exist" in msg.lower():
+                deleted = True  # Already gone — proceed with cleanup
+                break
+            if "busy" in msg.lower() and attempt < 2:
+                if on_progress:
+                    on_progress(f"Container busy, retrying ({attempt + 1}/3)...")
+                time.sleep(3 * (attempt + 1))
+                continue
+            break
+        except Exception as e:
+            last_error = str(e)
+            break
+
+    if not deleted:
+        return False, last_error or "unknown error"
+
+    remove_ssh_config(name)
+    _cleanup_tokens(name)
+    unregister_bubble(name)
+    return True, ""
+
+
 def _cleanup_tokens(name: str, remote_host_spec: str = ""):
     """Remove relay and auth proxy tokens for a container.
 
@@ -70,102 +161,69 @@ def register_lifecycle_commands(main):
     @click.option("-f", "--force", is_flag=True, help="Skip confirmation prompt")
     def pop(name, force):
         """Pop a bubble (destroy it permanently)."""
-        # Auto-route to remote host if the bubble is registered there
         info = get_bubble_info(name)
-        if info and info.get("remote_host"):
-            from ..remote import RemoteHost, apply_cloud_ssh_options, remote_command
 
-            host = RemoteHost.parse(info["remote_host"])
-            apply_cloud_ssh_options(host)
-            if not force:
+        # Confirmation prompt (skipped with -f)
+        if not force:
+            if info and info.get("remote_host"):
+                from ..remote import RemoteHost
+
+                host = RemoteHost.parse(info["remote_host"])
                 click.confirm(
                     f"Permanently pop bubble '{name}' on {host.ssh_destination}?",
                     abort=True,
                 )
-            result = remote_command(host, ["pop", "-f", name])
-            if result.returncode != 0:
-                click.echo(f"Failed to pop on {host.ssh_destination}: {result.stderr}", err=True)
-                sys.exit(1)
-            remove_ssh_config(name)
-            _cleanup_tokens(name, remote_host_spec=info["remote_host"])
-            unregister_bubble(name)
-            click.echo(f"Bubble '{name}' popped on {host.ssh_destination}.")
-            return
-
-        # Handle native workspaces
-        if info and info.get("native"):
-            native_path = info.get("native_path", "")
-            if not force and native_path and Path(native_path).is_dir():
-                cs = check_native_clean(native_path, name)
+            elif info and info.get("native"):
+                native_path = info.get("native_path", "")
+                if native_path and Path(native_path).is_dir():
+                    cs = check_native_clean(native_path, name)
+                    if cs.clean:
+                        click.echo(f"Native workspace '{name}' is clean. ", nl=False)
+                    elif cs.error:
+                        click.confirm(
+                            f"Cannot verify cleanness ({cs.error}). "
+                            f"Permanently pop native workspace '{name}'?",
+                            abort=True,
+                        )
+                    else:
+                        reasons = format_reasons(cs.reasons)
+                        click.echo("Warning: workspace has unsaved work:")
+                        for r in reasons:
+                            click.echo(f"  - {r}")
+                        click.confirm(f"Permanently pop native workspace '{name}'?", abort=True)
+            else:
+                config = load_config()
+                runtime = get_runtime(config, ensure_ready=False)
+                cs = check_clean(runtime, name)
                 if cs.clean:
-                    click.echo(f"Native workspace '{name}' is clean. ", nl=False)
+                    click.echo(f"Bubble '{name}' is clean. ", nl=False)
                 elif cs.error:
                     click.confirm(
-                        f"Cannot verify cleanness ({cs.error}). "
-                        f"Permanently pop native workspace '{name}'?",
+                        f"Cannot verify cleanness ({cs.error}). Permanently pop bubble '{name}'?",
                         abort=True,
                     )
                 else:
                     reasons = format_reasons(cs.reasons)
-                    click.echo("Warning: workspace has unsaved work:")
+                    click.echo("Warning: bubble has unsaved work:")
                     for r in reasons:
                         click.echo(f"  - {r}")
-                    click.confirm(f"Permanently pop native workspace '{name}'?", abort=True)
+                    click.confirm(f"Permanently pop bubble '{name}'?", abort=True)
 
-            if native_path and Path(native_path).is_dir():
-                resolved = Path(native_path).resolve()
-                native_dir_resolved = NATIVE_DIR.resolve()
-                if not str(resolved).startswith(str(native_dir_resolved) + os.sep):
-                    click.echo(
-                        f"Refusing to delete: path '{native_path}' is not under {NATIVE_DIR}",
-                        err=True,
-                    )
-                    sys.exit(1)
-                shutil.rmtree(resolved)
-            _cleanup_tokens(name)
-            unregister_bubble(name)
+        success, error = destroy_bubble(name, info=info, on_progress=click.echo)
+        if not success:
+            click.echo(f"Failed to delete bubble '{name}': {error}", err=True)
+            click.echo("Try 'bubble doctor' to diagnose and fix the issue.", err=True)
+            sys.exit(1)
+
+        if info and info.get("remote_host"):
+            from ..remote import RemoteHost
+
+            host = RemoteHost.parse(info["remote_host"])
+            click.echo(f"Bubble '{name}' popped on {host.ssh_destination}.")
+        elif info and info.get("native"):
             click.echo(f"Native workspace '{name}' popped.")
-            return
-
-        config = load_config()
-        runtime = get_runtime(config, ensure_ready=False)
-
-        if not force:
-            cs = check_clean(runtime, name)
-            if cs.clean:
-                click.echo(f"Bubble '{name}' is clean. ", nl=False)
-            elif cs.error:
-                click.confirm(
-                    f"Cannot verify cleanness ({cs.error}). Permanently pop bubble '{name}'?",
-                    abort=True,
-                )
-            else:
-                reasons = format_reasons(cs.reasons)
-                click.echo("Warning: bubble has unsaved work:")
-                for r in reasons:
-                    click.echo(f"  - {r}")
-                click.confirm(f"Permanently pop bubble '{name}'?", abort=True)
-
-        for attempt in range(3):
-            try:
-                runtime.delete(name, force=True)
-                break
-            except subprocess.CalledProcessError as e:
-                msg = ((e.stderr or "") + " " + (e.stdout or "")).strip()
-                if "not found" in msg.lower() or "does not exist" in msg.lower():
-                    break  # Already gone, just clean up registry/ssh
-                if "busy" in msg.lower() and attempt < 2:
-                    click.echo(f"Container busy, retrying ({attempt + 1}/3)...")
-                    time.sleep(3 * (attempt + 1))
-                    continue
-                click.echo(f"Failed to delete container: {msg}", err=True)
-                click.echo("Try 'bubble doctor' to diagnose and fix the issue.", err=True)
-                sys.exit(1)
-
-        remove_ssh_config(name)
-        _cleanup_tokens(name)
-        unregister_bubble(name)
-        click.echo(f"Bubble '{name}' popped.")
+        else:
+            click.echo(f"Bubble '{name}' popped.")
 
     @main.command()
     @click.option("-n", "--dry-run", is_flag=True, help="Show what would be popped")

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -29,6 +29,7 @@ def finalize_bubble(
     git_email="",
     command=None,
     ai_prompt="",
+    ephemeral=False,
 ):
     """Post-clone setup: hooks, SSH, registration, and attach.
 
@@ -122,7 +123,40 @@ def finalize_bubble(
 
     if not no_interactive:
         echo_editor_opening(editor)
-        open_editor(editor, name, project_dir, workspace_file=workspace_file, command=command)
+        exit_code = open_editor(
+            editor, name, project_dir, workspace_file=workspace_file, command=command
+        )
+        if ephemeral and command:
+            _ephemeral_pop_and_exit(name, exit_code)
+
+
+def _ephemeral_pop_and_exit(name: str, exit_code: int):
+    """Pop the bubble after an --ephemeral --command run and exit.
+
+    Pop is best-effort: if it fails we still propagate the command's exit
+    code so callers can detect command failure. On pop failure, local state
+    (registry, SSH config) is preserved by destroy_bubble so the user can
+    retry with `bubble pop -f`.
+    """
+    import sys
+
+    from .commands.lifecycle import destroy_bubble
+    from .output import detail
+
+    detail(f"Popping ephemeral bubble '{name}'...")
+    error = ""
+    try:
+        ok, error = destroy_bubble(name)
+    except Exception as e:
+        ok = False
+        error = str(e)
+    if not ok:
+        click.echo(
+            f"Warning: failed to pop ephemeral bubble '{name}': "
+            f"{error or 'unknown error'}. Run 'bubble pop -f {name}' to clean up.",
+            err=True,
+        )
+    sys.exit(exit_code)
 
 
 def echo_editor_opening(editor: str):

--- a/bubble/native.py
+++ b/bubble/native.py
@@ -47,6 +47,7 @@ def open_native(
     no_interactive,
     custom_name,
     command=None,
+    ephemeral=False,
 ):
     """Open a native (non-containerized) workspace."""
     registry = RepoRegistry()
@@ -73,7 +74,11 @@ def open_native(
             click.echo()
             step(f"Reattaching to native workspace '{name}' at {native_path}")
             if not no_interactive:
-                open_editor_native(editor, native_path, command=command)
+                exit_code = open_editor_native(editor, native_path, command=command)
+                if ephemeral and command:
+                    from .finalization import _ephemeral_pop_and_exit
+
+                    _ephemeral_pop_and_exit(name, exit_code)
             return
 
     ensure_dirs()
@@ -297,4 +302,8 @@ def open_native(
             step("Opening shell...")
         else:
             step("Opening VSCode...")
-        open_editor_native(editor, str(workspace_path), command=command)
+        exit_code = open_editor_native(editor, str(workspace_path), command=command)
+        if ephemeral and command:
+            from .finalization import _ephemeral_pop_and_exit
+
+            _ephemeral_pop_and_exit(name, exit_code)

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -158,7 +158,7 @@ def open_editor(
     remote_path: str = "/home/user",
     workspace_file: str | None = None,
     command: str | None = None,
-):
+) -> int:
     """Open the specified editor connected to a bubble.
 
     If command is provided (only valid with editor="shell"), runs that command
@@ -168,9 +168,13 @@ def open_editor(
     GH_CONFIG_DIR set in /etc/profile.d/bubble-gh.sh would be missing for
     non-login shells). The command runs from remote_path, mirroring the
     interactive --shell.
+
+    Returns the exit code from the underlying editor/SSH process. For editors
+    that detach (e.g. vscode), returns 0.
     """
     if editor == "vscode":
         open_vscode(bubble_name, remote_path, workspace_file=workspace_file)
+        return 0
     elif editor in ("emacs", "neovim"):
         editor_cmd = "emacs" if editor == "emacs" else "nvim"
         # Check for build marker file (written by hooks like LeanHook.post_clone)
@@ -189,7 +193,7 @@ def open_editor(
             "-t",
             f"{marker_check}cd {shlex.quote(remote_path)} && {editor_cmd} .",
         ]
-        subprocess.run(ssh_cmd)
+        return subprocess.run(ssh_cmd).returncode
     elif editor == "shell":
         ssh_cmd = ["ssh", f"bubble-{bubble_name}"]
         if command:
@@ -205,15 +209,19 @@ def open_editor(
             # doesn't accidentally consume the marker.
             inner = f"cd {shlex.quote(remote_path)} && exec {command}"
             ssh_cmd.append(shlex.join(["bash", "-lc", inner]))
-        subprocess.run(ssh_cmd)
+        return subprocess.run(ssh_cmd).returncode
+    return 0
 
 
-def open_editor_native(editor: str, local_path: str, command: str | None = None):
+def open_editor_native(editor: str, local_path: str, command: str | None = None) -> int:
     """Open the specified editor for a native (non-containerized) workspace.
 
     Opens VSCode directly on the local path, or spawns a shell in that directory.
     If command is provided (only with editor="shell"), runs it via `bash -c`,
     matching how the SSH shell editor passes the same string to the remote shell.
+
+    Returns the exit code from the underlying process. For editors that detach
+    (e.g. vscode), returns 0.
     """
     if editor == "vscode":
         try:
@@ -224,13 +232,14 @@ def open_editor_native(editor: str, local_path: str, command: str | None = None)
             )
         except (subprocess.CalledProcessError, FileNotFoundError):
             print(f"VSCode CLI not found or failed. Open manually: {local_path}")
+        return 0
     elif editor == "shell":
         if command:
-            subprocess.run(["bash", "-c", command], cwd=local_path)
-        else:
-            subprocess.run(
-                ["bash", "-c", f"cd {shlex.quote(local_path)} && exec $SHELL"],
-            )
+            return subprocess.run(["bash", "-c", command], cwd=local_path).returncode
+        return subprocess.run(
+            ["bash", "-c", f"cd {shlex.quote(local_path)} && exec $SHELL"],
+        ).returncode
+    return 0
 
 
 def open_vscode(

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -98,7 +98,11 @@ class TestOpenEditorEmacs:
     def test_emacs_ssh_command(self, monkeypatch):
         """Emacs editor should SSH with -t and run emacs in project dir."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("emacs", "test-bubble", "/home/user/project")
         assert len(calls) == 1
         cmd = calls[0]
@@ -112,7 +116,11 @@ class TestOpenEditorEmacs:
     def test_emacs_checks_build_marker(self, monkeypatch):
         """Emacs SSH command should include marker file check for auto-build."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("emacs", "test-bubble", "/home/user/project")
         cmd = calls[0][3]
         assert ".bubble-fetch-cache" in cmd
@@ -123,7 +131,11 @@ class TestOpenEditorNeovim:
     def test_neovim_ssh_command(self, monkeypatch):
         """Neovim editor should SSH with -t and run nvim in project dir."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("neovim", "test-bubble", "/home/user/project")
         assert len(calls) == 1
         cmd = calls[0]
@@ -136,7 +148,11 @@ class TestOpenEditorNeovim:
     def test_neovim_checks_build_marker(self, monkeypatch):
         """Neovim SSH command should include marker file check for auto-build."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("neovim", "test-bubble", "/home/user/project")
         cmd = calls[0][3]
         assert ".bubble-fetch-cache" in cmd
@@ -147,14 +163,22 @@ class TestOpenEditorShell:
     def test_shell_no_command(self, monkeypatch):
         """Shell editor without command should just SSH."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("shell", "test-bubble")
         assert calls == [["ssh", "bubble-test-bubble"]]
 
     def test_shell_with_command(self, monkeypatch):
         """Shell editor wraps command in `bash -lc` and cd's into remote_path."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("shell", "test-bubble", "/home/user/proj", command="lake build")
         assert calls == [
             [
@@ -167,14 +191,22 @@ class TestOpenEditorShell:
     def test_shell_with_command_default_cwd(self, monkeypatch):
         """When no remote_path is given, fall back to /home/user."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor("shell", "test-bubble", command="pwd")
         assert calls == [["ssh", "bubble-test-bubble", "bash -lc 'cd /home/user && exec pwd'"]]
 
     def test_shell_with_quoted_command(self, monkeypatch):
         """Quoted commands are passed verbatim through the bash -lc wrapper."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append(cmd))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor(
             "shell",
             "test-bubble",
@@ -194,11 +226,57 @@ class TestOpenEditorShell:
         ]
 
 
+class TestOpenEditorReturnCode:
+    def test_shell_returns_subprocess_returncode(self, monkeypatch):
+        """open_editor with shell+command should propagate the SSH exit code."""
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 42),
+        )
+        rc = open_editor("shell", "test-bubble", command="false")
+        assert rc == 42
+
+    def test_shell_no_command_returns_returncode(self, monkeypatch):
+        """open_editor with shell (no command) should still return SSH exit code."""
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0),
+        )
+        rc = open_editor("shell", "test-bubble")
+        assert rc == 0
+
+    def test_emacs_returns_returncode(self, monkeypatch):
+        """open_editor with emacs returns the SSH exit code."""
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 7),
+        )
+        rc = open_editor("emacs", "test-bubble", "/home/user/project")
+        assert rc == 7
+
+    def test_vscode_returns_zero(self, monkeypatch):
+        """open_editor with vscode returns 0 (it detaches)."""
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0),
+        )
+        rc = open_editor("vscode", "test-bubble", "/home/user/project")
+        assert rc == 0
+
+
 class TestOpenEditorNativeShell:
     def test_native_shell_no_command(self, monkeypatch):
         """Native shell without command spawns an interactive $SHELL in cwd."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append((cmd, kw)))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append((cmd, kw)), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor_native("shell", "/tmp/proj")
         assert calls[0][0][:2] == ["bash", "-c"]
         assert "exec $SHELL" in calls[0][0][2]
@@ -206,7 +284,11 @@ class TestOpenEditorNativeShell:
     def test_native_shell_with_command(self, monkeypatch):
         """Native shell with command runs it via `bash -c` in cwd."""
         calls = []
-        monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: calls.append((cmd, kw)))
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append((cmd, kw)), subprocess.CompletedProcess(cmd, 0))[1],
+        )
         open_editor_native("shell", "/tmp/proj", command="bash -lc 'gh auth status'")
         assert calls == [(["bash", "-c", "bash -lc 'gh auth status'"], {"cwd": "/tmp/proj"})]
 

--- a/tests/test_ephemeral.py
+++ b/tests/test_ephemeral.py
@@ -1,0 +1,183 @@
+"""Tests for --ephemeral: pop the bubble after --command exits."""
+
+import subprocess
+
+import pytest
+from click.testing import CliRunner
+
+from bubble.cli import main
+
+
+class TestEphemeralValidation:
+    def test_ephemeral_without_command_errors(self):
+        """--ephemeral requires --command."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["open", "--ephemeral", "."])
+        assert result.exit_code == 1
+        assert "--ephemeral requires --command" in result.output
+
+    def test_ephemeral_with_no_interactive_errors(self):
+        """--ephemeral cannot be combined with --no-interactive."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["open", "--ephemeral", "--no-interactive", "--command", "true", "."],
+        )
+        assert result.exit_code == 1
+        assert "--ephemeral cannot be combined with --no-interactive" in result.output
+
+
+class TestEphemeralPopExitCode:
+    """Ephemeral pop happens via _ephemeral_pop_and_exit."""
+
+    def test_pops_and_propagates_exit_code(self, monkeypatch):
+        from bubble import finalization
+
+        called = {}
+
+        def fake_destroy(name, info=None):
+            called["name"] = name
+            return True, ""
+
+        monkeypatch.setattr("bubble.commands.lifecycle.destroy_bubble", fake_destroy)
+
+        with pytest.raises(SystemExit) as exc:
+            finalization._ephemeral_pop_and_exit("my-bubble", 7)
+        assert exc.value.code == 7
+        assert called["name"] == "my-bubble"
+
+    def test_propagates_zero_exit_code(self, monkeypatch):
+        from bubble import finalization
+
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.destroy_bubble", lambda name, info=None: (True, "")
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            finalization._ephemeral_pop_and_exit("my-bubble", 0)
+        assert exc.value.code == 0
+
+    def test_destroy_failure_still_propagates_exit_code(self, monkeypatch):
+        """If destroy_bubble fails, we still propagate the command's exit code."""
+        from bubble import finalization
+
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.destroy_bubble",
+            lambda name, info=None: (False, "container busy"),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            finalization._ephemeral_pop_and_exit("my-bubble", 3)
+        assert exc.value.code == 3
+
+    def test_destroy_exception_still_propagates_exit_code(self, monkeypatch):
+        """If destroy_bubble raises, we still propagate the command's exit code."""
+        from bubble import finalization
+
+        def boom(name, info=None):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr("bubble.commands.lifecycle.destroy_bubble", boom)
+
+        with pytest.raises(SystemExit) as exc:
+            finalization._ephemeral_pop_and_exit("my-bubble", 5)
+        assert exc.value.code == 5
+
+
+class TestDestroyBubble:
+    """destroy_bubble preserves local state on failure."""
+
+    def test_native_outside_native_dir_fails(self, tmp_path, monkeypatch):
+        """Refuses to delete native paths outside NATIVE_DIR; preserves state."""
+        from bubble.commands import lifecycle
+
+        # Build an info entry with a path outside NATIVE_DIR
+        bad_path = tmp_path / "outside-native-dir"
+        bad_path.mkdir()
+        info = {"native": True, "native_path": str(bad_path)}
+
+        unregistered = []
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.unregister_bubble",
+            lambda name: unregistered.append(name),
+        )
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle._cleanup_tokens",
+            lambda *a, **kw: None,
+        )
+
+        ok, err = lifecycle.destroy_bubble("foo", info=info)
+        assert ok is False
+        assert "Refusing to delete" in err
+        assert unregistered == []  # local state preserved
+        assert bad_path.exists()  # path not deleted
+
+    def test_local_delete_failure_preserves_state(self, monkeypatch):
+        """If runtime.delete raises an unrecognized error, leave registry intact."""
+        from bubble.commands import lifecycle
+
+        unregistered = []
+        cleaned = []
+        ssh_removed = []
+
+        class FakeRuntime:
+            def delete(self, name, force=True):
+                raise subprocess.CalledProcessError(
+                    1, ["incus", "delete", name], stderr="some unrecoverable error"
+                )
+
+        monkeypatch.setattr("bubble.commands.lifecycle.load_config", lambda: {})
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.get_runtime",
+            lambda config, ensure_ready=False: FakeRuntime(),
+        )
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.unregister_bubble",
+            lambda name: unregistered.append(name),
+        )
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle._cleanup_tokens",
+            lambda *a, **kw: cleaned.append(a),
+        )
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.remove_ssh_config",
+            lambda name: ssh_removed.append(name),
+        )
+
+        # Pretend it's a local container (no remote_host, not native)
+        info = {}
+        ok, err = lifecycle.destroy_bubble("foo", info=info)
+        assert ok is False
+        assert "unrecoverable" in err
+        assert unregistered == []
+        assert cleaned == []
+        assert ssh_removed == []
+
+    def test_local_already_gone_succeeds_and_cleans_up(self, monkeypatch):
+        """If runtime says container is already gone, treat as success."""
+        from bubble.commands import lifecycle
+
+        unregistered = []
+
+        class FakeRuntime:
+            def delete(self, name, force=True):
+                raise subprocess.CalledProcessError(
+                    1, ["incus", "delete", name], stderr="Error: container not found"
+                )
+
+        monkeypatch.setattr("bubble.commands.lifecycle.load_config", lambda: {})
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.get_runtime",
+            lambda config, ensure_ready=False: FakeRuntime(),
+        )
+        monkeypatch.setattr(
+            "bubble.commands.lifecycle.unregister_bubble",
+            lambda name: unregistered.append(name),
+        )
+        monkeypatch.setattr("bubble.commands.lifecycle._cleanup_tokens", lambda *a, **kw: None)
+        monkeypatch.setattr("bubble.commands.lifecycle.remove_ssh_config", lambda name: None)
+
+        ok, err = lifecycle.destroy_bubble("foo", info={})
+        assert ok is True
+        assert err == ""
+        assert unregistered == ["foo"]


### PR DESCRIPTION
This PR adds an `--ephemeral` flag to `bubble open` that pops the bubble after `--command` exits, propagating the command's exit code as bubble's own exit code. This gives `pod`-style automation a clean "run X in a fresh bubble" primitive without per-bubble cleanup bookkeeping.

```
bubble --path <wt> --shell --command 'X' --ephemeral
```

`--ephemeral` requires `--command` and is incompatible with `--no-interactive`. It works for create, reattach, remote, and native flows.

Internally, the destroy logic from `bubble pop` is extracted into a shared `destroy_bubble(name)` helper that returns `(success, error_message)` and only cleans up local state (registry, SSH config, tunnels) on confirmed success — so a failed pop leaves the bubble recoverable via `bubble pop -f`. Closes https://github.com/kim-em/bubble/issues/266.

🤖 Prepared with Claude Code