### PR TITLE
fix: stop leaking GitHub tokens to the container's process list

### DIFF
--- a/bubble/commands/internal.py
+++ b/bubble/commands/internal.py
@@ -41,9 +41,15 @@ def register_internal_commands(main):
         # its own options.
         context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
     )
+    @click.option(
+        "--with-stdin",
+        is_flag=True,
+        help="Read this process's stdin and pipe it into the container's stdin. "
+        "Use this for secrets (tokens, passwords) that must not appear in argv.",
+    )
     @click.argument("container")
     @click.argument("argv", nargs=-1, type=click.UNPROCESSED, required=True)
-    def incus_exec(container, argv):
+    def incus_exec(with_stdin, container, argv):
         """Run ARGV inside CONTAINER via the remote bubble's runtime.
 
         Equivalent to ``incus exec CONTAINER -- ARGV…`` on the remote, but
@@ -56,8 +62,9 @@ def register_internal_commands(main):
         """
         config = load_config()
         runtime = get_runtime(config, ensure_ready=False)
+        input_data = sys.stdin.read() if with_stdin else None
         try:
-            output = runtime.exec(container, list(argv))
+            output = runtime.exec(container, list(argv), input=input_data)
         except RuntimeError as exc:
             click.echo(str(exc), err=True)
             sys.exit(1)

--- a/bubble/github_token.py
+++ b/bubble/github_token.py
@@ -47,6 +47,100 @@ _CONTAINER_PROXY_PORT = 7654
 _CONTAINER_GH_SOCKET = "/bubble/gh-proxy.sock"
 
 
