### PR TITLE
fix: stop leaking GitHub Set-Cookie / Location headers to containers

### DIFF
--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -118,6 +118,40 @@ _REDIRECT_ALLOWED_HOSTS = [
     "*.githubusercontent.com",
 ]
 
+# Response headers stripped before forwarding to the container. The container
+# authenticates to the proxy with its bubble token only — no other state should
+# bridge container and GitHub. The hop-by-hop entries are stripped because the
+# proxy terminates the upstream connection (RFC 7230 §6.1). The remaining
+# entries close auxiliary channels: Authorization / Proxy-Authorization could
+# echo upstream credentials; Set-Cookie would let GitHub (or an attacker
+# substituting an upstream response) plant client-side state the container
+# could replay against an exfil target; WWW-Authenticate / Proxy-Authenticate
+# prompt the client into a separate auth scheme outside the bubble token model.
+_STRIPPED_RESPONSE_HEADERS = frozenset(
+    {
+        # Hop-by-hop (RFC 7230 §6.1)
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "te",
+        "trailer",
+        "upgrade",
+        "proxy-authenticate",
+        "proxy-authorization",
+        # Auxiliary auth/state channels
+        "authorization",
+        "set-cookie",
+        "www-authenticate",
+    }
+)
+
+# On 4xx responses the Location header is purely informational (no redirect
+# follow happens) and would disclose upstream redirect targets — including
+# blob-storage URLs that already passed our redirect allowlist. Strip it on
+# error pass-through but keep it on 3xx so the container can follow redirects
+# the proxy explicitly chose not to handle.
+_STRIPPED_4XX_RESPONSE_HEADERS = _STRIPPED_RESPONSE_HEADERS | {"location"}
+
 logger = logging.getLogger("bubble.auth_proxy")
 
 
@@ -467,10 +501,13 @@ def _is_redirect_host_allowed(host: str) -> bool:
 
 def _follow_redirect(
     location: str, hops_remaining: int, method: str = "GET"
-) -> tuple[int, dict, bytes]:
+) -> tuple[int, list[tuple[str, str]], bytes]:
     """Follow a redirect URL with hardened rules.
 
-    Returns (status_code, headers_dict, body).
+    Returns (status_code, headers_list, body). Headers are returned as a
+    list of (name, value) tuples to preserve repeated headers (e.g. Link
+    pagination headers).
+
     Raises ValueError on policy violations.
     """
     parsed = urlparse(location)
