### PR TITLE
feat: route SSH-wrapped incus calls through 'bubble internal' RPC

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -1302,6 +1302,7 @@ from .commands.completion import register_completion_command  # noqa: E402
 from .commands.doctor import register_doctor_command  # noqa: E402
 from .commands.images import register_images_commands  # noqa: E402
 from .commands.infrastructure import register_infrastructure_commands  # noqa: E402
+from .commands.internal import register_internal_commands  # noqa: E402
 from .commands.lifecycle import register_lifecycle_commands  # noqa: E402
 from .commands.list_cmd import register_list_command  # noqa: E402
 from .commands.relay_cmd import register_relay_commands  # noqa: E402
@@ -1321,6 +1322,7 @@ register_security_commands(main)
 register_settings_commands(main)
 register_doctor_command(main)
 register_status_command(main)
+register_internal_commands(main)
 register_completion_command(main)
 
 

--- a/bubble/commands/internal.py
+++ b/bubble/commands/internal.py
@@ -1,0 +1,99 @@
+"""Hidden 'internal' command group used by bubble-on-bubble RPC over SSH.
+
+These subcommands exist so the local side of a remote bubble session
+(``github_token.py``, ``finalization.py``) can act on the remote container
+without shipping raw ``incus`` commands over SSH.  The remote bubble's own
+:class:`IncusRuntime` applies the right resource prefix (e.g.
+``bubble-colima:`` on macOS) without the local side having to know the
+remote's runtime topology.
+
+**Stability:** these commands are hidden from ``--help`` and not part of
+the user-facing CLI.  They are an IPC, not an API.  Keep verbs narrow —
+specifically, never accept opaque shell strings beyond the structured
+``--`` payload of ``incus-exec``.
+
+**Version-skew invariant:** callers must only invoke ``bubble internal …``
+on a remote where the bubble package has been deployed/updated.  That is
+true today for every code path in ``github_token.py`` and
+``finalization.py`` because they run after a successful
+``bubble open --machine-readable`` round-trip on the same host.
+"""
+
+import sys
+
+import click
+
+from ..config import load_config
+from ..setup import get_runtime
+
+
+def register_internal_commands(main):
+    """Register the hidden 'internal' command group on the main CLI."""
+
+    @main.group("internal", hidden=True)
+    def internal():
+        """Hidden RPC entry points used by bubble-on-bubble over SSH."""
+
+    @internal.command(
+        "incus-exec",
+        # Pass everything after CONTAINER straight to the container.  Without
+        # this Click would try to parse '-c', '-l', '--color=auto', etc. as
+        # its own options.
+        context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
+    )
+    @click.argument("container")
+    @click.argument("argv", nargs=-1, type=click.UNPROCESSED, required=True)
+    def incus_exec(container, argv):
+        """Run ARGV inside CONTAINER via the remote bubble's runtime.
+
+        Equivalent to ``incus exec CONTAINER -- ARGV…`` on the remote, but
+        goes through :class:`bubble.runtime.incus.IncusRuntime` so the
+        appropriate remote prefix is applied without the caller having to
+        know about it.
+
+        Stdout is forwarded to our stdout; runtime errors are surfaced as a
+        non-zero exit code.
+        """
+        config = load_config()
+        runtime = get_runtime(config, ensure_ready=False)
+        try:
+            output = runtime.exec(container, list(argv))
+        except RuntimeError as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        if output:
+            click.echo(output)
+
+    @internal.command("incus-add-device")
+    @click.argument("container")
+    @click.argument("device_name")
+    @click.argument("device_type")
+    @click.argument("props", nargs=-1)
+    def incus_add_device(container, device_name, device_type, props):
+        """Attach a device to CONTAINER via the remote bubble's runtime.
+
+        PROPS are ``KEY=VALUE`` pairs forwarded as keyword arguments to
+        :meth:`bubble.runtime.base.ContainerRuntime.add_device`.  Anything
+        without an ``=`` is rejected — this command does not accept opaque
+        shell fragments.
+        """
+        config = load_config()
+        runtime = get_runtime(config, ensure_ready=False)
+        kwargs: dict[str, str] = {}
+        for prop in props:
+            if "=" not in prop:
+                click.echo(
+                    f"Invalid prop {prop!r}: expected key=value (no '=' found).",
+                    err=True,
+                )
+                sys.exit(2)
+            key, _, value = prop.partition("=")
+            if not key:
+                click.echo(f"Invalid prop {prop!r}: empty key.", err=True)
+                sys.exit(2)
+            kwargs[key] = value
+        try:
+            runtime.add_device(container, device_name, device_type, **kwargs)
+        except RuntimeError as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -198,14 +198,15 @@ def inject_local_ssh_keys(remote_host, container_name: str):
         return
 
     keys_str = "\\n".join(pub_keys)