+# ---------------------------------------------------------------------------
+# Sensitive-payload helpers
+# ---------------------------------------------------------------------------
+#
+# Tokens MUST NOT appear in any process's argv on the host or inside the
+# container — argv is visible via /proc/<pid>/cmdline to other users on the
+# box.  These helpers build bash snippets that read the token from stdin
+# (we pipe it via the runtime's input=... channel) and use heredoc-fed
+# `cat` to write config files; both avoid putting the token on a command
+# line.
+#
+# The bash text itself only references the *literal* string ``$TOKEN`` —
+# it's the variable name, not the value, so it is safe to ship in argv.
+
+
+def _bash_with_stdin_token(payload: str) -> str:
+    """Wrap *payload* so it runs with ``$TOKEN`` set from stdin.
+
+    The caller passes the script via stdin (see ``runtime.exec(input=...)``
+    or ``_ssh_run(input=...)``).  The first line of stdin is read into
+    ``TOKEN``; *payload* may reference ``$TOKEN`` from that point on.
+
+    ``set -e`` aborts on the first failing step so a partial config write
+    doesn't leave a half-configured container.
+    """
+    # `IFS= read -r` reads one line without trimming; this is safer than
+    # `cat` which would slurp any trailing newline-or-content the caller
+    # might have appended.
+    return f"set -e\nIFS= read -r TOKEN\n{payload}"
+
+
+# Append [url] and [http] sections to user's .gitconfig.  Heredoc body
+# expansion happens in bash before piping to cat — no argv exposure.
+# {port} is the only template substitution; $TOKEN is literal until bash
+# expands it inside the heredoc.
+_AUTH_PROXY_GIT_CONFIG_PAYLOAD = """\
+mkdir -p /home/user
+touch /home/user/.gitconfig
+chown user:user /home/user/.gitconfig
+chmod 600 /home/user/.gitconfig
+cat >> /home/user/.gitconfig <<GITCONFIG
+[url "http://127.0.0.1:{port}/git/"]
+\tinsteadOf = https://github.com/
+[http "http://127.0.0.1:{port}/"]
+\textraHeader = X-Bubble-Token: $TOKEN
+GITCONFIG
+"""
+
+
+# Write /etc/profile.d/bubble-gh.sh with GH_CONFIG_DIR / GH_TOKEN / GH_REPO.
+# Both GH_REPO and GH_REPO_FILE are template-only (template-injected before
+# bash sees them) — they're shell metadata-free identifiers.  Only $TOKEN
+# is read from stdin.
+_GH_PROXY_PROFILE_PAYLOAD = """\
+mkdir -p /etc/profile.d
+cat > /etc/profile.d/bubble-gh.sh <<PROFILE
+export GH_CONFIG_DIR=/etc/bubble/gh
+export GH_TOKEN=$TOKEN{gh_repo_line}
+PROFILE
+chmod 644 /etc/profile.d/bubble-gh.sh{repo_file_block}
+"""
+
+
+# Write /etc/profile.d/bubble-gh-inject.sh with GH_TOKEN and GITHUB_TOKEN.
+# Used by the `direct` (level 5) escape hatch — the host's real token goes
+# into the container's environment.
+_GH_INJECT_PROFILE_PAYLOAD = """\
+mkdir -p /etc/profile.d
+cat > /etc/profile.d/bubble-gh-inject.sh <<PROFILE
+export GH_TOKEN=$TOKEN
+export GITHUB_TOKEN=$TOKEN
+PROFILE
+chmod 644 /etc/profile.d/bubble-gh-inject.sh
+"""
+
+
+def _gh_proxy_profile_payload(owner: str, repo: str) -> str:
+    """Build the gh proxy profile.d payload.  The optional GH_REPO line
+    only appears when owner/repo are known."""
+    if owner and repo:
+        # owner/repo are repo identifiers and contain no shell metacharacters
+        # we'd worry about — but quote anyway for defense in depth.
+        q_repo = shlex.quote(f"{owner}/{repo}")
+        gh_repo_line = f"\nexport GH_REPO={q_repo}"
+        repo_file_block = f"\nmkdir -p /etc/bubble/gh && echo {q_repo} > /etc/bubble/gh/repo"
+    else:
+        gh_repo_line = ""
+        repo_file_block = ""
+    return _GH_PROXY_PROFILE_PAYLOAD.format(
+        gh_repo_line=gh_repo_line,
+        repo_file_block=repo_file_block,
+    )
+
+
 def get_host_gh_token() -> str | None:
     """Get the GitHub auth token from the host's gh CLI.
 
@@ -268,19 +362,18 @@ def setup_auth_proxy(
     # the listener actually accepting connections.
     _wait_for_proxy_device(runtime, container, _CONTAINER_PROXY_PORT)
 
-    # Configure git inside the container to use the proxy
-    q_token = shlex.quote(token)
-    git_config_cmd = (
-        f"git config --global url.'http://127.0.0.1:{_CONTAINER_PROXY_PORT}/git/'.insteadOf"
-        f" 'https://github.com/'"
-        f" && git config --global http.'http://127.0.0.1:{_CONTAINER_PROXY_PORT}/'.extraHeader"
-        f" 'X-Bubble-Token: {q_token}'"
-    )
-
+    # Configure git inside the container to use the proxy.
+    #
+    # Write user's .gitconfig directly via heredoc — `git config --global`
+    # would put the token in argv ("git config http... extraHeader X-Bubble-Token: <real>")
+    # and so would `su -c "..."` with the token expanded into the command.
+    # The heredoc body is fed to `cat` via the kernel's pipe, not argv.
+    payload = _AUTH_PROXY_GIT_CONFIG_PAYLOAD.format(port=_CONTAINER_PROXY_PORT)
     try:
         runtime.exec(
             container,
-            ["bash", "-c", f"su - user -c {shlex.quote(git_config_cmd)}"],
+            ["bash", "-c", _bash_with_stdin_token(payload)],
+            input=token + "\n",
         )
     except RuntimeError as e:
         if not machine_readable:
@@ -336,26 +429,14 @@ def _setup_gh_proxy(
     # GH_CONFIG_DIR points to /etc/bubble/gh/ (created by gh.sh tool script)
     # GH_TOKEN is the per-container bubble proxy token — gh sends it as
     # Authorization header, the proxy validates it and swaps in the real token.
-    q_token = shlex.quote(token)
     # GH_REPO tells gh which repo to use, bypassing remote URL parsing.
-    # Without this, gh can't match the proxy URL (127.0.0.1:7654) to github.com.
-    gh_repo_line = ""
-    repo_file_line = ""
-    if owner and repo:
-        q_repo = shlex.quote(f"{owner}/{repo}")
-        gh_repo_line = f" && echo 'export GH_REPO={q_repo}' >> /etc/profile.d/bubble-gh.sh"
-        # Also write to a file for the gh wrapper to read in non-login shells
-        repo_file_line = f" && echo {q_repo} > /etc/bubble/gh/repo"
-    profile_script = (
-        f'echo "export GH_CONFIG_DIR=/etc/bubble/gh" > /etc/profile.d/bubble-gh.sh'
-        f" && echo 'export GH_TOKEN={q_token}' >> /etc/profile.d/bubble-gh.sh"
-        f"{gh_repo_line}"
-        f" && chmod 644 /etc/profile.d/bubble-gh.sh"
-        f"{repo_file_line}"
-    )
-
+    payload = _gh_proxy_profile_payload(owner, repo)
     try:
-        runtime.exec(container, ["bash", "-c", profile_script])
+        runtime.exec(
+            container,
+            ["bash", "-c", _bash_with_stdin_token(payload)],
+            input=token + "\n",
+        )
     except RuntimeError as e:
         if not machine_readable:
             detail(f"Warning: failed to configure gh environment: {e}")
@@ -439,15 +520,9 @@ def setup_auth_proxy_remote(
         remove_auth_tokens(container)
         return False
 
-    # Configure git inside the container to use the proxy
-    q_token = shlex.quote(token)
-    git_config_cmd = (
-        f"git config --global url.'http://127.0.0.1:{_CONTAINER_PROXY_PORT}/git/'.insteadOf"
-        f" 'https://github.com/'"
-        f" && git config --global http.'http://127.0.0.1:{_CONTAINER_PROXY_PORT}/'.extraHeader"
-        f" 'X-Bubble-Token: {q_token}'"
-    )
-
+    # Configure git inside the container to use the proxy.  Token comes
+    # via stdin (--with-stdin) so it never appears in the remote argv.
+    payload = _AUTH_PROXY_GIT_CONFIG_PAYLOAD.format(port=_CONTAINER_PROXY_PORT)
     try:
         _ssh_run(
             remote_host,
@@ -455,12 +530,14 @@ def setup_auth_proxy_remote(
                 "bubble",
                 "internal",
                 "incus-exec",
+                "--with-stdin",
                 container,
                 "bash",
                 "-c",
-                f"su - user -c {shlex.quote(git_config_cmd)}",
+                _bash_with_stdin_token(payload),
             ],
             timeout=15,
+            input=token + "\n",
         )
     except Exception as e:
         if not machine_readable:
@@ -521,28 +598,23 @@ def _setup_gh_proxy_remote(
             detail("gh CLI will not have API access.")
         return
 
-    # Configure gh environment via profile.d
-    q_token = shlex.quote(token)
-    gh_repo_line = ""
-    repo_file_line = ""
-    if owner and repo:
-        q_repo = shlex.quote(f"{owner}/{repo}")
-        gh_repo_line = f" && echo 'export GH_REPO={q_repo}' >> /etc/profile.d/bubble-gh.sh"
-        # Also write to a file for the gh wrapper to read in non-login shells
-        repo_file_line = f" && echo {q_repo} > /etc/bubble/gh/repo"
-    profile_cmd = (
-        f'echo "export GH_CONFIG_DIR=/etc/bubble/gh" > /etc/profile.d/bubble-gh.sh'
-        f" && echo 'export GH_TOKEN={q_token}' >> /etc/profile.d/bubble-gh.sh"
-        f"{gh_repo_line}"
-        f" && chmod 644 /etc/profile.d/bubble-gh.sh"
-        f"{repo_file_line}"
-    )
-
+    # Configure gh environment via profile.d.  Token comes via stdin.
+    payload = _gh_proxy_profile_payload(owner, repo)
     try:
         _ssh_run(
             remote_host,
-            ["bubble", "internal", "incus-exec", container, "bash", "-c", profile_cmd],
+            [
+                "bubble",
+                "internal",
+                "incus-exec",
+                "--with-stdin",
+                container,
+                "bash",
+                "-c",
+                _bash_with_stdin_token(payload),
+            ],
             timeout=15,
+            input=token + "\n",
         )
     except RuntimeError as e:
         if not machine_readable:
@@ -569,15 +641,12 @@ def inject_gh_token(
             detail("Warning: no host GitHub token available. Run 'gh auth login' first.")
         return False
 
-    q_token = shlex.quote(token)
-    profile_script = (
-        f'echo "export GH_TOKEN={q_token}" > /etc/profile.d/bubble-gh-inject.sh'
-        f" && echo 'export GITHUB_TOKEN={q_token}' >> /etc/profile.d/bubble-gh-inject.sh"
-        f" && chmod 644 /etc/profile.d/bubble-gh-inject.sh"
-    )
-
     try:
-        runtime.exec(container, ["bash", "-c", profile_script])
+        runtime.exec(
+            container,
+            ["bash", "-c", _bash_with_stdin_token(_GH_INJECT_PROFILE_PAYLOAD)],
+            input=token + "\n",
+        )
     except RuntimeError as e:
         if not machine_readable:
             detail(f"Warning: failed to inject GitHub token: {e}")
@@ -607,18 +676,21 @@ def inject_gh_token_remote(
             detail("Warning: no host GitHub token available. Run 'gh auth login' first.")
         return False
 
-    q_token = shlex.quote(token)
-    profile_script = (
-        f'echo "export GH_TOKEN={q_token}" > /etc/profile.d/bubble-gh-inject.sh'
-        f" && echo 'export GITHUB_TOKEN={q_token}' >> /etc/profile.d/bubble-gh-inject.sh"
-        f" && chmod 644 /etc/profile.d/bubble-gh-inject.sh"
-    )
-
     try:
         _ssh_run(
             remote_host,
-            ["bubble", "internal", "incus-exec", container, "bash", "-c", profile_script],
+            [
+                "bubble",
+                "internal",
+                "incus-exec",
+                "--with-stdin",
+                container,
+                "bash",
+                "-c",
+                _bash_with_stdin_token(_GH_INJECT_PROFILE_PAYLOAD),
+            ],
             timeout=15,
+            input=token + "\n",
         )
     except Exception as e:
         if not machine_readable:

--- a/bubble/remote.py
+++ b/bubble/remote.py
@@ -200,8 +200,15 @@ def _ssh_run(
     check: bool = True,
     capture: bool = True,
     timeout: int = 30,
+    input: str | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run a command on the remote host via SSH."""
+    """Run a command on the remote host via SSH.
+
+    When *input* is provided, it is piped to ssh's stdin; ssh forwards
+    stdin to the remote process by default, so the remote command's stdin
+    reads *input*.  This is the right channel for secrets that must not
+    appear in argv (visible in ``ps`` on the remote host).
+    """
     # SSH concatenates args after the destination and passes them to the
     # remote shell.  Shell-quote each part so spaces and metacharacters
     # in any argument are preserved correctly on the remote side.
