### PR TITLE
fix: support git worktrees in --path target resolution

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -206,8 +206,13 @@ def _resolve_ref_source(t, no_clone: bool) -> tuple[Path, str]:
     """
     if t.local_path:
         try:
+            # `--git-common-dir` resolves to the main repo's .git even for
+            # linked worktrees; `--absolute-git-dir` would return the
+            # per-worktree dir under .git/worktrees/<name>/, which git
+            # refuses to use as a `--reference` (linked checkout).
             git_dir_result = subprocess.run(
-                ["git", "-C", t.local_path, "rev-parse", "--absolute-git-dir"],
+                ["git", "-C", t.local_path, "rev-parse",
+                 "--path-format=absolute", "--git-common-dir"],
                 capture_output=True,
                 text=True,
                 check=True,

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -211,8 +211,14 @@ def _resolve_ref_source(t, no_clone: bool) -> tuple[Path, str]:
             # per-worktree dir under .git/worktrees/<name>/, which git
             # refuses to use as a `--reference` (linked checkout).
             git_dir_result = subprocess.run(
-                ["git", "-C", t.local_path, "rev-parse",
-                 "--path-format=absolute", "--git-common-dir"],
+                [
+                    "git",
+                    "-C",
+                    t.local_path,
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                ],
                 capture_output=True,
                 text=True,
                 check=True,


### PR DESCRIPTION
This PR fixes `bubble --path <worktree>` so it works against linked git worktrees, not just regular clones. Without this, every `bubble --path` invocation against a worktree fails in-container with `fatal: reference repository '/shared/git/<repo>.git' as a linked checkout is not supported yet`.

`_resolve_ref_source` used `git rev-parse --absolute-git-dir`, which returns the per-worktree linked-checkout dir (`.git/worktrees/<name>/`) when called from inside a worktree. Switch to `--path-format=absolute --git-common-dir`, which resolves to the main repo's `.git` for both regular clones and linked worktrees.

Verified locally: `bubble --path <worktree>` now lands the in-container clone on the worktree's branch (via `git fetch /shared/git/<mirror> <branch>:<branch>`).

Closes https://github.com/kim-em/bubble/issues/278.

🤖 Prepared with Claude Code