-    # Append local keys to the container's authorized_keys via incus exec
+    # Append local keys to the container's authorized_keys via the remote
+    # bubble's runtime (so bubble-colima:/local: prefix is applied for us).
     _ssh_run(
         remote_host,
         [
-            "incus",
-            "exec",
+            "bubble",
+            "internal",
+            "incus-exec",
             container_name,
-            "--",
             "su",
             "-",
             "user",

--- a/bubble/github_token.py
+++ b/bubble/github_token.py
@@ -420,10 +420,9 @@ def setup_auth_proxy_remote(
         _ssh_run(
             remote_host,
             [
-                "incus",
-                "config",
-                "device",
-                "add",
+                "bubble",
+                "internal",
+                "incus-add-device",
                 container,
                 "bubble-auth-proxy",
                 "proxy",
@@ -453,10 +452,10 @@ def setup_auth_proxy_remote(
         _ssh_run(
             remote_host,
             [
-                "incus",
-                "exec",
+                "bubble",
+                "internal",
+                "incus-exec",
                 container,
-                "--",
                 "bash",
                 "-c",
                 f"su - user -c {shlex.quote(git_config_cmd)}",
@@ -501,10 +500,9 @@ def _setup_gh_proxy_remote(
         _ssh_run(
             remote_host,
             [
-                "incus",
-                "config",
-                "device",
-                "add",
+                "bubble",
+                "internal",
+                "incus-add-device",
                 container,
                 "bubble-gh-proxy",
                 "proxy",
@@ -543,7 +541,7 @@ def _setup_gh_proxy_remote(
     try:
         _ssh_run(
             remote_host,
-            ["incus", "exec", container, "--", "bash", "-c", profile_cmd],
+            ["bubble", "internal", "incus-exec", container, "bash", "-c", profile_cmd],
             timeout=15,
         )
     except RuntimeError as e:
@@ -619,7 +617,7 @@ def inject_gh_token_remote(
     try:
         _ssh_run(
             remote_host,
-            ["incus", "exec", container, "--", "bash", "-c", profile_script],
+            ["bubble", "internal", "incus-exec", container, "bash", "-c", profile_script],
             timeout=15,
         )
     except Exception as e:

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,0 +1,177 @@
+"""Tests for the hidden 'bubble internal' RPC subcommands.
+
+These commands run on a remote bubble host (over SSH) so the local side
+can act on a container without shipping raw ``incus`` argv.  We don't
+actually exec real incus here — we install a mock runtime and verify
+exactly what arguments it would have received.
+"""
+
+from click.testing import CliRunner
+
+from bubble.cli import main
+
+
+class _RecordingRuntime:
+    """Stand-in for IncusRuntime that records calls without executing."""
+
+    def __init__(self):
+        self.exec_calls: list[tuple] = []
+        self.add_device_calls: list[tuple] = []
+
+    def exec(self, name, command, **kwargs):
+        self.exec_calls.append((name, list(command)))
+        return "ok"
+
+    def add_device(self, name, device_name, device_type, **props):
+        self.add_device_calls.append((name, device_name, device_type, props))
+
+
+def _patch_runtime(monkeypatch, rt):
+    """Make ``get_runtime`` in commands.internal return our recorder."""
+    import bubble.commands.internal as internal_mod
+
+    monkeypatch.setattr(internal_mod, "get_runtime", lambda *args, **kwargs: rt)
+
+
+def test_help_lists_subcommands():
+    """The 'internal' group itself should expose its verbs in --help."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["internal", "--help"])
+    assert result.exit_code == 0
+    assert "incus-exec" in result.output
+    assert "incus-add-device" in result.output
+
+
+def test_internal_hidden_from_top_level_help():
+    """The 'internal' group must not appear in top-level --help (it's IPC)."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "internal" not in result.output.lower().split()
+
+
+def test_incus_exec_forwards_argv(monkeypatch, tmp_data_dir):
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["internal", "incus-exec", "my-bubble", "bash", "-c", "echo hello"],
+    )
+    assert result.exit_code == 0
+    assert rt.exec_calls == [("my-bubble", ["bash", "-c", "echo hello"])]
+    # Output is forwarded
+    assert "ok" in result.output
+
+
+def test_incus_exec_requires_argv(monkeypatch, tmp_data_dir):
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(main, ["internal", "incus-exec", "my-bubble"])
+    assert result.exit_code != 0  # Click rejects missing required argv
+    assert rt.exec_calls == []
+
+
+def test_incus_exec_passes_dashes_through(monkeypatch, tmp_data_dir):
+    """Dashes in the command payload must reach the runtime, not be parsed by Click."""
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["internal", "incus-exec", "my-bubble", "ls", "-la", "--color=auto"],
+    )
+    assert result.exit_code == 0
+    assert rt.exec_calls == [("my-bubble", ["ls", "-la", "--color=auto"])]
+
+
+def test_incus_exec_runtime_error_exits_nonzero(monkeypatch, tmp_data_dir):
+    class _Failing:
+        def exec(self, name, command, **kwargs):
+            raise RuntimeError("kaboom")
+
+    _patch_runtime(monkeypatch, _Failing())
+    runner = CliRunner()
+    result = runner.invoke(main, ["internal", "incus-exec", "my-bubble", "true"])
+    assert result.exit_code == 1
+    assert "kaboom" in result.output
+
+
+def test_incus_add_device_parses_props(monkeypatch, tmp_data_dir):
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "internal",
+            "incus-add-device",
+            "my-bubble",
+            "bubble-auth-proxy",
+            "proxy",
+            "connect=tcp:127.0.0.1:7654",
+            "listen=tcp:127.0.0.1:8888",
+            "bind=container",
+        ],
+    )
+    assert result.exit_code == 0
+    assert rt.add_device_calls == [
+        (
+            "my-bubble",
+            "bubble-auth-proxy",
+            "proxy",
+            {
+                "connect": "tcp:127.0.0.1:7654",
+                "listen": "tcp:127.0.0.1:8888",
+                "bind": "container",
+            },
+        )
+    ]
+
+
+def test_incus_add_device_rejects_bare_value(monkeypatch, tmp_data_dir):
+    """A prop without '=' is not a structured argv element — refuse it."""
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["internal", "incus-add-device", "my-bubble", "dev", "proxy", "no-equals-here"],
+    )
+    assert result.exit_code == 2
+    assert "Invalid prop" in result.output
+    assert rt.add_device_calls == []
+
+
+def test_incus_add_device_rejects_empty_key(monkeypatch, tmp_data_dir):
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["internal", "incus-add-device", "my-bubble", "dev", "proxy", "=value"]
+    )
+    assert result.exit_code == 2
+    assert "empty key" in result.output
+
+
+def test_incus_add_device_value_can_contain_equals(monkeypatch, tmp_data_dir):
+    """Only the FIRST '=' splits key from value; the rest stays in the value."""
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "internal",
+            "incus-add-device",
+            "my-bubble",
+            "dev",
+            "proxy",
+            "raw.lxc=lxc.cap.drop = sys_admin",
+        ],
+    )
+    assert result.exit_code == 0
+    assert rt.add_device_calls == [
+        ("my-bubble", "dev", "proxy", {"raw.lxc": "lxc.cap.drop = sys_admin"}),
+    ]


### PR DESCRIPTION
This PR closes the macOS-remote gap that #277 left open.

After #277 stops bubble from switching the user's default Incus remote on macOS, the SSH-wrapped 'incus exec' calls in github_token.py and finalization.py target the wrong remote when used against a macOS-via-Colima remote host (e.g. 'bubble --ssh my-mac-mini'). Cloud / Linux remotes are unaffected because they don't use Colima at all.

Instead of teaching the local side about the remote's runtime topology (prefix caching, SSH-time probing, etc.), this PR moves the incus-aware work to the remote bubble, which already has an IncusRuntime that applies the right prefix. The local side calls a hidden RPC over SSH.

## New 'bubble internal' command group

Hidden from --help (it's IPC, not a user-facing API). Two narrow subcommands:

- 'incus-exec CONTAINER ARGV...'
  Forwards ARGV via runtime.exec(). Uses Click's ignore_unknown_options so the payload's own dashes ('-c', '--color=auto', etc.) reach the container intact instead of being parsed by Click.

- 'incus-add-device CONTAINER DEVICE_NAME DEVICE_TYPE [KEY=VALUE...]'
  Forwards device props via runtime.add_device(). KEY=VALUE only — bare values are rejected (no opaque shell fragments).

Both follow the design Codex pushed back on: keep the verbs narrow, no generic 'run arbitrary incus verb' API, structured argv only.

## Six callsites migrated

- finalization.py:171 — local-key injection ('incus exec')
- github_token.py:421 — auth proxy device ('incus config device add')
- github_token.py:456 — git-config-via-token ('incus exec')
- github_token.py:504 — gh socket proxy device ('incus config device add')
- github_token.py:546 — gh profile script ('incus exec')
- github_token.py:622 — direct token injection ('incus exec')

bubble/finalization.py and bubble/github_token.py no longer contain any raw '[\"incus\", ...]' literals.

## Stability / version-skew

'bubble internal' is hidden and not documented as user-facing. Callers must only invoke it on a remote where the bubble package is current — which is true today because every callsite runs after a successful 'bubble open --machine-readable' round-trip on the same host. The invariant is recorded in the module docstring.

## Followup (out of scope)

Codex flagged a separate concern that this PR does not address: github_token.py constructs commands like 'incus exec ... bash -c \"... extraHeader X-Bubble-Token: <real-token> ...\"'. The token is in the bash process's argv, visible to other users on the box. Independent of this refactor; worth a hardening pass via heredoc-on-stdin or a temp file inside the container.

🤖 Prepared with Claude Code