@@ -213,6 +220,7 @@ def _ssh_run(
         text=True,
         check=check,
         timeout=timeout,
+        input=input,
     )
 
 

--- a/bubble/runtime/base.py
+++ b/bubble/runtime/base.py
@@ -71,10 +71,14 @@ class ContainerRuntime(ABC):
         """Delete a container."""
 
     @abstractmethod
-    def exec(self, name: str, command: list[str], **kwargs) -> str:
+    def exec(self, name: str, command: list[str], *, input: str | None = None, **kwargs) -> str:
         """Execute a command inside a container, return stdout.
 
         Raises ``RuntimeError`` (or a subclass) if the command fails.
+
+        ``input`` (when non-None) is piped to the command's stdin.  This is
+        the right channel for sensitive data — anything passed in argv shows
+        up in the container's process list.
         """
 
     @abstractmethod

--- a/bubble/runtime/incus.py
+++ b/bubble/runtime/incus.py
@@ -177,11 +177,19 @@ class IncusRuntime(ContainerRuntime):
             args.append("--force")
         self._run(args)
 
-    def exec(self, name: str, command: list[str], **kwargs) -> str:
+    def exec(self, name: str, command: list[str], *, input: str | None = None, **kwargs) -> str:
         args = ["exec", self._q(name), "--"]
         args.extend(command)
         cmd = ["incus"] + args
