### PR TITLE
fix: rate-limit and cache GraphQL preflight calls

### DIFF
--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -39,6 +39,7 @@ import os
 import re
 import ssl
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.error import HTTPError
 from urllib.parse import urlparse
@@ -73,6 +74,14 @@ RATE_LIMIT_PER_HOUR = 600
 
 # Maximum tracked containers
 MAX_TRACKED_CONTAINERS = 100
+
+# Pre-flight result cache TTLs (seconds). Positive results are cached longer
+# to avoid re-querying for legitimate repeated mutations on the same node.
+# Negative results are cached briefly to blunt loops on bad/never-resolving IDs
+# without keeping stale "missing" answers around.
+PREFLIGHT_POSITIVE_CACHE_TTL = 300.0
+PREFLIGHT_NEGATIVE_CACHE_TTL = 60.0
+MAX_PREFLIGHT_CACHE_ENTRIES = 1024
 
 # ---------------------------------------------------------------------------
 # Path patterns
@@ -604,6 +613,18 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
     _repo_node_id_cache: dict[tuple[str, str], str] = {}
     _repo_node_id_lock = threading.Lock()
 
+    # Pre-flight node-id resolution cache. Stores both positive and negative
+    # results with TTLs to avoid re-querying GitHub for repeated probes.
+    # Maps node_id -> (resolved_repo_or_None, expiry_unix_ts).
+    _preflight_cache: dict[str, tuple[str | None, float]] = {}
+    _preflight_cache_lock = threading.Lock()
+
+    # In-flight singleflight tracking. Prevents the threaded HTTP server from
+    # firing N concurrent host-side preflights for the same node id when N
+    # handlers all miss the cache simultaneously.
+    _preflight_inflight: dict[str, threading.Event] = {}
+    _preflight_inflight_lock = threading.Lock()
+
     def log_message(self, format, *args):
         """Route HTTP server logs to our logger."""
         logger.info(format, *args)
@@ -842,8 +863,8 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
                     parsed,
                     owner,
                     repo,
-                    preflight_fn=self._preflight_check,
-                    repo_node_id_fn=self._get_repo_node_id,
+                    preflight_fn=lambda nid: self._preflight_check(nid, container),
+                    repo_node_id_fn=lambda o, r: self._get_repo_node_id(o, r, container),
                 )
                 if error:
                     self._send_error(403, f"GraphQL mutation validation failed: {error}")
@@ -867,7 +888,7 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
                     parsed,
                     owner,
                     repo,
-                    preflight_fn=self._preflight_check,
+                    preflight_fn=lambda nid: self._preflight_check(nid, container),
                 )
                 if error:
                     self._send_error(403, f"GraphQL read validation failed: {error}")
@@ -898,13 +919,27 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
         resp = opener.open(req, timeout=30)
         return json.loads(resp.read())
 
-    def _get_repo_node_id(self, owner: str, repo: str) -> str | None:
-        """Get the GitHub node ID for a repository. Cached."""
+    def _get_repo_node_id(self, owner: str, repo: str, container: str) -> str | None:
+        """Get the GitHub node ID for a repository. Cached.
+
+        Counts uncached upstream queries against the originating container's
+        rate window so misbehaving containers can't burn the host's GitHub
+        quota through preflight traffic.
+        """
         key = (owner.lower(), repo.lower())
         with self._repo_node_id_lock:
             cached = self._repo_node_id_cache.get(key)
             if cached is not None:
                 return cached
+
+        if not self.rate_limiter.check(container):
+            logger.info(
+                "PREFLIGHT rate-limited container=%s repo_id_lookup=%s/%s",
+                container,
+                owner,
+                repo,
+            )
+            return None
 
         from .graphql_validator import REPO_ID_QUERY
 
@@ -919,19 +954,114 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
             logger.info("PREFLIGHT repo_node_id failed for %s/%s", owner, repo)
             return None
 
