### PR TITLE
feat: narrow SSH authorized_keys injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 - **IPv6 blocked**: All IPv6 traffic is dropped
 - **DNS restricted**: DNS queries only go to the container's configured resolver
 - **No outbound SSH**: Containers cannot SSH out (VSCode uses `incus exec` ProxyCommand)
-- **SSH key-only auth**: Password authentication is disabled
+- **SSH key-only auth**: Password authentication is disabled. By default only `~/.ssh/id_ed25519.pub` is injected as `authorized_keys` (with `id_rsa.pub`/`id_ecdsa.pub` as fallbacks if no ed25519 key exists). Override with `[ssh] authorized_keys = "~/.ssh/yubikey.pub"` (or a list) in `~/.bubble/config.toml`, or with the `BUBBLE_AUTHORIZED_KEYS` env var (colon-separated paths).
 - **Shell injection hardening**: All user-supplied values are quoted with `shlex.quote()`
 - **Per-repo git mount**: Each container only sees its own bare repo, not the entire git store
 - **Bubble-in-bubble relay**: Containers can open new bubbles on the host, but only for repos already cloned in `~/.bubble/git/`. Disable with `bubble security set relay off`

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -359,7 +359,7 @@ def _open_remote(
     org_repo = result.get("org_repo", "")
 
     # Inject local SSH keys into the container so the chained ProxyCommand works
-    inject_local_ssh_keys(remote_host, name)
+    inject_local_ssh_keys(remote_host, name, config=config)
 
     # Set up GitHub auth based on the unified github security level
     gh_level = get_github_level(config)

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -74,6 +74,7 @@ DEFAULT_CONFIG = {
         "credentials": True,
     },
     "security": {},
+    "ssh": {},
     "tools": {},
 }
 

--- a/bubble/container_helpers.py
+++ b/bubble/container_helpers.py
@@ -1,5 +1,6 @@
 """Shared container helper functions: find, ensure running, SSH, git config, network."""
 
+import os
 import shlex
 import subprocess
 import sys
@@ -13,6 +14,65 @@ from .output import detail, step
 from .runtime.base import ContainerRuntime
 from .security import filter_github_domains
 from .vscode import add_ssh_config
+
+
+def collect_authorized_keys(config: dict | None = None) -> list[str]:
+    """Collect public key contents to inject as authorized_keys in containers.
+
+    Resolution order (first match wins):
+      1. ``BUBBLE_AUTHORIZED_KEYS`` env var (colon-separated paths).
+      2. ``[ssh] authorized_keys`` config — string path or list of paths.
+      3. Default: ``~/.ssh/id_ed25519.pub`` if present.
+      4. Fallback (only when no ed25519 key exists): ``~/.ssh/id_rsa.pub``
+         and ``~/.ssh/id_ecdsa.pub``.
+
+    Paths support ``~`` expansion. With (1) or (2), every listed path must
+    exist; missing files raise ``ClickException``. An explicit empty list
+    means "no keys" — SSH will still be running but nothing will be
+    authorized.
+    """
+    explicit_paths: list[str] | None = None
+
+    env_value = os.environ.get("BUBBLE_AUTHORIZED_KEYS")
+    if env_value is not None:
+        explicit_paths = [p for p in env_value.split(":") if p]
+    elif config is not None:
+        cfg_value = config.get("ssh", {}).get("authorized_keys")
+        if isinstance(cfg_value, str):
+            explicit_paths = [cfg_value] if cfg_value else []
+        elif isinstance(cfg_value, list):
+            explicit_paths = [str(p) for p in cfg_value]
+        elif cfg_value is not None:
+            raise click.ClickException(
+                f"[ssh] authorized_keys must be a string or list of strings, "
+                f"got {type(cfg_value).__name__}"
+            )
+
+    if explicit_paths is not None:
+        keys: list[str] = []
+        for path_str in explicit_paths:
+            path = Path(path_str).expanduser()
+            if not path.exists():
+                raise click.ClickException(f"SSH key file not found: {path_str}")
+            content = path.read_text().strip()
+            if content:
+                keys.append(content)
+        return keys
+
+    ssh_dir = Path.home() / ".ssh"
+    ed25519 = ssh_dir / "id_ed25519.pub"
+    if ed25519.exists():
+        content = ed25519.read_text().strip()
+        return [content] if content else []
+
+    keys = []
+    for fallback in ("id_rsa.pub", "id_ecdsa.pub"):
+        path = ssh_dir / fallback
+        if path.exists():
+            content = path.read_text().strip()
+            if content:
+                keys.append(content)
+    return keys
 
 
 def find_container(runtime: ContainerRuntime, name: str):