-        result = subprocess.run(cmd, capture_output=True, text=True, stdin=subprocess.DEVNULL)
+        # When *input* is provided we pipe it through stdin so secrets stay
+        # out of the container's argv (process list).  Otherwise we close
+        # stdin so subprocesses don't inherit our terminal.
+        run_kwargs: dict = {"capture_output": True, "text": True}
+        if input is None:
+            run_kwargs["stdin"] = subprocess.DEVNULL
+        else:
+            run_kwargs["input"] = input
+        result = subprocess.run(cmd, **run_kwargs)
         if result.returncode != 0:
             raise IncusError(result.returncode, cmd, result.stdout, result.stderr)
         return result.stdout.strip()

--- a/tests/test_github_token.py
+++ b/tests/test_github_token.py
@@ -137,12 +137,22 @@ def test_setup_auth_proxy_remote_starts_tunnel():
             graphql_write="none",
         )
 
-        # Two SSH calls: incus device add + incus exec (git config)
+        # Two SSH calls: incus device add + incus exec (writing .gitconfig)
         assert mock_ssh.call_count == 2
         device_call = mock_ssh.call_args_list[0]
         assert "bubble-auth-proxy" in device_call[0][1]
         git_call = mock_ssh.call_args_list[1]
-        assert "git config" in " ".join(str(a) for a in git_call[0][1])
+        argv = git_call[0][1]
+        # The git config write goes through bubble internal incus-exec
+        assert argv[:4] == ["bubble", "internal", "incus-exec", "--with-stdin"]
+        # Bash payload references $TOKEN (literal) and writes .gitconfig
+        bash_script = " ".join(str(a) for a in argv)
+        assert "/home/user/.gitconfig" in bash_script
+        assert "X-Bubble-Token: $TOKEN" in bash_script
+        # Token must NOT appear in argv — it's piped via input=
+        assert "tok123" not in bash_script
+        # Token MUST appear in the input kwarg (stdin payload)
+        assert "tok123" in (git_call[1].get("input") or "")
 
 
 def test_setup_auth_proxy_remote_tunnel_fails():

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -18,8 +18,8 @@ class _RecordingRuntime:
         self.exec_calls: list[tuple] = []
         self.add_device_calls: list[tuple] = []
 
