### PR TITLE
feat: add --github-security flag for per-launch GitHub level override

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -586,6 +586,18 @@ def _reattach(runtime, name, editor, no_interactive, command=None):
     ),
 )
 @click.option(
+    "--github-security",
+    type=str,
+    default=None,
+    help=(
+        "Override security.github for this bubble only. Accepts the same"
+        " values as `bubble security set github`: off, basic, rest,"
+        " allowlist-read-graphql, allowlist-write-graphql, write-graphql,"
+        " direct. Lockdown still wins. Default: use the host-configured"
+        " level."
+    ),
+)
+@click.option(
     "--ai-prompt-stdin",
     is_flag=True,
     hidden=True,
@@ -624,10 +636,22 @@ def open_cmd(
     codex_credentials,
     claude_config,
     codex_config,
+    github_security,
     ai_prompt_stdin,
     skip_auth_setup,
 ):
     """Open a bubble for one or more targets (GitHub URL, repo, local path, or PR number)."""
+    # Validate --github-security against the known levels.
+    if github_security is not None:
+        from .security import GITHUB_LEVELS
+
+        if github_security not in GITHUB_LEVELS:
+            click.echo(
+                f"Error: --github-security {github_security!r} not in {', '.join(GITHUB_LEVELS)}",
+                err=True,
+            )
+            sys.exit(1)
+
     # When -b is used without an explicit target, infer owner/repo from cwd
     if not targets:
         if new_branch:
@@ -686,6 +710,7 @@ def open_cmd(
                 codex_credentials=codex_credentials,
                 claude_config=claude_config,
                 codex_config=codex_config,
+                github_security=github_security,
                 ai_prompt_stdin=ai_prompt_stdin,
                 skip_auth_setup=skip_auth_setup,
             )
@@ -743,6 +768,7 @@ def _open_single(
     codex_credentials,
     claude_config,
     codex_config,
+    github_security,
     ai_prompt_stdin,
     skip_auth_setup=False,
 ):
@@ -751,6 +777,21 @@ def _open_single(
         target = "./" + target
 
     config = load_config()
+
+    # --github-security: per-launch override of security.github. Lockdown
+    # still wins. Apply by mutating a config copy so all downstream
+    # `get_github_level(config)` calls see the override transparently.
+    if github_security is not None:
+        if is_locked_off(config, "github"):
+            click.echo(
+                "Error: --github-security rejected because security.github=off."
+                " Re-enable: bubble security set github auto",
+                err=True,
+            )
+            sys.exit(1)
+        config = dict(config)
+        config["security"] = dict(config.get("security", {}))
+        config["security"]["github"] = github_security
 
     # Enforce security: reject all user mounts when user_mounts is locked off
     # This covers both --mount CLI flags and [[mounts]] from config

--- a/bubble/security.py
+++ b/bubble/security.py
@@ -215,6 +215,23 @@ def get_github_level(config: dict) -> str:
     return value
 
 
+def resolve_github_level(config: dict, override: str | None = None) -> str:
+    """Resolve effective GitHub level, honouring an optional per-launch override.
+
+    Lockdown still wins: if `security.github` is explicitly locked off, an
+    override raises ValueError. Otherwise an explicit override (one of the
+    `GITHUB_LEVELS` values) is returned verbatim; with no override, falls
+    back to `get_github_level(config)`.
+    """
+    if override is None:
+        return get_github_level(config)
+    if override not in GITHUB_LEVELS:
+        raise ValueError(f"override {override!r} not in {GITHUB_LEVELS}")
+    if is_locked_off(config, "github"):
+        raise ValueError("Cannot override --github-security: security.github is locked off")
+    return override
+
+
 def should_include_credentials(requested: bool, config: dict, setting_name: str) -> bool:
     """Resolve whether credentials should be included.
 


### PR DESCRIPTION
This PR adds a `--github-security <level>` flag to `bubble open` so callers can override `security.github` for one bubble at a time without changing the host-wide default. Accepts the same values as `bubble security set github`: `off`, `basic`, `rest`, `allowlist-read-graphql`, `allowlist-write-graphql`, `write-graphql`, `direct`. Lockdown still wins — if `security.github` is locked off, the override is rejected with an explanatory error.

Implementation is small: validate against `GITHUB_LEVELS` at parse time, then inside `_open_single` after `load_config()` mutate a config copy to set `config["security"]["github"] = override`. Every downstream helper that calls `get_github_level(config)` (`cli.py:351, 1117`; `container_helpers.py:139`; `github_token.py:121, 145`) reads from that mutated config and picks up the override transparently — no threading needed.

Use case: autonomous tooling like `pod` running sub-agents in bubbles needs `write-graphql` for `gh issue list --label X`, which gh implements as a multi-top-level GraphQL `search()` query that the default `allowlist-write-graphql` correctly rejects. With this flag, those bubbles can elevate just for themselves while the user's other bubbles keep the safer default.

Closes https://github.com/kim-em/bubble/issues/280.

🤖 Prepared with Claude Code