-    def _preflight_check(self, node_id: str) -> str | None:
+    def _preflight_cache_get(self, node_id: str) -> tuple[bool, str | None]:
+        """Look up a preflight result in the cache. Returns (hit, value)."""
+        now = time.time()
+        with self._preflight_cache_lock:
+            cached = self._preflight_cache.get(node_id)
+            if cached is None:
+                return False, None
+            value, expiry = cached
+            if expiry <= now:
+                # Expired: drop and miss.
+                self._preflight_cache.pop(node_id, None)
+                return False, None
+            return True, value
+
+    def _preflight_cache_put(self, node_id: str, value: str | None) -> None:
+        """Cache a preflight result with TTL based on positive/negative."""
+        ttl = PREFLIGHT_POSITIVE_CACHE_TTL if value else PREFLIGHT_NEGATIVE_CACHE_TTL
+        expiry = time.time() + ttl
+        with self._preflight_cache_lock:
+            # Bound the cache: drop the entry with the soonest expiry if full.
+            if (
+                len(self._preflight_cache) >= MAX_PREFLIGHT_CACHE_ENTRIES
+                and node_id not in self._preflight_cache
+            ):
+                oldest = min(self._preflight_cache, key=lambda k: self._preflight_cache[k][1])
+                self._preflight_cache.pop(oldest, None)
+            self._preflight_cache[node_id] = (value, expiry)
+
+    def _preflight_check(self, node_id: str, container: str) -> str | None:
         """Check which repo a node belongs to.
 
-        Returns "owner/repo" string or None on failure.
+        Returns "owner/repo" string or None on failure / unverifiable.
+
+        Counts uncached upstream queries against the originating container's
+        rate window so misbehaving containers can't burn the host's GitHub
+        quota through preflight traffic. Caches both positive results and
+        definitive negative answers from GitHub with short TTLs so repeated
+        probes for the same ID don't re-query at all. Transient failures
+        (network errors, timeouts, GraphQL-level errors) are NOT cached, to
+        avoid one upstream blip locking out a legitimate node ID for 60s.
+
+        Concurrent misses for the same node id are serialized via a per-id
+        singleflight so a flood of parallel handlers can't fan out into N
+        host-side calls before the first one populates the cache.
         """
-        from .graphql_validator import PREFLIGHT_QUERY, extract_repo_from_preflight
+        hit, value = self._preflight_cache_get(node_id)
+        if hit:
+            return value
+
+        # Singleflight: at most one upstream query per node id at a time.
+        # If another handler is already querying, wait for its result then
+        # re-check the cache. If the cache still misses (transient failure
+        # — those aren't cached), fall through and try again ourselves,
+        # subject to the rate limiter.
+        while True:
+            with self._preflight_inflight_lock:
+                event = self._preflight_inflight.get(node_id)
+                if event is None:
+                    event = threading.Event()
+                    self._preflight_inflight[node_id] = event
+                    is_leader = True
+                else:
+                    is_leader = False
+            if is_leader:
+                break
+            # Wait modestly longer than the upstream timeout (30s) so a
+            # stuck leader can't pin us forever.
+            event.wait(timeout=35)
+            hit, value = self._preflight_cache_get(node_id)
+            if hit:
+                return value
+            # Cache miss after the leader finished — leader saw a transient
+            # failure and didn't cache. Loop to take the leader role.
 
         try:
-            data = self._github_graphql_query(PREFLIGHT_QUERY, {"id": node_id})
-            return extract_repo_from_preflight(data)
-        except Exception:
-            logger.info("PREFLIGHT check failed for node %s", node_id)
-            return None
+            if not self.rate_limiter.check(container):
+                logger.info(
+                    "PREFLIGHT rate-limited container=%s node_id=%s",
+                    container,
+                    node_id,
+                )
+                # Don't cache: the rate-limit decision is per-container/
+                # per-window, not a property of the node ID.
+                return None
+
+            from .graphql_validator import PREFLIGHT_QUERY, extract_repo_from_preflight
+
+            try:
+                data = self._github_graphql_query(PREFLIGHT_QUERY, {"id": node_id})
+            except Exception:
+                logger.info("PREFLIGHT check failed for node %s", node_id)
+                # Transient (HTTP error / timeout / network): don't cache.
+                return None
+
+            # Treat GraphQL-level errors as transient too: a 200 with an
+            # `errors` array can be a server hiccup ("Something went wrong",
+            # secondary rate limit, etc.) and shouldn't poison the cache.
+            if isinstance(data, dict) and data.get("errors"):
+                logger.info("PREFLIGHT graphql errors for node %s", node_id)
+                return None
+
+            result = extract_repo_from_preflight(data)
+            self._preflight_cache_put(node_id, result)
+            return result
+        finally:
+            with self._preflight_inflight_lock:
+                self._preflight_inflight.pop(node_id, None)
+            event.set()
 
     def _forward_to_github(
         self,

--- a/tests/test_auth_proxy.py
+++ b/tests/test_auth_proxy.py
@@ -1009,6 +1009,308 @@ class TestAccessLevelRouting:
 
 
 # ---------------------------------------------------------------------------
+# Pre-flight rate limiting and caching (issue #286)
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightRateLimiting:
+    """Pre-flight queries against GitHub must:
+
+    1. Count toward the originating container's rate window so a misbehaving
+       container can't burn the host's GitHub API quota.
+    2. Cache positive and negative results so repeated probes for the same
+       node don't issue fresh upstream queries.
+    """
+
+    def _make_handler(self):
+        handler = AuthProxyHandler.__new__(AuthProxyHandler)
+        handler.rate_limiter = ProxyRateLimiter()
+        handler.token_refresher = GitHubTokenRefresher("ghp_test_token")
+        # Reset class-level caches so tests are independent.
+        handler._repo_node_id_cache = {}
+        handler._preflight_cache = {}
+        handler._preflight_inflight = {}
+        handler._repo_node_id_lock = threading.Lock()
+        handler._preflight_cache_lock = threading.Lock()
+        handler._preflight_inflight_lock = threading.Lock()
+        return handler
+
+    def test_preflight_consumes_rate_quota(self, monkeypatch):
+        """Each upstream preflight call consumes a slot in the container's
+        rate window so a flood of bad-id mutations can't bypass throttling."""
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {"data": {"node": None}}
+
+        handler._github_graphql_query = fake_query
+
+        # First call hits upstream and consumes a quota slot.
+        result = handler._preflight_check("node-1", "c1")
+        assert result is None
+        assert len(calls) == 1
+        assert len(handler.rate_limiter._requests["c1"]) == 1
+
+    def test_preflight_blocked_when_rate_limited(self, monkeypatch):
+        """When the container is over its window, preflight skips upstream."""
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {"data": {"node": None}}
+
+        handler._github_graphql_query = fake_query
+
+        # Saturate the per-minute window.
+        for _ in range(60):
+            handler.rate_limiter.check("c1")
+
+        # Use a fresh node id (no cache) to force an upstream attempt.
+        result = handler._preflight_check("fresh-node", "c1")
+        assert result is None
+        assert calls == []  # upstream not called
+
+    def test_preflight_negative_result_cached(self, monkeypatch):
+        """Repeated probes for the same bad node id only hit upstream once
+        within the negative-cache TTL, so a loop on a single bad id can't
+        burn through the rate window."""
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {"data": {"node": None}}
+
+        handler._github_graphql_query = fake_query
+
+        for _ in range(50):
+            result = handler._preflight_check("bad-id", "c1")
+            assert result is None
+
+        assert len(calls) == 1
+        # And only one rate-limit slot was consumed.
+        assert len(handler.rate_limiter._requests["c1"]) == 1
+
+    def test_preflight_positive_result_cached(self, monkeypatch):
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {
+                "data": {
+                    "node": {
+                        "__typename": "Issue",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    }
+                }
+            }
+
+        handler._github_graphql_query = fake_query
+
+        for _ in range(5):
+            assert handler._preflight_check("good-id", "c1") == "owner/repo"
+        assert len(calls) == 1
+
+    def test_preflight_negative_cache_expires(self, monkeypatch):
+        """Once the negative TTL passes, a probe for the same id re-queries
+        and re-consumes a quota slot."""
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {"data": {"node": None}}
+
+        handler._github_graphql_query = fake_query
+
+        # Patch time so the cache entry appears expired on the second call.
+        from bubble import auth_proxy as ap
+
+        t = [1000.0]
+        monkeypatch.setattr(ap.time, "time", lambda: t[0])
+
+        assert handler._preflight_check("bad-id", "c1") is None
+        assert len(calls) == 1
+
+        t[0] += ap.PREFLIGHT_NEGATIVE_CACHE_TTL + 1
+        assert handler._preflight_check("bad-id", "c1") is None
+        assert len(calls) == 2
+
+    def test_preflight_cache_ignores_rate_limit_misses(self, monkeypatch):
+        """Rate-limit denials must not poison the cache: the next request
+        from a fresh container should still resolve normally."""
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {
+                "data": {
+                    "node": {
+                        "__typename": "Issue",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    }
+                }
+            }
+
+        handler._github_graphql_query = fake_query
+
+        # Saturate c1, then probe.
+        for _ in range(60):
+            handler.rate_limiter.check("c1")
+        assert handler._preflight_check("node-X", "c1") is None
+        assert calls == []
+
+        # c2 has fresh quota and should succeed.
+        assert handler._preflight_check("node-X", "c2") == "owner/repo"
+        assert len(calls) == 1
+
+    def test_repo_node_id_consumes_rate_quota(self, monkeypatch):
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {"data": {"repository": {"id": "R_xyz"}}}
+
+        handler._github_graphql_query = fake_query
+
+        assert handler._get_repo_node_id("o", "r", "c1") == "R_xyz"
+        assert len(calls) == 1
+        assert len(handler.rate_limiter._requests["c1"]) == 1
+
+        # Cached: no further upstream calls, no further quota consumed.
+        assert handler._get_repo_node_id("o", "r", "c1") == "R_xyz"
+        assert len(calls) == 1
+        assert len(handler.rate_limiter._requests["c1"]) == 1
+
+    def test_preflight_transient_exception_not_cached(self, monkeypatch):
+        """A network/HTTP error must NOT poison the cache: a single bad
+        moment shouldn't lock out a legitimate node id for the negative TTL."""
+        handler = self._make_handler()
+        attempts = []
+
+        def fake_query(query, variables):
+            attempts.append(variables)
+            if len(attempts) == 1:
+                raise OSError("transient network error")
+            return {
+                "data": {
+                    "node": {
+                        "__typename": "Issue",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    }
+                }
+            }
+
+        handler._github_graphql_query = fake_query
+
+        # First attempt fails with a transient error; nothing cached.
+        assert handler._preflight_check("legit-id", "c1") is None
+        assert len(attempts) == 1
+
+        # Second attempt: same id, no waiting required, fresh upstream call,
+        # this time succeeds.
+        assert handler._preflight_check("legit-id", "c1") == "owner/repo"
+        assert len(attempts) == 2
+
+    def test_preflight_graphql_errors_not_cached(self, monkeypatch):
+        """GraphQL-level errors (200 + errors[]) are treated as transient:
+        could be secondary rate limit, server hiccup, etc."""
+        handler = self._make_handler()
+        attempts = []
+        responses = [
+            {"errors": [{"type": "RATE_LIMITED", "message": "slow down"}]},
+            {
+                "data": {
+                    "node": {
+                        "__typename": "Issue",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    }
+                }
+            },
+        ]
+
+        def fake_query(query, variables):
+            attempts.append(variables)
+            return responses[len(attempts) - 1]
+
+        handler._github_graphql_query = fake_query
+
+        assert handler._preflight_check("id-x", "c1") is None
+        assert handler._preflight_check("id-x", "c1") == "owner/repo"
+        assert len(attempts) == 2
+
+    def test_preflight_singleflight_serializes_concurrent_misses(self, monkeypatch):
+        """Concurrent handlers asking about the same uncached node id must
+        result in only one upstream call. This prevents N-handler fan-out
+        from amplifying a single fake id into N host quota burns."""
+        handler = self._make_handler()
+        attempts = []
+        gate = threading.Event()
+        upstream_lock = threading.Lock()
+
+        def fake_query(query, variables):
+            with upstream_lock:
+                attempts.append(variables)
+                # Hold the leader inside the upstream call until other
+                # threads have queued up behind the singleflight.
+                gate.wait(timeout=2)
+            return {
+                "data": {
+                    "node": {
+                        "__typename": "Issue",
+                        "repository": {"nameWithOwner": "owner/repo"},
+                    }
+                }
+            }
+
+        handler._github_graphql_query = fake_query
+
+        results = []
+        threads = [
+            threading.Thread(
+                target=lambda: results.append(handler._preflight_check("hot-id", f"c{i}"))
+            )
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        # Give followers a moment to enter and block on the singleflight.
+        time.sleep(0.05)
+        gate.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert results == ["owner/repo"] * 8
+        # Exactly one upstream call across all 8 concurrent handlers.
+        assert len(attempts) == 1
+        # And only one rate-limit slot consumed (by the leader).
+        total_slots = sum(len(q) for q in handler.rate_limiter._requests.values())
+        assert total_slots == 1
+
+    def test_repo_node_id_blocked_when_rate_limited(self, monkeypatch):
+        handler = self._make_handler()
+        calls = []
+
+        def fake_query(query, variables):
+            calls.append(variables)
+            return {"data": {"repository": {"id": "R_xyz"}}}
+
+        handler._github_graphql_query = fake_query
+
+        for _ in range(60):
+            handler.rate_limiter.check("c1")
+
+        assert handler._get_repo_node_id("o", "r", "c1") is None
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
 # Integration: API proxy round-trip
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes a bypass in the auth proxy where GraphQL preflight ownership checks went to `api.github.com` under the host token without crossing the per-container rate window. A misbehaving container could fire ~600 mutations/hr with random fake node ids and burn the host's authenticated GitHub quota (5,000/hr) even though its own `ProxyRateLimiter` was capped at 60/min, 600/hr.

The originating container is now threaded down into `_preflight_check` and `_get_repo_node_id`. Each uncached upstream query consumes a slot in that container's rate window before any host-side call; on denial the preflight returns None and the validator treats the node as ownership-unverifiable and rejects the mutation.

A small TTL'd preflight cache absorbs repeats: positive results cached 5 min, definitive negatives 1 min. Transient failures (network errors, GraphQL `errors` arrays) are not cached so one upstream blip can't lock out a legitimate node id for a minute. Concurrent handlers hitting the same uncached id collapse to one upstream call via a per-id singleflight, so the threaded HTTP server can't fan out into N host calls before the first response populates the cache.

Closes https://github.com/kim-em/bubble/issues/286

🤖 Prepared with Claude Code