### PR TITLE
fix: atomic, locked, symlink-safe SSH config writes

### DIFF
--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -1,9 +1,15 @@
 """VSCode Remote SSH integration."""
 
+import contextlib
+import fcntl
+import os
 import re
 import shlex
 import subprocess
+import tempfile
 from pathlib import Path
+
+from .config import DATA_DIR
 
 # Valid bubble name pattern (alphanumeric + hyphens, starts with letter)
 _BUBBLE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
@@ -11,6 +17,41 @@ _BUBBLE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 SSH_CONFIG_DIR = Path.home() / ".ssh" / "config.d"
 SSH_CONFIG_FILE = SSH_CONFIG_DIR / "bubble"
 SSH_MAIN_CONFIG = Path.home() / ".ssh" / "config"
+_SSH_CONFIG_LOCK_FILE = DATA_DIR / "ssh-config.lock"
+
+
+@contextlib.contextmanager
+def _ssh_config_lock():
+    """Serialize all SSH-config writes (add/remove + Include directive)."""
+    _SSH_CONFIG_LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(_SSH_CONFIG_LOCK_FILE, "w") as fd:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Atomically replace *path* with *content*, preserving symlinks and mode.
+
+    If *path* is a symlink, writes to (and replaces) the symlink target rather
+    than clobbering the symlink itself — important for users whose
+    ~/.ssh/config is symlinked from a dotfiles repo.
+    """
+    real = path.resolve() if path.is_symlink() else path
+    real.parent.mkdir(parents=True, exist_ok=True)
+    mode = real.stat().st_mode & 0o777 if real.exists() else 0o600
+    fd, tmp = tempfile.mkstemp(prefix=real.name + ".", dir=str(real.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.chmod(tmp, mode)
+        os.replace(tmp, real)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp)
+        raise
 
 
 def add_ssh_config(
@@ -30,7 +71,6 @@ def add_ssh_config(
     """
     if not _BUBBLE_NAME_RE.match(bubble_name):
         raise ValueError(f"Invalid bubble name for SSH config: {bubble_name!r}")
-    SSH_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
     incus_cmd = f'incus exec {bubble_name} -- su - {user} -c "nc localhost 22"'
 
