### PR TITLE
fix: drive a dedicated 'bubble-colima' Colima profile

### DIFF
--- a/bubble/commands/doctor.py
+++ b/bubble/commands/doctor.py
@@ -1,6 +1,5 @@
 """The 'doctor' diagnostic command."""
 
-import json
 import subprocess
 import sys
 
@@ -91,16 +90,9 @@ def register_doctor_command(main):
         # 2. Check for stuck incus operations
         click.echo("Checking for stuck operations...")
         try:
-            result = subprocess.run(
-                ["incus", "operation", "list", "--format=json"],
-                capture_output=True,
-                text=True,
-                check=True,
-                stdin=subprocess.DEVNULL,
-            )
+            all_ops = runtime.list_operations()
             _restore_terminal(saved_tty)
 
-            all_ops = json.loads(result.stdout) if result.stdout.strip() else []
             # websocket ops are active exec/console sessions (e.g. VS Code SSH), not stuck
             # Only "Running" operations can be stuck; "Success"/"Failure"/"Cancelled" are
             # just completed history that Incus retains temporarily.
@@ -123,14 +115,7 @@ def register_doctor_command(main):
                         if not op_id:
                             continue
                         try:
-                            subprocess.run(
-                                ["incus", "operation", "delete", op_id],
-                                capture_output=True,
-                                text=True,
-                                check=True,
-                                timeout=10,
-                                stdin=subprocess.DEVNULL,
-                            )
+                            runtime.delete_operation(op_id)
                             cancelled += 1
                         except subprocess.CalledProcessError as e:
                             msg = (e.stderr or "").strip()
@@ -146,7 +131,7 @@ def register_doctor_command(main):
                             click.echo(err_msg, err=True)
             else:
                 click.echo("  No stuck operations.")
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, RuntimeError):
             click.echo("  Could not check operations (incus unavailable).")
 
         # 3. Check registry vs actual containers

--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -89,29 +89,21 @@ IMAGES = {
 }
 
 
-def _get_bridge_dns_ip() -> str | None:
+def _get_bridge_dns_ip(runtime: ContainerRuntime) -> str | None:
     """Get the IPv4 address of the default incus bridge (for DNS proxy workaround)."""
-    cidr = _get_bridge_cidr()
+    cidr = _get_bridge_cidr(runtime)
     if cidr:
         return cidr.split("/")[0]
     return None
 
 
-def _get_bridge_cidr() -> str | None:
+def _get_bridge_cidr(runtime: ContainerRuntime) -> str | None:
     """Get the full CIDR of the incus bridge (e.g. '10.228.152.1/24')."""
     try:
-        result = subprocess.run(
-            ["incus", "network", "get", "incusbr0", "ipv4.address"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            stdin=subprocess.DEVNULL,
-        )
-        if result.returncode == 0:
-            cidr = result.stdout.strip()
-            if "/" in cidr:
-                return cidr
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+        cidr = runtime.network_get("incusbr0", "ipv4.address").strip()
+        if "/" in cidr:
+            return cidr
+    except (subprocess.TimeoutExpired, FileNotFoundError, RuntimeError):
         pass
     return None
 
@@ -131,7 +123,7 @@ def _fix_ipv4_static(runtime: ContainerRuntime, name: str) -> bool:
     Picks an address in the bridge subnet and configures it directly.
     Returns True if IPv4 was successfully configured.
     """
-    cidr = _get_bridge_cidr()
+    cidr = _get_bridge_cidr(runtime)
     if not cidr:
         return False
 
@@ -167,7 +159,7 @@ def _fix_dns_with_proxy(runtime: ContainerRuntime, name: str) -> bool:
 
     Returns True if the fix was applied and DNS works.
     """
-    dns_ip = _get_bridge_dns_ip()
+    dns_ip = _get_bridge_dns_ip(runtime)
     if not dns_ip:
         return False
 

--- a/bubble/runtime/base.py
+++ b/bubble/runtime/base.py
@@ -28,6 +28,16 @@ class ContainerRuntime(ABC):
     backend errors uniformly.
     """
 
+    def qualify(self, name: str) -> str:
+        """Qualify a resource name with the runtime's remote prefix, if any.
+
+        For the default Incus backend on Linux this is the identity function.
+        On macOS-via-Colima the runtime targets a non-default Incus remote
+        and this returns ``"<remote>:<name>"`` so callers don't have to depend
+        on the user's default remote being set to ours.
+        """
+        return name
+
     @abstractmethod
     def is_available(self) -> bool:
         """Check if the runtime is available."""

--- a/bubble/runtime/colima.py
+++ b/bubble/runtime/colima.py
@@ -8,13 +8,38 @@ import subprocess
 import sys
 from pathlib import Path
 
+# bubble drives a dedicated Colima profile rather than the default one.
+# This isolates bubble's VM from any unrelated Colima profile a user may
+# already have running, and lets us safely operate on its files.
+BUBBLE_COLIMA_PROFILE = "bubble-colima"
+
+# The matching incus remote alias.  We pick the same name as the profile
+# for consistency; collision risk with a user-defined remote is checked
+# before we ever switch the default.
+BUBBLE_INCUS_REMOTE = "bubble-colima"
+
+# Colima per-profile state lives here.
+COLIMA_HOME = Path.home() / ".colima"
+COLIMA_PROFILE_DIR = COLIMA_HOME / BUBBLE_COLIMA_PROFILE
+COLIMA_LIMA_DIR = COLIMA_HOME / "_lima" / BUBBLE_COLIMA_PROFILE
+
+
+def _colima_args(*subcommand_args: str) -> list[str]:
+    """Build a colima command line targeting bubble's profile.
+
+    Uses the global ``--profile`` flag rather than the positional profile
+    argument because not all colima subcommands accept the positional form
+    (notably ``colima ssh``).
+    """
+    return ["colima", "--profile", BUBBLE_COLIMA_PROFILE, *subcommand_args]
+
 
 def is_colima_running() -> bool:
     try:
         # colima status can fail even when the VM is running (e.g. empty
         # runtime field in colima 0.10.x), so fall back to colima list.
         result = subprocess.run(
-            ["colima", "status"],
+            _colima_args("status"),
             capture_output=True,
             text=True,
             check=False,
@@ -37,7 +62,7 @@ def is_colima_running() -> bool:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if entry.get("name") == "default" and entry.get("status") == "Running":
+                if entry.get("name") == BUBBLE_COLIMA_PROFILE and entry.get("status") == "Running":
                     return True
         return False
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -54,6 +79,7 @@ def _colima_supports_vm_type() -> bool:
             timeout=5,
             stdin=subprocess.DEVNULL,
         )
+        # --help describes flags regardless of profile, so no need to scope it.
         return "--vm-type" in result.stdout
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
@@ -117,14 +143,13 @@ def _run_colima_start(args: list[str]) -> subprocess.CompletedProcess:
 
 def start_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
     """Start Colima with incus runtime and specified resources."""
-    args = [
-        "colima",
+    args = _colima_args(
         "start",
         "--runtime=incus",
         f"--cpu={cpu}",
         f"--memory={memory}",
         f"--disk={disk}",
-    ]
+    )
     if _colima_supports_vm_type():
         args.append(f"--vm-type={vm_type}")
     result = _run_colima_start(args)
@@ -132,15 +157,15 @@ def start_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
         if "already exists" in result.stdout:
             # Stale instance exists but isn't running — delete and retry
             subprocess.run(
-                ["colima", "delete", "--force"],
+                _colima_args("delete", "--force"),
                 check=False,
                 stdin=subprocess.DEVNULL,
             )
             # colima delete can fail if lima.yaml is missing, leaving
-            # the instance directory behind. Remove it manually.
-            lima_dir = Path.home() / ".colima" / "_lima" / "colima"
-            if lima_dir.exists():
-                shutil.rmtree(lima_dir)
+            # the bubble-colima profile's Lima dir behind.  Only remove
+            # the bubble-owned dir — never touch other profiles.
+            if COLIMA_LIMA_DIR.exists():
+                shutil.rmtree(COLIMA_LIMA_DIR)
             result = _run_colima_start(args)
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, args, output=result.stdout)
@@ -149,11 +174,17 @@ def start_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
 
 
 def _ensure_incus_remote():
-    """Ensure the incus client is configured to talk to Colima's incus socket."""
-    sock = Path.home() / ".colima" / "default" / "incus.sock"
+    """Ensure the incus client is configured to talk to bubble's Colima socket.
+
+    If a remote alias matching BUBBLE_INCUS_REMOTE already exists but points
+    somewhere other than our expected unix socket, refuse to clobber it and
+    surface a clear error to stderr instead of silently switching the user's
+    default to the wrong place.
+    """
+    sock = COLIMA_PROFILE_DIR / "incus.sock"
     if not sock.exists():
         return
-    sock_uri = f"unix://{sock}"
+    expected_addr = f"unix://{sock}"
 
     try:
         result = subprocess.run(
@@ -168,10 +199,10 @@ def _ensure_incus_remote():
     except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         current = ""
 
-    if current == "colima":
+    if current == BUBBLE_INCUS_REMOTE:
         return
 
-    # Add the colima remote if it doesn't exist
+    # Inspect the existing remote list before adding/switching.
     result = subprocess.run(
         ["incus", "remote", "list", "--format=json"],
         capture_output=True,
@@ -180,23 +211,36 @@ def _ensure_incus_remote():
         timeout=10,
         stdin=subprocess.DEVNULL,
     )
+    remotes: dict = {}
     if result.returncode == 0:
         try:
             remotes = json.loads(result.stdout)
         except json.JSONDecodeError:
             remotes = {}
-        if "colima" not in remotes:
-            subprocess.run(
-                ["incus", "remote", "add", "colima", sock_uri],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=10,
-                stdin=subprocess.DEVNULL,
+
+    if BUBBLE_INCUS_REMOTE in remotes:
+        existing_addr = remotes[BUBBLE_INCUS_REMOTE].get("Addr", "")
+        if existing_addr != expected_addr:
+            print(
+                f"Refusing to overwrite incus remote '{BUBBLE_INCUS_REMOTE}': "
+                f"its address is {existing_addr!r}, expected {expected_addr!r}. "
+                f"Remove it (`incus remote remove {BUBBLE_INCUS_REMOTE}`) and "
+                "retry.",
+                file=sys.stderr,
             )
+            return
+    else:
+        subprocess.run(
+            ["incus", "remote", "add", BUBBLE_INCUS_REMOTE, expected_addr],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+        )
 
     subprocess.run(
-        ["incus", "remote", "switch", "colima"],
+        ["incus", "remote", "switch", BUBBLE_INCUS_REMOTE],
         capture_output=True,
         text=True,
         check=False,
@@ -209,7 +253,7 @@ def _check_colima_dns() -> bool:
     """Check if DNS resolution works inside the Colima VM."""
     try:
         result = subprocess.run(
-            ["colima", "ssh", "--", "cat", "/etc/resolv.conf"],
+            _colima_args("ssh", "--", "cat", "/etc/resolv.conf"),
             capture_output=True,
             text=True,
             timeout=10,
@@ -225,7 +269,7 @@ def _check_colima_dns() -> bool:
 
 def _remove_stale_ssh_socket():
     """Remove a stale SSH control socket that can cause colima commands to hang."""
-    sock = Path.home() / ".colima" / "_lima" / "colima" / "ssh.sock"
+    sock = COLIMA_LIMA_DIR / "ssh.sock"
     if sock.exists():
         try:
             sock.unlink()
@@ -243,7 +287,7 @@ def ensure_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
         print("Colima VM DNS is broken, restarting...", file=sys.stderr)
         try:
             subprocess.run(
-                ["colima", "stop"],
+                _colima_args("stop"),
                 capture_output=True,
                 check=False,
                 timeout=30,
@@ -253,7 +297,7 @@ def ensure_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
             print("Colima stop timed out, forcing...", file=sys.stderr)
             try:
                 subprocess.run(
-                    ["colima", "stop", "--force"],
+                    _colima_args("stop", "--force"),
                     capture_output=True,
                     check=False,
                     timeout=15,
@@ -275,7 +319,7 @@ def colima_host_ip() -> str:
     """
     try:
         result = subprocess.run(
-            ["colima", "ssh", "--", "getent", "hosts", "host.lima.internal"],
+            _colima_args("ssh", "--", "getent", "hosts", "host.lima.internal"),
             capture_output=True,
             text=True,
             timeout=10,

--- a/bubble/runtime/colima.py
+++ b/bubble/runtime/colima.py
@@ -174,35 +174,22 @@ def start_colima(cpu: int, memory: int, disk: int = 60, vm_type: str = "vz"):
 
 
 def _ensure_incus_remote():
-    """Ensure the incus client is configured to talk to bubble's Colima socket.
+    """Ensure the incus client knows about bubble's Colima socket.
 
-    If a remote alias matching BUBBLE_INCUS_REMOTE already exists but points
-    somewhere other than our expected unix socket, refuse to clobber it and
-    surface a clear error to stderr instead of silently switching the user's
-    default to the wrong place.
+    Adds an incus remote alias pointing at the bubble-colima profile's Unix
+    socket if it doesn't already exist.  Bubble does **not** switch the
+    user's default remote — instead it targets resources by prefixing them
+    with ``bubble-colima:`` (see :class:`IncusRuntime`).
+
+    If a remote alias matching ``BUBBLE_INCUS_REMOTE`` already exists but
+    points somewhere other than our expected unix socket, refuse to clobber
+    it and surface a clear error to stderr.
     """
     sock = COLIMA_PROFILE_DIR / "incus.sock"
     if not sock.exists():
         return
     expected_addr = f"unix://{sock}"
 
-    try:
-        result = subprocess.run(
-            ["incus", "remote", "get-default"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=10,
-            stdin=subprocess.DEVNULL,
-        )
-        current = result.stdout.strip()
-    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        current = ""
-
-    if current == BUBBLE_INCUS_REMOTE:
-        return
-
-    # Inspect the existing remote list before adding/switching.
     result = subprocess.run(
         ["incus", "remote", "list", "--format=json"],
         capture_output=True,
@@ -228,19 +215,10 @@ def _ensure_incus_remote():
                 "retry.",
                 file=sys.stderr,
             )
-            return
-    else:
-        subprocess.run(
-            ["incus", "remote", "add", BUBBLE_INCUS_REMOTE, expected_addr],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=10,
-            stdin=subprocess.DEVNULL,
-        )
+        return
 
     subprocess.run(
-        ["incus", "remote", "switch", BUBBLE_INCUS_REMOTE],
+        ["incus", "remote", "add", BUBBLE_INCUS_REMOTE, expected_addr],
         capture_output=True,
         text=True,
         check=False,

--- a/bubble/runtime/incus.py
+++ b/bubble/runtime/incus.py
@@ -27,7 +27,32 @@ class IncusError(subprocess.CalledProcessError, RuntimeError):
 
 
 class IncusRuntime(ContainerRuntime):
-    """Container runtime using Incus."""
+    """Container runtime using Incus.
+
+    The optional ``remote`` constructor argument names a non-default
+    Incus remote that all resource references will be prefixed with
+    (e.g. ``"bubble-colima"`` on macOS).  When empty, container/image
+    names are passed through unchanged and the user's current default
+    remote applies — bubble does not switch it.
+    """
+
+    def __init__(self, remote: str = ""):
+        self._remote = remote
+
+    def qualify(self, name: str) -> str:
+        """Prefix *name* with our remote if one is configured.
+
+        Names that already contain ``:`` are assumed to be explicitly
+        qualified by the caller and pass through unchanged.
+        """
+        if self._remote and ":" not in name:
+            return f"{self._remote}:{name}"
+        return name
+
+    def _q(self, name: str) -> str:
+        # Internal alias matching the public method, kept short so call sites
+        # stay readable.
+        return self.qualify(name)
 
     def _run(self, args: list[str], check: bool = True, capture: bool = True) -> str:
         """Run an incus command."""
@@ -74,7 +99,7 @@ class IncusRuntime(ContainerRuntime):
             return False
 
     def launch(self, name: str, image: str, **kwargs) -> ContainerInfo:
-        args = ["launch", image, name]
+        args = ["launch", self._q(image), self._q(name)]
         self._run(args)
         return self._get_info(name)
 
@@ -118,13 +143,15 @@ class IncusRuntime(ContainerRuntime):
 
     def _get_info(self, name: str) -> ContainerInfo:
         """Get info for a single container."""
-        data = self._run_json(["list", name])
+        data = self._run_json(["list", self._q(name)])
         if not data:
             raise RuntimeError(f"Container '{name}' not found")
         return self._parse_container(data[0])
 
     def list_containers(self, fast: bool = True) -> list[ContainerInfo]:
-        args = ["list"]
+        # When a remote is set, pass "remote:" with no name so list scopes
+        # to that remote rather than the user's default.
+        args = ["list", self._q("")] if self._remote else ["list"]
         if fast:
             args.append("--fast")
         data = self._run_json(args)
@@ -133,25 +160,25 @@ class IncusRuntime(ContainerRuntime):
         return [self._parse_container(c) for c in data]
 
     def start(self, name: str):
-        self._run(["start", name])
+        self._run(["start", self._q(name)])
 
     def stop(self, name: str):
-        self._run(["stop", name])
+        self._run(["stop", self._q(name)])
 
     def freeze(self, name: str):
-        self._run(["pause", name])
+        self._run(["pause", self._q(name)])
 
     def unfreeze(self, name: str):
-        self._run(["start", name])  # unpauses a frozen container
+        self._run(["start", self._q(name)])  # unpauses a frozen container
 
     def delete(self, name: str, force: bool = False):
-        args = ["delete", name]
+        args = ["delete", self._q(name)]
         if force:
             args.append("--force")
         self._run(args)
 
     def exec(self, name: str, command: list[str], **kwargs) -> str:
-        args = ["exec", name, "--"]
+        args = ["exec", self._q(name), "--"]
         args.extend(command)
         cmd = ["incus"] + args
         result = subprocess.run(cmd, capture_output=True, text=True, stdin=subprocess.DEVNULL)
@@ -174,7 +201,7 @@ class IncusRuntime(ContainerRuntime):
         """
         if on_line is None:
             return self.exec(name, command)
-        args = ["exec", name, "--"] + command
+        args = ["exec", self._q(name), "--"] + command
         cmd = ["incus"] + args
         proc = subprocess.Popen(
             cmd,
@@ -204,7 +231,7 @@ class IncusRuntime(ContainerRuntime):
         return output
 
     def add_device(self, name: str, device_name: str, device_type: str, **props):
-        args = ["config", "device", "add", name, device_name, device_type]
+        args = ["config", "device", "add", self._q(name), device_name, device_type]
         for k, v in props.items():
             args.append(f"{k}={v}")
         self._run(args)
@@ -226,30 +253,51 @@ class IncusRuntime(ContainerRuntime):
         # Delete existing image with same alias
         if self.image_exists(alias):
             self.image_delete(alias)
-        self._run(["publish", name, "--alias", alias])
+        self._run(["publish", self._q(name), "--alias", alias])
 
     def image_exists(self, alias: str) -> bool:
         try:
-            self._run(["image", "show", alias])
+            self._run(["image", "show", self._q(alias)])
             return True
         except subprocess.CalledProcessError:
             return False
 
     def image_delete(self, alias_or_fingerprint: str):
-        self._run(["image", "delete", alias_or_fingerprint])
+        self._run(["image", "delete", self._q(alias_or_fingerprint)])
 
     def image_delete_all(self):
         images = self.list_images()
         for img in images:
             fingerprint = img.get("fingerprint", "")
             if fingerprint:
-                self._run(["image", "delete", fingerprint])
+                self._run(["image", "delete", self._q(fingerprint)])
 
     def list_images(self) -> list[dict]:
-        data = self._run_json(["image", "list"])
+        args = ["image", "list", self._q("")] if self._remote else ["image", "list"]
+        data = self._run_json(args)
         if not isinstance(data, list):
             return []
         return data
 
     def push_file(self, name: str, local_path: str, remote_path: str):
-        self._run(["file", "push", local_path, f"{name}{remote_path}"])
+        self._run(["file", "push", local_path, f"{self._q(name)}{remote_path}"])
+
+    # --- Operation introspection (used by `bubble doctor`) -------------
+
+    def list_operations(self) -> list[dict]:
+        """List currently running incus operations on our remote."""
+        args = ["operation", "list", self._q("")] if self._remote else ["operation", "list"]
+        data = self._run_json(args)
+        if not isinstance(data, list):
+            return []
+        return data
+
+    def delete_operation(self, op_id: str):
+        """Cancel a running operation by id."""
+        self._run(["operation", "delete", self._q(op_id)])
+
+    # --- Network introspection (used by image build IPv4/DNS fixups) --
+
+    def network_get(self, network: str, key: str) -> str:
+        """Get a single config value from an incus-managed network."""
+        return self._run(["network", "get", self._q(network), key])

--- a/bubble/setup.py
+++ b/bubble/setup.py
@@ -429,5 +429,12 @@ def get_runtime(config: dict, ensure_ready: bool = True) -> ContainerRuntime:
             )
     backend = config["runtime"]["backend"]
     if backend == "incus":
+        # On macOS we drive a dedicated Colima profile via a non-default
+        # incus remote; route every incus call through that prefix instead
+        # of switching the user's default remote globally.
+        if platform.system() == "Darwin":
+            from .runtime.colima import BUBBLE_INCUS_REMOTE
+
+            return IncusRuntime(remote=BUBBLE_INCUS_REMOTE)
         return IncusRuntime()
     raise ValueError(f"Unknown runtime backend: {backend}")

--- a/tests/test_colima.py
+++ b/tests/test_colima.py
@@ -1,0 +1,174 @@
+"""Tests for bubble.runtime.colima.
+
+These cover the parts that don't actually need a running Colima:
+command construction, path constants, and the incus-remote setup
+logic with a mocked subprocess.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+class TestColimaArgs:
+    def test_uses_global_profile_flag(self):
+        from bubble.runtime.colima import BUBBLE_COLIMA_PROFILE, _colima_args
+
+        assert _colima_args("status") == [
+            "colima",
+            "--profile",
+            BUBBLE_COLIMA_PROFILE,
+            "status",
+        ]
+
+    def test_works_for_ssh_subcommand(self):
+        """colima ssh does not accept positional profile, must use --profile."""
+        from bubble.runtime.colima import _colima_args
+
+        args = _colima_args("ssh", "--", "echo", "hi")
+        # --profile must come before the subcommand
+        assert args[0] == "colima"
+        assert args[1] == "--profile"
+        assert "ssh" in args
+        ssh_idx = args.index("ssh")
+        profile_idx = args.index("--profile")
+        assert profile_idx < ssh_idx
+
+
+class TestPathConstants:
+    def test_paths_use_bubble_profile_name(self):
+        from bubble.runtime.colima import (
+            BUBBLE_COLIMA_PROFILE,
+            COLIMA_LIMA_DIR,
+            COLIMA_PROFILE_DIR,
+        )
+
+        assert BUBBLE_COLIMA_PROFILE == "bubble-colima"
+        assert COLIMA_PROFILE_DIR == Path.home() / ".colima" / "bubble-colima"
+        assert COLIMA_LIMA_DIR == Path.home() / ".colima" / "_lima" / "bubble-colima"
+
+
+@pytest.fixture
+def fake_socket(tmp_path, monkeypatch):
+    """Make COLIMA_PROFILE_DIR resolve to a tmp dir with an incus.sock present."""
+    from bubble.runtime import colima as colima_mod
+
+    profile_dir = tmp_path / ".colima" / "bubble-colima"
+    profile_dir.mkdir(parents=True)
+    sock = profile_dir / "incus.sock"
+    sock.write_text("")  # presence only
+    monkeypatch.setattr(colima_mod, "COLIMA_PROFILE_DIR", profile_dir)
+    return sock
+
+
+class _FakeRun:
+    """Records subprocess.run calls and returns scripted responses."""
+
+    def __init__(self, scripts: dict):
+        # scripts maps a tuple key (the first 3 argv tokens, e.g.
+        # ("incus","remote","get-default")) to a CompletedProcess.
+        self.scripts = scripts
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append(list(args))
+        key = tuple(args[:3])
+        if key in self.scripts:
+            return self.scripts[key]
+        # Default: stub success with empty output
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+def _completed(stdout="", returncode=0):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+
+
+class TestEnsureIncusRemote:
+    def test_noop_when_socket_missing(self, tmp_path, monkeypatch):
+        from bubble.runtime import colima as colima_mod
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr(colima_mod, "COLIMA_PROFILE_DIR", empty_dir)
+
+        fake = _FakeRun({})
+        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
+        colima_mod._ensure_incus_remote()
+        assert fake.calls == []
+
+    def test_noop_when_default_already_correct(self, fake_socket, monkeypatch):
+        from bubble.runtime import colima as colima_mod
+
+        fake = _FakeRun(
+            {
+                ("incus", "remote", "get-default"): _completed(
+                    stdout=colima_mod.BUBBLE_INCUS_REMOTE + "\n"
+                ),
+            }
+        )
+        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
+        colima_mod._ensure_incus_remote()
+        # We should have asked for the default and stopped there.
+        assert fake.calls == [["incus", "remote", "get-default"]]
+
+    def test_adds_and_switches_when_remote_missing(self, fake_socket, monkeypatch):
+        from bubble.runtime import colima as colima_mod
+
+        fake = _FakeRun(
+            {
+                ("incus", "remote", "get-default"): _completed(stdout="local\n"),
+                ("incus", "remote", "list"): _completed(stdout=json.dumps({})),
+            }
+        )
+        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
+        colima_mod._ensure_incus_remote()
+
+        cmds = [tuple(c[:3]) for c in fake.calls]
+        assert ("incus", "remote", "add") in cmds
+        assert ("incus", "remote", "switch") in cmds
+
+    def test_refuses_to_clobber_alias_with_wrong_address(self, fake_socket, monkeypatch, capsys):
+        from bubble.runtime import colima as colima_mod
+
+        bogus_remotes = {
+            colima_mod.BUBBLE_INCUS_REMOTE: {"Addr": "unix:///somewhere/else.sock"},
+        }
+        fake = _FakeRun(
+            {
+                ("incus", "remote", "get-default"): _completed(stdout="local\n"),
+                ("incus", "remote", "list"): _completed(stdout=json.dumps(bogus_remotes)),
+            }
+        )
+        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
+        colima_mod._ensure_incus_remote()
+
+        # We must NOT have called `add` (alias exists) or `switch` (alias is stale).
+        cmds = [tuple(c[:3]) for c in fake.calls]
+        assert ("incus", "remote", "add") not in cmds
+        assert ("incus", "remote", "switch") not in cmds
+        # User should have been told.
+        err = capsys.readouterr().err
+        assert "Refusing to overwrite" in err
+
+    def test_switches_when_alias_already_points_at_us(self, fake_socket, monkeypatch):
+        from bubble.runtime import colima as colima_mod
+
+        expected_addr = f"unix://{fake_socket}"
+        good_remotes = {
+            colima_mod.BUBBLE_INCUS_REMOTE: {"Addr": expected_addr},
+        }
+        fake = _FakeRun(
+            {
+                ("incus", "remote", "get-default"): _completed(stdout="local\n"),
+                ("incus", "remote", "list"): _completed(stdout=json.dumps(good_remotes)),
+            }
+        )
+        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
+        colima_mod._ensure_incus_remote()
+
+        cmds = [tuple(c[:3]) for c in fake.calls]
+        # No `add` (alias already exists) but yes `switch`.
+        assert ("incus", "remote", "add") not in cmds
+        assert ("incus", "remote", "switch") in cmds

--- a/tests/test_colima.py
+++ b/tests/test_colima.py
@@ -86,6 +86,10 @@ def _completed(stdout="", returncode=0):
 
 
 class TestEnsureIncusRemote:
+    """The remote-setup code adds an alias if missing but never switches the
+    user's default — bubble targets resources by prefix instead.
+    """
+
     def test_noop_when_socket_missing(self, tmp_path, monkeypatch):
         from bubble.runtime import colima as colima_mod
 
@@ -98,27 +102,11 @@ class TestEnsureIncusRemote:
         colima_mod._ensure_incus_remote()
         assert fake.calls == []
 
-    def test_noop_when_default_already_correct(self, fake_socket, monkeypatch):
+    def test_adds_when_remote_missing_but_does_not_switch(self, fake_socket, monkeypatch):
         from bubble.runtime import colima as colima_mod
 
         fake = _FakeRun(
             {
-                ("incus", "remote", "get-default"): _completed(
-                    stdout=colima_mod.BUBBLE_INCUS_REMOTE + "\n"
-                ),
-            }
-        )
-        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
-        colima_mod._ensure_incus_remote()
-        # We should have asked for the default and stopped there.
-        assert fake.calls == [["incus", "remote", "get-default"]]
-
-    def test_adds_and_switches_when_remote_missing(self, fake_socket, monkeypatch):
-        from bubble.runtime import colima as colima_mod
-
-        fake = _FakeRun(
-            {
-                ("incus", "remote", "get-default"): _completed(stdout="local\n"),
                 ("incus", "remote", "list"): _completed(stdout=json.dumps({})),
             }
         )
@@ -127,7 +115,7 @@ class TestEnsureIncusRemote:
 
         cmds = [tuple(c[:3]) for c in fake.calls]
         assert ("incus", "remote", "add") in cmds
-        assert ("incus", "remote", "switch") in cmds
+        assert ("incus", "remote", "switch") not in cmds
 
     def test_refuses_to_clobber_alias_with_wrong_address(self, fake_socket, monkeypatch, capsys):
         from bubble.runtime import colima as colima_mod
@@ -137,14 +125,13 @@ class TestEnsureIncusRemote:
         }
         fake = _FakeRun(
             {
-                ("incus", "remote", "get-default"): _completed(stdout="local\n"),
                 ("incus", "remote", "list"): _completed(stdout=json.dumps(bogus_remotes)),
             }
         )
         monkeypatch.setattr(colima_mod.subprocess, "run", fake)
         colima_mod._ensure_incus_remote()
 
-        # We must NOT have called `add` (alias exists) or `switch` (alias is stale).
+        # We must NOT have called `add` (alias exists) or `switch` (we never switch).
         cmds = [tuple(c[:3]) for c in fake.calls]
         assert ("incus", "remote", "add") not in cmds
         assert ("incus", "remote", "switch") not in cmds
@@ -152,7 +139,7 @@ class TestEnsureIncusRemote:
         err = capsys.readouterr().err
         assert "Refusing to overwrite" in err
 
-    def test_switches_when_alias_already_points_at_us(self, fake_socket, monkeypatch):
+    def test_noop_when_alias_already_points_at_us(self, fake_socket, monkeypatch):
         from bubble.runtime import colima as colima_mod
 
         expected_addr = f"unix://{fake_socket}"
@@ -161,7 +148,6 @@ class TestEnsureIncusRemote:
         }
         fake = _FakeRun(
             {
-                ("incus", "remote", "get-default"): _completed(stdout="local\n"),
                 ("incus", "remote", "list"): _completed(stdout=json.dumps(good_remotes)),
             }
         )
@@ -169,6 +155,33 @@ class TestEnsureIncusRemote:
         colima_mod._ensure_incus_remote()
 
         cmds = [tuple(c[:3]) for c in fake.calls]
-        # No `add` (alias already exists) but yes `switch`.
+        # Alias is already in place at the right address; no add and no switch.
         assert ("incus", "remote", "add") not in cmds
-        assert ("incus", "remote", "switch") in cmds
+        assert ("incus", "remote", "switch") not in cmds
+
+
+class TestIncusRuntimeQualify:
+    def test_default_runtime_does_not_prefix(self):
+        from bubble.runtime.incus import IncusRuntime
+
+        rt = IncusRuntime()
+        assert rt.qualify("foo") == "foo"
+
+    def test_remote_runtime_prefixes(self):
+        from bubble.runtime.incus import IncusRuntime
+
+        rt = IncusRuntime(remote="bubble-colima")
+        assert rt.qualify("foo") == "bubble-colima:foo"
+
+    def test_already_qualified_name_passes_through(self):
+        from bubble.runtime.incus import IncusRuntime
+
+        rt = IncusRuntime(remote="bubble-colima")
+        assert rt.qualify("other-remote:foo") == "other-remote:foo"
+
+    def test_empty_name_yields_remote_with_colon(self):
+        """Used by list_containers / list_images to scope to the remote."""
+        from bubble.runtime.incus import IncusRuntime
+
+        rt = IncusRuntime(remote="bubble-colima")
+        assert rt.qualify("") == "bubble-colima:"


### PR DESCRIPTION
This PR makes bubble drive its own Colima profile (bubble-colima) instead of the default one, AND stops bubble from ever switching the user's default incus remote. Two related fixes that landed together to keep the behavior coherent.

Three problems fixed:

1. bubble shared Colima's default VM with whatever else the user was running.
2. A stale-state recovery path in start_colima() did shutil.rmtree(~/.colima/_lima/colima/) — which would wipe the user's unrelated default profile if it happened to exist.
3. _ensure_incus_remote() ran `incus remote switch bubble-colima` on every startup, silently overwriting the user's default incus remote so any non-bubble incus work (e.g. `incus list`) targeted the wrong place.

Changes:

**Profile rename** (commit 1)
- New constants BUBBLE_COLIMA_PROFILE = BUBBLE_INCUS_REMOTE = "bubble-colima".
- New _colima_args() helper passes the global `--profile` flag rather than the positional profile argument. The positional form doesn't work for `colima ssh`, which we use for DNS checks and host-IP discovery.
- Path constants (COLIMA_PROFILE_DIR, COLIMA_LIMA_DIR) point at the bubble-colima dirs. The stale-state rmtree only ever touches our profile.

**Remote prefix instead of default-switching** (commit 2)
- IncusRuntime gains a `remote` constructor argument and a `qualify(name)` method that returns `"<remote>:<name>"` when set.
- Every container/image/network reference inside IncusRuntime is routed through self._q(). list_containers / list_images / list_operations pass `"<remote>:"` to scope to our remote rather than relying on the user's default.
- New runtime methods (list_operations, delete_operation, network_get) so doctor.py and images/builder.py no longer reach for raw `subprocess.run(["incus", ...])`.
- get_runtime() passes remote=BUBBLE_INCUS_REMOTE on Darwin. Linux is unaffected.
- _ensure_incus_remote() only adds the alias if missing; it never calls `incus remote switch`. The stale-address check still refuses to clobber a hand-rolled alias.

**Out of scope**: SSH-wrapped incus commands in github_token.py and finalization.py — those run on a remote bubble host via SSH. The local side doesn't know whether the remote is using Colima or native Incus, so addressing them needs per-host context. The remote bubble's behavior is unchanged in this PR; tracked as a future followup.

Tests in tests/test_colima.py (new file) cover command construction, path constants, the four branches of _ensure_incus_remote (no-socket, fresh-add, stale-alias-refusal, alias-already-correct), and qualify() in identity/prefix/already-qualified/empty-name modes.

No migration logic — there are no existing users yet. A leftover ~/.colima/_lima/colima/ from a pre-rename install is simply ignored.

Plan: fourth and final small PR hardening filesystem-safety. Independent of #274, #275, #276.

🤖 Prepared with Claude Code