@@ -36,16 +96,16 @@ def ensure_running(runtime: ContainerRuntime, name: str):
     return info
 
 
-def setup_ssh(runtime: ContainerRuntime, name: str, host_key_trust: bool = True):
+def setup_ssh(
+    runtime: ContainerRuntime,
+    name: str,
+    host_key_trust: bool = True,
+    config: dict | None = None,
+):
     """Start SSH and inject host public keys into a container."""
     runtime.exec(name, ["bash", "-c", "service ssh start || /usr/sbin/sshd"])
 
-    ssh_dir = Path.home() / ".ssh"
-    pub_keys = []
-    for key_file in ["id_ed25519.pub", "id_rsa.pub", "id_ecdsa.pub"]:
-        key_path = ssh_dir / key_file
-        if key_path.exists():
-            pub_keys.append(key_path.read_text().strip())
+    pub_keys = collect_authorized_keys(config)
     if pub_keys:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".keys", delete=False) as f:
             f.write("\n".join(pub_keys) + "\n")

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -2,7 +2,6 @@
 
 import json
 import shlex
-from pathlib import Path
 
 import click
 
@@ -73,7 +72,12 @@ def finalize_bubble(
         from .output import step
 
         step("Setting up SSH access...")
-    setup_ssh(runtime, name, host_key_trust=is_enabled(config, "host_key_trust"))
+    setup_ssh(
+        runtime,
+        name,
+        host_key_trust=is_enabled(config, "host_key_trust"),
+        config=config,
+    )
     setup_git_config(runtime, name, git_name, git_email)
 
     commit = ""
@@ -179,41 +183,40 @@ def machine_readable_output(status: str, name: str, **kwargs):
     click.echo(json.dumps(data))
 
 
-def inject_local_ssh_keys(remote_host, container_name: str):
+def inject_local_ssh_keys(remote_host, container_name: str, config: dict | None = None):
     """Inject local SSH public keys into a remote container's authorized_keys.
 
     The remote `bubble open` only injects the remote host's keys. For the
     chained ProxyCommand (local → remote → container) to work, the local
     machine's keys must also be present.
     """
+    from .container_helpers import collect_authorized_keys
     from .remote import _ssh_run
 
-    ssh_dir = Path.home() / ".ssh"
-    pub_keys = []
-    for key_file in ["id_ed25519.pub", "id_rsa.pub", "id_ecdsa.pub"]:
-        key_path = ssh_dir / key_file
-        if key_path.exists():
-            pub_keys.append(key_path.read_text().strip())
+    pub_keys = collect_authorized_keys(config)
     if not pub_keys:
         return
 
-    keys_str = "\\n".join(pub_keys)
-    # Append local keys to the container's authorized_keys via the remote
-    # bubble's runtime (so bubble-colima:/local: prefix is applied for us).
+    # Pipe the keys via stdin rather than embedding them in the shell
+    # command — public-key comments may legally contain quotes, '$',
+    # backticks, etc., which would otherwise be mangled or expanded.
+    keys_blob = "\n".join(pub_keys) + "\n"
     _ssh_run(
         remote_host,
         [
             "bubble",
             "internal",
             "incus-exec",
+            "--with-stdin",
             container_name,
             "su",
             "-",
             "user",
             "-c",
-            f"mkdir -p ~/.ssh && chmod 700 ~/.ssh "
-            f'&& printf "{keys_str}\\n" >> ~/.ssh/authorized_keys '
-            f"&& chmod 600 ~/.ssh/authorized_keys",
+            "mkdir -p ~/.ssh && chmod 700 ~/.ssh "
+            "&& cat >> ~/.ssh/authorized_keys "
+            "&& chmod 600 ~/.ssh/authorized_keys",
         ],
         timeout=15,
+        input=keys_blob,
     )

--- a/tests/test_authorized_keys.py
+++ b/tests/test_authorized_keys.py
@@ -1,0 +1,129 @@
+"""Tests for authorized_keys collection logic."""
+
+import click
+import pytest
+
+from bubble.container_helpers import collect_authorized_keys
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Provide a temporary HOME with an empty .ssh dir."""
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Also clear the env var so tests don't pick up a real one
+    monkeypatch.delenv("BUBBLE_AUTHORIZED_KEYS", raising=False)
+    return tmp_path
+
+
+def _write_key(ssh_dir, name, content="ssh-ed25519 AAAA test"):
+    path = ssh_dir / name
+    path.write_text(content + "\n")
+    return path
+
+
+class TestDefaults:
+    def test_no_keys_returns_empty(self, fake_home):
+        assert collect_authorized_keys() == []
+        assert collect_authorized_keys({}) == []
+
+    def test_only_ed25519(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_ed25519.pub", "ssh-ed25519 AAAA me")
+        keys = collect_authorized_keys()
+        assert keys == ["ssh-ed25519 AAAA me"]
+
+    def test_ed25519_preferred_over_rsa(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_ed25519.pub", "ssh-ed25519 AAAA me")
+        _write_key(fake_home / ".ssh", "id_rsa.pub", "ssh-rsa AAAA old")
+        keys = collect_authorized_keys()
+        assert keys == ["ssh-ed25519 AAAA me"]
+
+    def test_falls_back_to_rsa_when_no_ed25519(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_rsa.pub", "ssh-rsa AAAA old")
+        keys = collect_authorized_keys()
+        assert keys == ["ssh-rsa AAAA old"]
+
+    def test_falls_back_to_ecdsa(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_ecdsa.pub", "ecdsa-sha2 AAAA card")
+        keys = collect_authorized_keys()
+        assert keys == ["ecdsa-sha2 AAAA card"]
+
+    def test_includes_both_rsa_and_ecdsa_when_no_ed25519(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_rsa.pub", "ssh-rsa AAAA old")
+        _write_key(fake_home / ".ssh", "id_ecdsa.pub", "ecdsa-sha2 AAAA card")
+        keys = collect_authorized_keys()
+        assert "ssh-rsa AAAA old" in keys
+        assert "ecdsa-sha2 AAAA card" in keys
+        assert len(keys) == 2
+
+    def test_empty_pub_file_skipped(self, fake_home):
+        (fake_home / ".ssh" / "id_ed25519.pub").write_text("")
+        assert collect_authorized_keys() == []
+
+
+class TestConfigOverride:
+    def test_string_path(self, fake_home):
+        path = _write_key(fake_home / ".ssh", "yubikey.pub", "ssh-ed25519 AAAA yk")
+        # Also drop a default key to confirm it's ignored
+        _write_key(fake_home / ".ssh", "id_ed25519.pub", "ssh-ed25519 AAAA me")
+        cfg = {"ssh": {"authorized_keys": str(path)}}
+        keys = collect_authorized_keys(cfg)
+        assert keys == ["ssh-ed25519 AAAA yk"]
+
+    def test_list_paths(self, fake_home):
+        p1 = _write_key(fake_home / ".ssh", "yubikey.pub", "ssh-ed25519 AAAA yk")
+        p2 = _write_key(fake_home / ".ssh", "laptop.pub", "ssh-ed25519 AAAA lap")
+        _write_key(fake_home / ".ssh", "id_ed25519.pub", "ssh-ed25519 AAAA me")
+        cfg = {"ssh": {"authorized_keys": [str(p1), str(p2)]}}
+        keys = collect_authorized_keys(cfg)
+        assert keys == ["ssh-ed25519 AAAA yk", "ssh-ed25519 AAAA lap"]
+
+    def test_tilde_expansion(self, fake_home):
+        _write_key(fake_home / ".ssh", "yubikey.pub", "ssh-ed25519 AAAA yk")
+        cfg = {"ssh": {"authorized_keys": "~/.ssh/yubikey.pub"}}
+        keys = collect_authorized_keys(cfg)
+        assert keys == ["ssh-ed25519 AAAA yk"]
+
+    def test_missing_explicit_path_raises(self, fake_home):
+        cfg = {"ssh": {"authorized_keys": str(fake_home / ".ssh" / "nope.pub")}}
+        with pytest.raises(click.ClickException, match="not found"):
+            collect_authorized_keys(cfg)
+
+    def test_empty_list_returns_no_keys(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_ed25519.pub", "ssh-ed25519 AAAA me")
+        cfg = {"ssh": {"authorized_keys": []}}
+        # Explicit empty list overrides defaults
+        assert collect_authorized_keys(cfg) == []
+
+    def test_empty_string_returns_no_keys(self, fake_home):
+        _write_key(fake_home / ".ssh", "id_ed25519.pub", "ssh-ed25519 AAAA me")
+        cfg = {"ssh": {"authorized_keys": ""}}
+        assert collect_authorized_keys(cfg) == []
+
+    def test_invalid_type_raises(self, fake_home):
+        cfg = {"ssh": {"authorized_keys": 42}}
+        with pytest.raises(click.ClickException, match="must be a string or list"):
+            collect_authorized_keys(cfg)
+
+
+class TestEnvVar:
+    def test_env_var_overrides_config(self, fake_home, monkeypatch):
+        path = _write_key(fake_home / ".ssh", "env.pub", "ssh-ed25519 AAAA env")
+        cfg_path = _write_key(fake_home / ".ssh", "cfg.pub", "ssh-ed25519 AAAA cfg")
+        monkeypatch.setenv("BUBBLE_AUTHORIZED_KEYS", str(path))
+        cfg = {"ssh": {"authorized_keys": str(cfg_path)}}
+        keys = collect_authorized_keys(cfg)
+        assert keys == ["ssh-ed25519 AAAA env"]
+
+    def test_env_var_colon_separated(self, fake_home, monkeypatch):
+        p1 = _write_key(fake_home / ".ssh", "a.pub", "ssh-ed25519 AAAA a")
+        p2 = _write_key(fake_home / ".ssh", "b.pub", "ssh-ed25519 AAAA b")
+        monkeypatch.setenv("BUBBLE_AUTHORIZED_KEYS", f"{p1}:{p2}")
+        keys = collect_authorized_keys()
+        assert keys == ["ssh-ed25519 AAAA a", "ssh-ed25519 AAAA b"]
+
+    def test_env_var_missing_path_raises(self, fake_home, monkeypatch):
+        monkeypatch.setenv("BUBBLE_AUTHORIZED_KEYS", str(fake_home / ".ssh" / "nope.pub"))
+        with pytest.raises(click.ClickException, match="not found"):
+            collect_authorized_keys()


### PR DESCRIPTION
This PR tightens which host SSH public keys end up in a bubble's `authorized_keys`. Previously `setup_ssh` concatenated every `~/.ssh/id_*.pub` on the host with no per-bubble selection or opt-out, so any private half from a synced backup or older laptop install could be used to SSH the bubble.

The default is now `~/.ssh/id_ed25519.pub` only, with `id_rsa.pub`/`id_ecdsa.pub` as a fallback only when no ed25519 key is present. Users can narrow further (or list specific keys like a Yubikey) via `[ssh] authorized_keys` in `~/.bubble/config.toml` (string or list of paths, `~` expanded) or the `BUBBLE_AUTHORIZED_KEYS` env var (colon-separated paths). Both the local `setup_ssh` path and the remote `inject_local_ssh_keys` path go through the same helper so behavior is consistent.

Also fixes a latent shell-injection issue in `inject_local_ssh_keys`: public-key comments may legally contain `"`, `$`, backticks, spaces, etc., which would have been mangled or expanded by the `printf "..."` chain it used to embed keys in a `su -c` command. Keys are now piped via `--with-stdin`/`cat` so they reach `authorized_keys` byte-for-byte without going through a shell.

Closes https://github.com/kim-em/bubble/issues/289

🤖 Prepared with Claude Code