### PR TITLE
fix: rename ai-projects aside instead of rmtree on migration

### DIFF
--- a/bubble/config.py
+++ b/bubble/config.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -514,7 +516,15 @@ def do_symlink_ai_projects() -> bool:
     """Link ~/.bubble/ai-projects/ to ~/.claude/projects/ via symlink.
 
     Merges existing contents from bubble-projects into claude-projects before
-    creating the symlink. Aborts if any files conflict (exist in both locations).
+    creating the symlink. Aborts if any files conflict (exist in both
+    locations).
+
+    Anything left in ~/.bubble/ai-projects/ after the merge (residual empty
+    directories, or files that appeared during the merge from a concurrently-
+    running bubble) is renamed aside to ai-projects.old.<timestamp>.<rand>/
+    rather than deleted. The user can inspect and remove that directory once
+    they're satisfied the merge worked.
+
     Returns True if the symlink was created, False otherwise.
     """
     import click
@@ -563,9 +573,31 @@ def do_symlink_ai_projects() -> bool:
 
     # Pass 2: no conflicts, safe to merge
     _merge_dir(bubble_projects, claude_projects)
-    shutil.rmtree(str(bubble_projects))
-    bubble_projects.symlink_to(claude_projects)
+
+    # Rename the (now-residual) source aside instead of rmtree'ing it.
+    # mkdtemp gives a guaranteed-unique suffix; rename() needs the target
+    # to be absent so we remove the empty placeholder it creates.
+    backup = Path(
+        tempfile.mkdtemp(
+            prefix=f"ai-projects.old.{time.strftime('%Y%m%d-%H%M%S')}.",
+            dir=str(bubble_projects.parent),
+        )
+    )
+    backup.rmdir()
+    bubble_projects.rename(backup)
+    try:
+        bubble_projects.symlink_to(claude_projects)
+    except OSError:
+        # Symlink failed: roll the directory back so the user is not left
+        # without ~/.bubble/ai-projects/ at all.
+        backup.rename(bubble_projects)
+        raise
+
     click.echo(f"Created symlink: {bubble_projects} -> {claude_projects}")
+    click.echo(
+        f"Residual data from the merge is at {backup}. "
+        "Inspect and remove once you're satisfied the merge worked."
+    )
     return True
 
 

--- a/tests/test_claude_projects_symlink.py
+++ b/tests/test_claude_projects_symlink.py
@@ -295,6 +295,55 @@ class TestDoSymlinkClaudeProjects:
 
         assert result is True
 
+    def test_renames_residual_directory_aside(self, setup_dirs):
+        """After merge, ~/.bubble/ai-projects/ is renamed aside, not deleted."""
+        claude_projects, bubble_projects = setup_dirs
+        bubble_projects.mkdir()
+
+        (bubble_projects / "session-a").mkdir()
+        (bubble_projects / "session-a" / "data.jsonl").write_text("data")
+
+        with patch("bubble.config._is_inside_git_repo", return_value=True):
+            result = do_symlink_ai_projects()
+
+        assert result is True
+        # Symlink in place
+        assert bubble_projects.is_symlink()
+        # Backup directory should exist alongside it (residual empty subtree)
+        backups = list(bubble_projects.parent.glob("ai-projects.old.*"))
+        assert len(backups) == 1, f"expected 1 backup dir, got {backups}"
+        # Real session data was moved (not in the backup)
+        assert (claude_projects / "session-a" / "data.jsonl").read_text() == "data"
+
+    def test_symlink_failure_rolls_back_rename(self, setup_dirs, monkeypatch):
+        """If symlink_to() fails, ~/.bubble/ai-projects/ is restored from the backup."""
+        claude_projects, bubble_projects = setup_dirs
+        bubble_projects.mkdir()
+        (bubble_projects / "session-a").mkdir()
+
+        from pathlib import Path as RealPath
+
+        original_symlink_to = RealPath.symlink_to
+
+        def boom(self, *args, **kwargs):
+            if self == bubble_projects:
+                raise OSError("simulated symlink failure")
+            return original_symlink_to(self, *args, **kwargs)
+
+        monkeypatch.setattr(RealPath, "symlink_to", boom)
+
+        with (
+            patch("bubble.config._is_inside_git_repo", return_value=True),
+            pytest.raises(OSError, match="simulated"),
+        ):
+            do_symlink_ai_projects()
+
+        # Roll-back: ai-projects/ exists again, and no backup directory remains
+        assert bubble_projects.is_dir()
+        assert not bubble_projects.is_symlink()
+        backups = list(bubble_projects.parent.glob("ai-projects.old.*"))
+        assert backups == []
+
 
 class TestSymlinkClaudeProjectsCLI:
     def test_exit_code_on_failure(self, setup_dirs):


### PR DESCRIPTION
This PR replaces the destructive rmtree() in do_symlink_ai_projects() with a mkdtemp-based rename-aside, plus a roll-back path if the symlink itself fails.

Today the migration code in bubble/config.py does:

    _merge_dir(bubble_projects, claude_projects)
    shutil.rmtree(str(bubble_projects))
    bubble_projects.symlink_to(claude_projects)

Two failure modes:

- If _merge_dir() fails partway through (disk full, permission error, race with a running bubble writing a new AI session), some files have already been moved and the rmtree silently deletes the rest.
- If symlink_to() fails after the rmtree, the user is left with no ~/.bubble/ai-projects/ at all and no recovery information.

Fix:

- Rename the now-residual source directory aside to ai-projects.old.<timestamp>.<rand>/. mkdtemp gives a guaranteed-unique suffix — a 1-second-resolution timestamp can collide on repeat runs.
- On symlink_to() failure, rename the backup back into place so the user is never left without ai-projects/ at all.
- Update the docstring to clarify this preserves \"residual data\" rather than a true full pre-migration backup (since _merge_dir() has already moved files when we get here).
- Print a one-line message so the user knows where to look and that they can delete it once they're satisfied.

Tests cover the residual-aside behavior and the rollback path.

Plan: third of four small PRs hardening filesystem-safety. Independent of https://github.com/kim-em/bubble/pull/274 and https://github.com/kim-em/bubble/pull/275.

🤖 Prepared with Claude Code