-    def exec(self, name, command, **kwargs):
-        self.exec_calls.append((name, list(command)))
+    def exec(self, name, command, *, input=None, **kwargs):
+        self.exec_calls.append((name, list(command), input))
         return "ok"
 
     def add_device(self, name, device_name, device_type, **props):
@@ -59,7 +59,7 @@ def test_incus_exec_forwards_argv(monkeypatch, tmp_data_dir):
         ["internal", "incus-exec", "my-bubble", "bash", "-c", "echo hello"],
     )
     assert result.exit_code == 0
-    assert rt.exec_calls == [("my-bubble", ["bash", "-c", "echo hello"])]
+    assert rt.exec_calls == [("my-bubble", ["bash", "-c", "echo hello"], None)]
     # Output is forwarded
     assert "ok" in result.output
 
@@ -83,7 +83,38 @@ def test_incus_exec_passes_dashes_through(monkeypatch, tmp_data_dir):
         ["internal", "incus-exec", "my-bubble", "ls", "-la", "--color=auto"],
     )
     assert result.exit_code == 0
-    assert rt.exec_calls == [("my-bubble", ["ls", "-la", "--color=auto"])]
+    assert rt.exec_calls == [("my-bubble", ["ls", "-la", "--color=auto"], None)]
+
+
+def test_incus_exec_with_stdin_pipes_stdin_to_runtime(monkeypatch, tmp_data_dir):
+    """--with-stdin reads our stdin and passes it to runtime.exec(input=...)."""
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["internal", "incus-exec", "--with-stdin", "my-bubble", "bash", "-c", "cat"],
+        input="secret-token\n",
+    )
+    assert result.exit_code == 0
+    # Token reached the runtime via the input= kwarg, not argv
+    assert rt.exec_calls == [
+        ("my-bubble", ["bash", "-c", "cat"], "secret-token\n"),
+    ]
+
+
+def test_incus_exec_without_with_stdin_does_not_read_stdin(monkeypatch, tmp_data_dir):
+    """Without --with-stdin, input= stays None even if stdin has content."""
+    rt = _RecordingRuntime()
+    _patch_runtime(monkeypatch, rt)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["internal", "incus-exec", "my-bubble", "true"],
+        input="should-be-ignored\n",
+    )
+    assert result.exit_code == 0
+    assert rt.exec_calls == [("my-bubble", ["true"], None)]
 
 
 def test_incus_exec_runtime_error_exits_nonzero(monkeypatch, tmp_data_dir):

