### PR TITLE
fix: drop unreachable multi-top-level-field exception in GraphQL validator

### DIFF
--- a/bubble/graphql_validator.py
+++ b/bubble/graphql_validator.py
@@ -718,14 +718,7 @@ def validate_structure(parsed: ParsedGraphQL, op_count: int = 1) -> str | None:
     if len(parsed.top_level_fields) == 0:
         return "No fields in operation"
     if len(parsed.top_level_fields) > 1:
-        # Allow multiple scalar fields for RepositoryInfo queries
-        if parsed.op_type == "query" and all(
-            f.name in ALLOWED_REPO_FIELDS and f.selection_start is None
-            for f in parsed.top_level_fields
-        ):
-            pass  # RepositoryInfo exception: multiple scalar fields
-        else:
-            return "Multiple top-level fields not allowed"
+        return "Multiple top-level fields not allowed"
 
     # No aliases on top-level fields
     if any(f.alias is not None for f in parsed.top_level_fields):
@@ -758,8 +751,13 @@ def validate_read(
     preflight_fn: callable(node_id) -> "owner/repo" or None
     Returns error message or None if valid.
     """
-    if not parsed.top_level_fields:
-        return "No fields in query"
+    # Defense-in-depth: validate_structure already enforces exactly one
+    # top-level field, but assert it here too so this helper is safe if
+    # ever called without structural validation. Without this check, only
+    # parsed.top_level_fields[0] is inspected and any trailing fields would
+    # silently bypass repo-scoping.
+    if len(parsed.top_level_fields) != 1:
+        return "Expected exactly one top-level field"
 
     field_name = parsed.top_level_fields[0].name
 
@@ -863,8 +861,11 @@ def validate_write(
     repo_node_id_fn: callable(owner, repo) -> node_id or None
     Returns error message or None if valid.
     """
-    if not parsed.top_level_fields:
-        return "No fields in mutation"
+    # Defense-in-depth: structural validation already enforces a single
+    # top-level field. Re-check here so this helper stays safe if ever
+    # called without it.
+    if len(parsed.top_level_fields) != 1:
+        return "Expected exactly one top-level field"
 
     mutation_name = parsed.top_level_fields[0].name
 

--- a/tests/test_graphql_validator.py
+++ b/tests/test_graphql_validator.py
@@ -285,17 +285,20 @@ class TestStructuralValidation:
         assert error is not None
         assert "Multiple" in error
 
-    def test_multiple_scalar_fields_allowed(self):
-        """RepositoryInfo exception: multiple scalar fields under repository are OK,
-        but multiple top-level fields are still rejected."""
-        # Multiple scalar fields AT the top level (as if inside a repository selection)
-        # would only happen if the top-level fields are all in ALLOWED_REPO_FIELDS
-        # and have no selection set
+    def test_multiple_top_level_scalars_rejected(self):
+        """Multiple top-level fields are rejected unconditionally.
+
+        Real gh queries nest scalars under `repository(...) { ... }`, so there
+        is no need for a top-level multi-scalar exception. Allowing one would
+        be a footgun: any future addition of a scalar to
+        ALLOWED_TOP_LEVEL_QUERY_FIELDS would silently bypass repo-scoping on
+        fields 2..N.
+        """
         query = "query { name description url }"
         parsed, op_count = self._parse(query)
-        # These are scalar fields in ALLOWED_REPO_FIELDS without selection sets
         error = validate_structure(parsed, op_count)
-        assert error is None
+        assert error is not None
+        assert "Multiple" in error
 
     def test_alias_rejected(self):
         parsed, op_count = self._parse("query { myAlias: repository { name } }")


### PR DESCRIPTION
This PR fixes #288 by dropping the unreachable multi-top-level-field exception in `validate_structure`, and adds a defense-in-depth invariant at the top of `validate_read` and `validate_write` that rejects anything other than exactly one top-level field.

`validate_structure` previously allowed multiple top-level fields when all were scalar and all were in `ALLOWED_REPO_FIELDS`, intended for `RepositoryInfo`-style queries. Real `gh` `RepositoryInfo` queries nest those scalars under `repository(...) { ... }`, so the branch was unreachable in practice — but it would silently turn into a repo-scoping bypass on fields 2..N if any scalar were ever added to `ALLOWED_TOP_LEVEL_QUERY_FIELDS`, since `validate_read` only inspects `top_level_fields[0]`.

The unreachability was a coincidence of two independent allowlists, and the right policy is "exactly one top-level field" full stop. The defense-in-depth check in `validate_read`/`validate_write` keeps those helpers safe even if a future caller skips structural validation.

Codex was consulted on whether to delete the exception or harden `validate_read` to iterate every top-level field; it agreed deletion is the right primary fix and suggested the small invariant added here.

🤖 Prepared with Claude Code