@@ -513,8 +550,7 @@ def _follow_redirect(
             raise ValueError("Redirect response too large")
         body_parts.append(chunk)
 
-    headers = {k: v for k, v in resp.getheaders()}
-    return resp.status, headers, b"".join(body_parts)
+    return resp.status, resp.getheaders(), b"".join(body_parts)
 
 
 # ---------------------------------------------------------------------------
@@ -624,6 +660,13 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
         if auth.startswith("Bearer "):
             return auth[7:].strip()
         return None
+
+    def _copy_response_headers(self, headers_iter, stripped=_STRIPPED_RESPONSE_HEADERS):
+        """Forward upstream response headers, dropping anything in `stripped`."""
+        for header, value in headers_iter:
+            if header.lower() in stripped:
+                continue
+            self.send_header(header, value)
 
     def _authenticate(self) -> dict | None:
         """Authenticate the request via X-Bubble-Token.
@@ -991,11 +1034,7 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
                     return
                 # For git or non-followable redirects, return as-is
                 self.send_response(e.code)
-                for header, value in e.headers.items():
-                    lower = header.lower()
-                    if lower in ("transfer-encoding", "connection", "keep-alive"):
-                        continue
-                    self.send_header(header, value)
+                self._copy_response_headers(e.headers.items())
                 self.end_headers()
                 body_data = e.read()
                 if body_data:
@@ -1035,14 +1074,9 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
             # Pass through 4xx errors from GitHub (auth failures, not found, etc.)
             if 400 <= e.code < 500:
                 self.send_response(e.code)
-                for header, value in e.headers.items():
-                    lower = header.lower()
-                    if lower in ("transfer-encoding", "connection", "keep-alive"):
-                        continue
-                    # Strip GitHub's auth-related headers
-                    if lower == "authorization":
-                        continue
-                    self.send_header(header, value)
+                self._copy_response_headers(
+                    e.headers.items(), stripped=_STRIPPED_4XX_RESPONSE_HEADERS
+                )
                 self.end_headers()
                 body_data = e.read()
                 if body_data:
@@ -1079,11 +1113,7 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
 
         # Send response back to client
         self.send_response(resp.status)
-        for header, value in resp.getheaders():
-            lower = header.lower()
-            if lower in ("transfer-encoding", "connection", "keep-alive"):
-                continue
-            self.send_header(header, value)
+        self._copy_response_headers(resp.getheaders())
         self.end_headers()
 
         # Stream response body
@@ -1119,11 +1149,13 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
             return
 
         self.send_response(status)
-        for header, value in headers.items():
-            lower = header.lower()
-            if lower in ("transfer-encoding", "connection", "keep-alive"):
-                continue
-            self.send_header(header, value)
+        # Defensive: today _follow_redirect only returns on 2xx (HTTPError is
+        # raised above and converted to 502), but if that ever changes, keep
+        # the same Location-strip rule that direct 4xx pass-through uses.
+        stripped = (
+            _STRIPPED_4XX_RESPONSE_HEADERS if 400 <= status < 500 else _STRIPPED_RESPONSE_HEADERS
+        )
+        self._copy_response_headers(headers, stripped=stripped)
         self.end_headers()
         if body:
             self.wfile.write(body)

--- a/tests/test_auth_proxy.py
+++ b/tests/test_auth_proxy.py
@@ -356,6 +356,140 @@ class TestAuthProxyHandler:
         assert 403 in handler._responses
 
 
+class TestCopyResponseHeaders:
+    """The proxy must not bridge auxiliary state (cookies, auth challenges,
+    upstream redirect targets on errors) between GitHub and the container."""
+
+    def _make_handler(self):
+        handler = AuthProxyHandler.__new__(AuthProxyHandler)
+        handler._sent = []
+        handler.send_header = lambda k, v: handler._sent.append((k, v))
+        return handler
+
+    def test_default_strips_auxiliary_headers(self):
+        from bubble.auth_proxy import _STRIPPED_RESPONSE_HEADERS
+
+        handler = self._make_handler()
+        upstream = [
+            ("Content-Type", "application/json"),
+            ("Set-Cookie", "_gh_sess=abc; Path=/"),
+            ("WWW-Authenticate", 'Bearer realm="GitHub"'),
+            ("Authorization", "token leaked"),
+            ("Transfer-Encoding", "chunked"),
+            ("Connection", "keep-alive"),
+            ("Keep-Alive", "timeout=5"),
+            ("Location", "https://example.com/redirect"),
+            ("X-RateLimit-Remaining", "42"),
+        ]
+        handler._copy_response_headers(upstream)
+        forwarded = {k.lower() for k, _ in handler._sent}
+        assert forwarded.isdisjoint(_STRIPPED_RESPONSE_HEADERS)
+        # Non-stripped headers (including Location and X-RateLimit-*) survive
+        # by default — Location is required on 3xx for the container to
+        # follow proxy-skipped redirects.
+        assert "content-type" in forwarded
+        assert "location" in forwarded
+        assert "x-ratelimit-remaining" in forwarded
+
+    def test_4xx_strips_location(self):
+        from bubble.auth_proxy import _STRIPPED_4XX_RESPONSE_HEADERS
+
+        handler = self._make_handler()
+        upstream = [
+            ("Content-Type", "application/json"),
+            ("Set-Cookie", "_gh_sess=abc"),
+            ("Location", "https://blob.example.com/sensitive"),
+            ("X-RateLimit-Remaining", "0"),
+        ]
+        handler._copy_response_headers(upstream, stripped=_STRIPPED_4XX_RESPONSE_HEADERS)
+        forwarded = {k.lower(): v for k, v in handler._sent}
+        assert "location" not in forwarded
+        assert "set-cookie" not in forwarded
+        assert forwarded.get("content-type") == "application/json"
+        # X-RateLimit-* remains visible — useful for clients to back off.
+        assert "x-ratelimit-remaining" in forwarded
+
+    def test_repeated_set_cookie_all_stripped(self):
+        """HTTPMessage.items() yields one entry per Set-Cookie value; each
+        must be filtered."""
+        handler = self._make_handler()
+        upstream = [
+            ("Set-Cookie", "a=1"),
+            ("Set-Cookie", "b=2"),
+            ("Content-Type", "text/plain"),
+        ]
+        handler._copy_response_headers(upstream)
+        assert all(k.lower() != "set-cookie" for k, _ in handler._sent)
+        assert ("Content-Type", "text/plain") in handler._sent
+
+    def test_case_insensitive_matching(self):
+        handler = self._make_handler()
+        upstream = [
+            ("SET-COOKIE", "x=1"),
+            ("set-cookie", "y=2"),
+            ("Set-Cookie", "z=3"),
+        ]
+        handler._copy_response_headers(upstream)
+        assert handler._sent == []
+
+    def test_useful_github_headers_preserved(self):
+        """Don't strip headers gh CLI relies on for pagination and backoff."""
+        handler = self._make_handler()
+        upstream = [
+            ("Link", '<https://api.github.com/x?page=2>; rel="next"'),
+            ("Link", '<https://api.github.com/x?page=3>; rel="last"'),
+            ("X-RateLimit-Limit", "5000"),
+            ("X-RateLimit-Remaining", "4999"),
+            ("X-RateLimit-Reset", "1700000000"),
+            ("Retry-After", "60"),
+        ]
+        handler._copy_response_headers(upstream)
+        # Both Link entries forwarded — pagination relies on this.
+        link_values = [v for k, v in handler._sent if k.lower() == "link"]
+        assert len(link_values) == 2
+        assert all(k.lower() != "set-cookie" for k, _ in handler._sent)
+        assert ("Retry-After", "60") in handler._sent
+        assert ("X-RateLimit-Remaining", "4999") in handler._sent
+
+    def test_extended_hop_by_hop_stripped(self):
+        from bubble.auth_proxy import _STRIPPED_RESPONSE_HEADERS
+
+        # RFC 7230 §6.1 hop-by-hop headers should never reach the container.
+        for name in (
+            "TE",
+            "Trailer",
+            "Upgrade",
+            "Proxy-Authenticate",
+            "Proxy-Authorization",
+        ):
+            assert name.lower() in _STRIPPED_RESPONSE_HEADERS
+
+    def test_real_httperror_set_cookie_duplicates_stripped(self):
+        """HTTPError.headers is an email.message.Message — verify items()
+        yields one entry per Set-Cookie value (not collapsed) and our helper
+        filters all of them."""
+        import email.message
+
+        from bubble.auth_proxy import _STRIPPED_RESPONSE_HEADERS
+
+        msg = email.message.Message()
+        msg["Set-Cookie"] = "session=abc"
+        msg["Set-Cookie"] = "user=xyz"
+        msg["Content-Type"] = "application/json"
+        msg["X-RateLimit-Remaining"] = "0"
+
+        # Confirm the assumption baked into the production code: items()
+        # really does yield one tuple per Set-Cookie value.
+        cookie_count = sum(1 for k, _ in msg.items() if k.lower() == "set-cookie")
+        assert cookie_count == 2
+
+        handler = self._make_handler()
+        handler._copy_response_headers(msg.items())
+        forwarded = {k.lower() for k, _ in handler._sent}
+        assert forwarded.isdisjoint(_STRIPPED_RESPONSE_HEADERS)
+        assert "x-ratelimit-remaining" in forwarded
+
+
 # ---------------------------------------------------------------------------
 # Integration: full proxy round-trip with mock GitHub backend
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR stops the auth proxy from forwarding GitHub's `Set-Cookie`, `WWW-Authenticate`, and `Location` headers — and several hop-by-hop headers — through to containers on 4xx responses (and tightens the same denylist on the 2xx, 3xx, and followed-redirect paths).

The proxy is meant to be the *only* channel between a bubble and GitHub, with the per-container token as the bubble's only identity. The previous denylist (just `transfer-encoding`/`connection`/`keep-alive` everywhere, plus `authorization` on 4xx) let `Set-Cookie` reach containers — replayable against attacker-controlled exfil targets — and let `Location` disclose upstream redirect targets including blob-storage URLs that already passed our redirect allowlist.

Factor a single `_copy_response_headers` helper and a `_STRIPPED_RESPONSE_HEADERS` set, applied at all four header-copy sites. Strip the RFC 7230 §6.1 hop-by-hop set in full (`TE`, `Trailer`, `Upgrade`, `Proxy-Authenticate`, `Proxy-Authorization`) plus the auxiliary auth/state channels (`Set-Cookie`, `WWW-Authenticate`). Strip `Location` on 4xx specifically — it's informational only when no redirect follow happens. Keep `X-RateLimit-*`, `Link`, and `Retry-After`: gh CLI relies on them for backoff and pagination.

Also fix `_follow_redirect` to return a list of `(name, value)` tuples instead of a dict — the previous `dict(...)` comprehension collapsed repeated headers, dropping all but the last `Link` entry on the followed-redirect path.

Reviewed independently by Codex; their findings on incomplete hop-by-hop coverage, the dict-collapse of repeated `Link` headers in `_follow_redirect`, and a defensive 4xx strip in `_handle_redirect` are all addressed here.

Closes #287

🤖 Prepared with Claude Code