@@ -59,47 +99,57 @@ def add_ssh_config(
     lines.append("  LogLevel ERROR")
 
     entry = "\n" + "\n".join(lines) + "\n"
-    # Append to config file
-    with open(SSH_CONFIG_FILE, "a") as f:
-        f.write(entry)
-
-    _ensure_include_directive()
+    with _ssh_config_lock():
+        SSH_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        existing = SSH_CONFIG_FILE.read_text() if SSH_CONFIG_FILE.exists() else ""
+        _atomic_write_text(SSH_CONFIG_FILE, existing + entry)
+        _ensure_include_directive_locked()
 
 
 def remove_ssh_config(bubble_name: str):
     """Remove an SSH config entry for a bubble."""
-    if not SSH_CONFIG_FILE.exists():
-        return
+    with _ssh_config_lock():
+        if not SSH_CONFIG_FILE.exists():
+            return
 
-    lines = SSH_CONFIG_FILE.read_text().splitlines()
-    result = []
-    skip = False
-    for line in lines:
-        if line.strip() == f"Host bubble-{bubble_name}":
-            skip = True
-            continue
-        if skip and line.strip().startswith("Host "):
-            skip = False
-        if not skip:
-            result.append(line)
+        lines = SSH_CONFIG_FILE.read_text().splitlines()
+        result = []
+        skip = False
+        for line in lines:
+            if line.strip() == f"Host bubble-{bubble_name}":
+                skip = True
+                continue
+            if skip and line.strip().startswith("Host "):
+                skip = False
+            if not skip:
+                result.append(line)
 
-    SSH_CONFIG_FILE.write_text("\n".join(result) + "\n" if result else "")
+        new_content = "\n".join(result) + "\n" if result else ""
+        _atomic_write_text(SSH_CONFIG_FILE, new_content)
 
 
-def _ensure_include_directive():
-    """Ensure ~/.ssh/config includes our config.d directory."""
+def _ensure_include_directive_locked():
+    """Ensure ~/.ssh/config includes our config.d directory.
+
+    Caller must hold _ssh_config_lock().
+    """
     ssh_config = SSH_MAIN_CONFIG
     include_line = f"Include {SSH_CONFIG_DIR}/*"
 
-    if ssh_config.exists():
-        content = ssh_config.read_text()
+    if ssh_config.exists() or ssh_config.is_symlink():
+        # is_symlink() check covers a symlink whose target is missing — we
+        # still want to update the linked file rather than create a sibling.
+        try:
+            content = ssh_config.read_text()
+        except FileNotFoundError:
+            content = ""
         if include_line in content:
             return
         # Prepend the include (must be at top of ssh config)
-        ssh_config.write_text(include_line + "\n\n" + content)
+        _atomic_write_text(ssh_config, include_line + "\n\n" + content)
     else:
         ssh_config.parent.mkdir(parents=True, exist_ok=True)
-        ssh_config.write_text(include_line + "\n")
+        _atomic_write_text(ssh_config, include_line + "\n")
 
 
 def open_editor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,6 +177,7 @@ def tmp_ssh_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(vscode, "SSH_CONFIG_DIR", ssh_dir)
     monkeypatch.setattr(vscode, "SSH_CONFIG_FILE", ssh_file)
     monkeypatch.setattr(vscode, "SSH_MAIN_CONFIG", tmp_path / ".ssh" / "config")
+    monkeypatch.setattr(vscode, "_SSH_CONFIG_LOCK_FILE", tmp_path / "ssh-config.lock")
 
     return ssh_dir
 

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -79,6 +79,81 @@ class TestRemoveSshConfig:
         assert content_before == content_after
 
 
+class TestAtomicSshConfig:
+    """SSH config writes survive process death and don't clobber dotfiles symlinks."""
+
+    def test_failed_write_leaves_original_intact(self, tmp_ssh_dir, monkeypatch):
+        """If os.replace raises mid-write, the original ~/.ssh/config is unchanged."""
+        import os as real_os
+
+        from bubble import vscode
+
+        add_ssh_config("first")
+        original = (tmp_ssh_dir / "bubble").read_text()
+
+        replace_calls = {"n": 0}
+        real_replace = real_os.replace
+
+        def flaky_replace(src, dst):
+            # Let the SSH_MAIN_CONFIG include-directive write succeed; fail on
+            # the bubble-config write itself.
+            if str(dst).endswith("/bubble"):
+                replace_calls["n"] += 1
+                raise OSError("simulated kill mid-replace")
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(vscode.os, "replace", flaky_replace)
+
+        with pytest.raises(OSError, match="simulated"):
+            add_ssh_config("second")
+
+        # Original content preserved
+        assert (tmp_ssh_dir / "bubble").read_text() == original
+        assert replace_calls["n"] == 1
+        # No leftover temp files in the dir
+        leftovers = [p.name for p in tmp_ssh_dir.iterdir() if p.name.startswith("bubble.")]
+        assert leftovers == []
+
+    def test_main_config_symlink_is_preserved(self, tmp_ssh_dir, tmp_path):
+        """Writing through a symlinked ~/.ssh/config updates the target, not the link."""
+        from bubble import vscode
+
+        # Simulate a dotfiles-style setup: ~/.ssh/config -> dotfiles/ssh_config
+        dotfiles = tmp_path / "dotfiles"
+        dotfiles.mkdir()
+        real_target = dotfiles / "ssh_config"
+        real_target.write_text("# user dotfiles\n")
+        vscode.SSH_MAIN_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        vscode.SSH_MAIN_CONFIG.symlink_to(real_target)
+
+        add_ssh_config("symlink-bubble")
+
+        # Symlink itself is preserved
+        assert vscode.SSH_MAIN_CONFIG.is_symlink()
+        assert vscode.SSH_MAIN_CONFIG.resolve() == real_target.resolve()
+        # Original content preserved + Include line prepended
+        content = real_target.read_text()
+        assert "# user dotfiles" in content
+        assert "Include " in content
+
+    def test_concurrent_adds_do_not_lose_entries(self, tmp_ssh_dir):
+        """Two processes calling add_ssh_config concurrently both win."""
+        import multiprocessing as mp
+
+        # Use spawn so child re-imports modules cleanly
+        ctx = mp.get_context("fork")
+        procs = [ctx.Process(target=add_ssh_config, args=(f"concurrent-{i}",)) for i in range(8)]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=10)
+            assert p.exitcode == 0
+
+        content = (tmp_ssh_dir / "bubble").read_text()
+        for i in range(8):
+            assert f"Host bubble-concurrent-{i}" in content
+
+
 class TestRemoteProxyCommand:
     def test_chained_proxy_with_default_port(self, tmp_ssh_dir):
         ssh_file = tmp_ssh_dir / "bubble"


### PR DESCRIPTION
This PR hardens the three SSH-config write paths in bubble/vscode.py against truncation, symlink-clobber, and lost-update races.

The current code does write_text() and \"a\"-mode appends against ~/.ssh/config and ~/.ssh/config.d/bubble. Three problems:

1. If the process is killed mid-write, the file is truncated and the user loses every Host entry they had.
2. write_text() through a symlinked ~/.ssh/config (common in dotfiles setups) replaces the symlink with a regular file, severing the link.
3. add_ssh_config / remove_ssh_config / the include-directive writer are all read-modify-write under the hood, and can race across concurrent bubble open / pop / doctor calls and lose updates.

Fixes:

- _atomic_write_text() writes via tempfile.mkstemp + os.replace, resolves symlinks so the link itself is preserved, and stat()s the target to preserve its mode (defaulting to 0600 when creating fresh).
- _ssh_config_lock() is an fcntl LOCK_EX over a lock file under ~/.bubble/, serializing all three writers.
- add_ssh_config is now read-modify-write inside the lock, matching remove_ssh_config.
- Helper renamed _ensure_include_directive → _ensure_include_directive_locked to make the contract explicit.

Tests cover: a simulated os.replace failure mid-write leaves the original ~/.ssh/config.d/bubble intact, a symlinked ~/.ssh/config has its link preserved while the target is updated, and 8 concurrent add_ssh_config processes all land their entries.

Plan: second of four small PRs hardening filesystem-safety. Stacks logically after https://github.com/kim-em/bubble/pull/274 but doesn't depend on it.

🤖 Prepared with Claude Code