--- a/tests/test_token_no_argv_leak.py
+++ b/tests/test_token_no_argv_leak.py
@@ -1,0 +1,161 @@
+"""Security regression: tokens must not appear in argv.
+
+These tests don't actually run incus or ssh — they intercept the calls
+just before subprocess.run is invoked and assert that the token string
+appears nowhere in the argv that would be visible via /proc/<pid>/cmdline
+on the host or inside the container.
+
+If a callsite ever regresses to embedding the token in a shell command,
+these tests catch it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def captured_runtime_calls(monkeypatch):
+    """Make IncusRuntime.exec record its argv + input rather than running."""
+    from bubble.runtime import incus as incus_mod
+
+    calls: list[dict] = []
+
+    def fake_exec(self, name, command, *, input=None, **kwargs):
+        calls.append({"name": name, "command": list(command), "input": input})
+        return ""
+
+    monkeypatch.setattr(incus_mod.IncusRuntime, "exec", fake_exec)
+    monkeypatch.setattr(incus_mod.IncusRuntime, "add_device", lambda *a, **kw: None)
+    return calls
+
+
+@pytest.fixture
+def captured_ssh_calls(monkeypatch):
+    """Intercept _ssh_run to capture argv + input without spawning ssh."""
+    import subprocess
+
+    import bubble.remote as remote_mod
+
+    calls: list[dict] = []
+
+    def fake_ssh_run(host, command, **kwargs):
+        calls.append({"command": list(command), "input": kwargs.get("input")})
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(remote_mod, "_ssh_run", fake_ssh_run)
+    return calls
+
+
+SENSITIVE_TOKEN = "ghp_thisIsTheRealHostToken_doNotLeak"
+
+
+def _assert_token_not_in_argv(calls: list[dict], token: str):
+    """For every captured call, the token must be in input= but NEVER in argv."""
+    found_in_input = False
+    for call in calls:
+        for arg in call["command"]:
+            assert token not in str(arg), (
+                f"Token leaked into argv element: {arg!r}\nFull call: {call!r}"
+            )
+        if call.get("input") and token in call["input"]:
+            found_in_input = True
+    assert found_in_input, (
+        f"Token never reached the input= channel — was it dropped?\nCalls: {calls!r}"
+    )
+
+
+def test_setup_auth_proxy_local_does_not_leak_token(
+    captured_runtime_calls, monkeypatch, tmp_data_dir
+):
+    """Local setup_auth_proxy never puts the per-container token in argv."""
+    import bubble.github_token as gt
+    import bubble.runtime.incus as incus_mod
+
+    monkeypatch.setattr(gt, "_ensure_auth_proxy_running", lambda: 7654)
+    monkeypatch.setattr(gt, "_wait_for_proxy_device", lambda *a, **kw: None)
+    monkeypatch.setattr("bubble.auth_proxy.generate_auth_token", lambda *a, **kw: SENSITIVE_TOKEN)
+
+    runtime = incus_mod.IncusRuntime()
+    ok = gt.setup_auth_proxy(runtime, "my-container", "kim-em", "bubble")
+    assert ok is True
+    _assert_token_not_in_argv(captured_runtime_calls, SENSITIVE_TOKEN)
+
+
+def test_setup_auth_proxy_remote_does_not_leak_token(captured_ssh_calls, monkeypatch, tmp_data_dir):
+    """Remote setup_auth_proxy never puts the token in any SSH-shipped argv."""
+    import bubble.github_token as gt
+
+    monkeypatch.setattr(gt, "_ensure_auth_proxy_running", lambda: 7654)
+    monkeypatch.setattr("bubble.tunnel.start_tunnel", lambda *a, **kw: True)
+    monkeypatch.setattr("bubble.auth_proxy.generate_auth_token", lambda *a, **kw: SENSITIVE_TOKEN)
+
+    remote_host = type("H", (), {"spec_string": lambda self: "h", "ssh_destination": "h"})()
+    ok = gt.setup_auth_proxy_remote(remote_host, "my-container", "kim-em", "bubble")
+    assert ok is True
+    _assert_token_not_in_argv(captured_ssh_calls, SENSITIVE_TOKEN)
+
+
+def test_inject_gh_token_local_does_not_leak_token(
+    captured_runtime_calls, monkeypatch, tmp_data_dir
+):
+    import bubble.github_token as gt
+    import bubble.runtime.incus as incus_mod
+
+    monkeypatch.setattr(gt, "get_host_gh_token", lambda: SENSITIVE_TOKEN)
+
+    runtime = incus_mod.IncusRuntime()
+    ok = gt.inject_gh_token(runtime, "my-container")
+    assert ok is True
+    _assert_token_not_in_argv(captured_runtime_calls, SENSITIVE_TOKEN)
+
+
+def test_inject_gh_token_remote_does_not_leak_token(captured_ssh_calls, monkeypatch, tmp_data_dir):
+    import bubble.github_token as gt
+
+    monkeypatch.setattr(gt, "get_host_gh_token", lambda: SENSITIVE_TOKEN)
+
+    remote_host = type("H", (), {"spec_string": lambda self: "h", "ssh_destination": "h"})()
+    ok = gt.inject_gh_token_remote(remote_host, "my-container")
+    assert ok is True
+    _assert_token_not_in_argv(captured_ssh_calls, SENSITIVE_TOKEN)
+
+
+def test_runtime_exec_input_kwarg_pipes_to_stdin(monkeypatch):
+    """IncusRuntime.exec(input=...) actually passes input= to subprocess.run."""
+    import subprocess
+
+    import bubble.runtime.incus as incus_mod
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        captured["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(incus_mod.subprocess, "run", fake_run)
+    rt = incus_mod.IncusRuntime()
+    rt.exec("foo", ["bash"], input="hello-stdin")
+    assert captured["input"] == "hello-stdin"
+    # When input is passed, stdin must NOT be DEVNULL (which would block writes)
+    assert captured.get("stdin") is not subprocess.DEVNULL
+
+
+def test_runtime_exec_no_input_closes_stdin(monkeypatch):
+    """Without input=, stdin is closed (DEVNULL) so subprocesses don't block on inherited tty."""
+    import subprocess
+
+    import bubble.runtime.incus as incus_mod
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(incus_mod.subprocess, "run", fake_run)
+    rt = incus_mod.IncusRuntime()
+    rt.exec("foo", ["true"])
+    assert captured["stdin"] is subprocess.DEVNULL
+    assert "input" not in captured


### PR DESCRIPTION
Codex flagged this during the #277 review and I deferred it as a separate concern. Here's the fix.

## The problem

Token-bearing commands in bubble/github_token.py constructed bash strings like:

    incus exec container -- bash -c \"su - user -c 'git config --global http.<proxy>.extraHeader \"X-Bubble-Token: <real-token>\"'\"

The expanded token ends up in the bash/git/su process's argv on the box. Any other user (or a neighbor container with /proc visibility) could read it via /proc/<pid>/cmdline for the duration of the call. Not multi-tenant in practice, but cheap to fix and the right default.

## The fix

Move tokens to stdin. Three layers, kept narrow:

1. **runtime layer** — ContainerRuntime.exec gains an 'input: str | None' parameter that pipes to subprocess.run(input=...). When None, stdin stays DEVNULL (existing behavior).
2. **SSH layer** — _ssh_run gains the same 'input=' parameter; ssh forwards stdin to the remote process by default.
3. **internal RPC** — 'bubble internal incus-exec' learns '--with-stdin' which slurps its own stdin and forwards as input= to the runtime. Without the flag, behavior is unchanged.

In github_token.py, a small '_bash_with_stdin_token(payload)' helper wraps each script with 'IFS= read -r TOKEN' at the top. The bash text only references the literal '\$TOKEN' (the variable name), never the value. The token enters via input=.

The .gitconfig-write payload now writes directly to /home/user/.gitconfig via heredoc instead of going through 'git config --global', because even 'git config ... extraHeader \"\$TOKEN\"' would put the expanded value in git's argv. Same for the /etc/profile.d/bubble-gh*.sh files: cat-from-heredoc, not echo.

## Six callsites migrated

- setup_auth_proxy (local), line 272
- _setup_gh_proxy (local), line 339
- setup_auth_proxy_remote, line 444
- _setup_gh_proxy_remote, line 527
- inject_gh_token (local), line 574
- inject_gh_token_remote, line 612

## Tests

New tests/test_token_no_argv_leak.py is the security regression. It patches subprocess.run and _ssh_run, then for each of the four entry points (setup_auth_proxy / setup_auth_proxy_remote / inject_gh_token / inject_gh_token_remote) asserts that the token string appears nowhere in any captured argv, only in the input= channel. If a future callsite regresses to embedding the token in a command line, these tests fail loudly.

Also two new tests in tests/test_internal.py for --with-stdin's stdin-reading behavior, and an update to the existing setup_auth_proxy_remote test in tests/test_github_token.py to assert the new shape.

1123 tests pass total.

🤖 Prepared with Claude Code