### PR TITLE
fix: re-apply network allowlist after a stop/start cycle

### DIFF
--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.16"
+__version__ = "0.7.17"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -440,6 +440,8 @@ def _open_remote(
 
 def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=False):
     """Re-attach to an existing container."""
+    # ``ensure_running`` re-applies the network allowlist on stop/start
+    # transitions; see issue #285.
     ensure_running(runtime, name)
 
     if no_interactive:

--- a/bubble/commands/infrastructure.py
+++ b/bubble/commands/infrastructure.py
@@ -32,14 +32,23 @@ def register_infrastructure_commands(main):
     @network_group.command("apply")
     @click.argument("name")
     def network_apply(name):
-        """Apply network allowlist to a bubble."""
-        from ..container_helpers import apply_network
+        """Apply network allowlist to a bubble.
+
+        Restores the hook-contributed domains stored at provision time so a
+        manual replay matches the original bubble's allowlist (issue #285).
+        """
+        from ..container_helpers import apply_network, recover_extra_domains
+        from ..lifecycle import get_bubble_info
 
         config = load_config()
         runtime = get_runtime(config, ensure_ready=False)
         ensure_running(runtime, name)
 
-        apply_network(runtime, name, config)
+        info = get_bubble_info(name) or {}
+        extra_domains = info.get("extra_domains")
+        if extra_domains is None:
+            extra_domains = recover_extra_domains(info) or []
+        apply_network(runtime, name, config, extra_domains=list(extra_domains))
 
     @network_group.command("remove")
     @click.argument("name")

--- a/bubble/commands/lifecycle.py
+++ b/bubble/commands/lifecycle.py
@@ -233,15 +233,17 @@ def register_lifecycle_commands(main):
                 click.echo(f"No bubbles unused for {age}+ days.")
                 return
 
-        # Start stopped/frozen containers temporarily for checking
+        # Start stopped/frozen containers temporarily for checking. ``incus
+        # stop`` destroys the network namespace, so route stopped containers
+        # through ``ensure_running`` to replay the iptables allowlist before
+        # we exec ``check_clean`` inside them (issue #285).
+        from ..container_helpers import ensure_running
+
         started_containers = []
         for c in to_start:
             try:
                 click.echo(f"  Starting {c.name} for inspection...")
-                if c.state == "frozen":
-                    runtime.unfreeze(c.name)
-                else:
-                    runtime.start(c.name)
+                ensure_running(runtime, c.name)
                 started_containers.append(c)
                 to_check.append(c)
             except Exception as e:

--- a/bubble/container_helpers.py
+++ b/bubble/container_helpers.py
@@ -85,15 +85,89 @@ def find_container(runtime: ContainerRuntime, name: str):
 
 
 def ensure_running(runtime: ContainerRuntime, name: str):
-    """Ensure a container is running (unpause/start if needed)."""
+    """Ensure a container is running, restoring iptables rules on stop/start.
+
+    ``incus stop`` destroys the container's network namespace, which drops
+    the iptables allowlist installed at provision time. Without an explicit
+    replay the container would silently come back up with default-ACCEPT
+    egress (issue #285). Freeze/unfreeze (incus pause/start) keeps the
+    namespace intact, so paused bubbles don't need replay.
+
+    On replay failure the container is stopped again so the next attempt
+    starts from a clean ``stopped`` state — failing closed rather than
+    leaving an unprotected container running.
+    """
     info = find_container(runtime, name)
-    if info.state == "frozen":
+    prior_state = info.state
+    if prior_state == "frozen":
         step(f"Unpausing '{name}'...")
         runtime.unfreeze(name)
-    elif info.state == "stopped":
+    elif prior_state == "stopped":
         step(f"Starting '{name}'...")
         runtime.start(name)
+        try:
+            reapply_network_after_restart(runtime, name)
+        except Exception:
+            try:
+                runtime.stop(name)
+            except Exception:
+                pass
+            raise
     return info
+
+
+def reapply_network_after_restart(runtime: ContainerRuntime, name: str):
+    """Re-apply the network allowlist after an ``incus stop``/``start`` cycle.
+
+    Looks up the bubble's network state from the registry: ``network_enabled``
+    decides whether to re-apply at all (so ``--no-network`` bubbles aren't
+    suddenly locked down), and ``extra_domains`` restores the hook-contributed
+    allowlist that the container was originally provisioned with.
+
+    Legacy entries that predate the registry fields are handled
+    conservatively: ``network_enabled`` defaults to ``True`` (the historical
+    default of the ``--network`` flag) and ``extra_domains`` is recovered by
+    re-detecting the language hook against the bare repo.
+    """
+    from .config import load_config
+    from .lifecycle import get_bubble_info
+
+    info = get_bubble_info(name) or {}
+    if not info.get("network_enabled", True):
+        return
+
+    extra_domains = info.get("extra_domains")
+    if extra_domains is None:
+        extra_domains = recover_extra_domains(info) or []
+
+    config = load_config()
+    apply_network(runtime, name, config, extra_domains=list(extra_domains))
+
+
+def recover_extra_domains(info: dict) -> list[str] | None:
+    """Best-effort recovery of hook domains for legacy registry entries.
+
+    Returns ``None`` when recovery isn't possible (no org_repo, no bare repo,
+    or no matching hook). Prefers ``commit`` over ``branch`` so that long-lived
+    bubbles whose branch tip has advanced upstream still see the same hook
+    output that the bubble was originally provisioned with.
+    """
+    org_repo = info.get("org_repo")
+    if not org_repo:
+        return None
+    repo_short = org_repo.split("/")[-1] if "/" in org_repo else org_repo
+    from .config import DATA_DIR
+    from .hooks import select_hook
+
+    bare_repo = DATA_DIR / "git" / f"{repo_short}.git"
+    if not bare_repo.exists():
+        return None
+    ref = info.get("commit") or info.get("branch") or "HEAD"
+    try:
+        hook = select_hook(bare_repo, ref)
+    except Exception:
+        return None
+    return list(hook.network_domains()) if hook else []
 
 
 def setup_ssh(

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -89,6 +89,7 @@ def finalize_bubble(
     except Exception:
         pass
 
+    extra_domains = list(hook.network_domains()) if hook else []
     register_bubble(
         name,
         t.org_repo,
@@ -97,6 +98,8 @@ def finalize_bubble(
         pr=int(t.ref) if t.kind == "pr" else 0,
         base_image=image_name,
         project_dir=project_dir,
+        network_enabled=network,
+        extra_domains=extra_domains,
     )
 
     workspace_file = hook.workspace_file(project_dir) if hook else None

--- a/bubble/lifecycle.py
+++ b/bubble/lifecycle.py
@@ -61,8 +61,15 @@ def register_bubble(
     base_image: str = "",
     remote_host: str = "",
     project_dir: str = "",
+    network_enabled: bool | None = None,
+    extra_domains: list[str] | None = None,
 ):
-    """Record a bubble's creation in the registry."""
+    """Record a bubble's creation in the registry.
+
+    network_enabled and extra_domains capture the network allowlist state
+    so that ``_reattach`` can rebuild iptables rules after ``incus stop``
+    destroys the container's network namespace. See issue #285.
+    """
     with _registry_lock():
         registry = _read_registry()
         entry = {
@@ -78,6 +85,13 @@ def register_bubble(
             entry["remote_host"] = remote_host
         if project_dir:
             entry["project_dir"] = project_dir
+        if network_enabled is not None:
+            entry["network_enabled"] = bool(network_enabled)
+        # Persist whenever the caller knows the value (including ``[]``) so a
+        # post-fix entry is distinguishable from a legacy one and we don't
+        # uselessly re-run hook detection on every restart.
+        if extra_domains is not None:
+            entry["extra_domains"] = list(extra_domains)
         registry["bubbles"][name] = entry
         _save_registry(registry)
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -73,6 +73,34 @@ class TestRegistry:
         assert info is not None
         assert "project_dir" not in info
 
+    def test_register_with_network_state(self, tmp_data_dir):
+        register_bubble(
+            "net-bubble",
+            "org/repo",
+            network_enabled=True,
+            extra_domains=["example.com", "deps.example.com"],
+        )
+        info = get_bubble_info("net-bubble")
+        assert info is not None
+        assert info["network_enabled"] is True
+        assert info["extra_domains"] == ["example.com", "deps.example.com"]
+
+    def test_register_with_network_disabled(self, tmp_data_dir):
+        register_bubble("no-net-bubble", "org/repo", network_enabled=False)
+        info = get_bubble_info("no-net-bubble")
+        assert info is not None
+        assert info["network_enabled"] is False
+        # Empty list shouldn't be persisted
+        assert "extra_domains" not in info
+
+    def test_register_without_network_state(self, tmp_data_dir):
+        # Legacy / unspecified path: nothing persisted, defaults applied at read time.
+        register_bubble("legacy", "org/repo")
+        info = get_bubble_info("legacy")
+        assert info is not None
+        assert "network_enabled" not in info
+        assert "extra_domains" not in info
+
 
 class TestPruneStaleEntries:
     def test_prunes_missing_local_containers(self, tmp_data_dir):

--- a/tests/test_reattach_network.py
+++ b/tests/test_reattach_network.py
@@ -1,0 +1,191 @@
+"""Tests for issue #285: re-applying the network allowlist after a stop/start.
+
+After ``incus stop`` destroys the container's network namespace, the next
+``incus start`` recreates it empty (default-ACCEPT iptables). Without explicit
+replay, the bubble silently comes back up unprotected. ``ensure_running``
+performs the replay; on replay failure it stops the container so we fail
+closed instead of leaving an unprotected container running.
+"""
+
+import pytest
+
+from bubble.container_helpers import (
+    ensure_running,
+    reapply_network_after_restart,
+    recover_extra_domains,
+)
+from bubble.lifecycle import register_bubble
+from bubble.runtime.base import ContainerInfo
+
+
+class _RecordingRuntime:
+    """Minimal runtime that records exec/start/stop/unfreeze calls."""
+
+    def __init__(self, name: str, state: str = "stopped"):
+        self._info = ContainerInfo(name=name, state=state)
+        self.exec_calls: list[list[str]] = []
+        self.start_calls: list[str] = []
+        self.stop_calls: list[str] = []
+        self.unfreeze_calls: list[str] = []
+        self.exec_should_raise = False
+
+    def list_containers(self, fast: bool = True):
+        return [self._info]
+
+    def start(self, name: str):
+        self.start_calls.append(name)
+
+    def stop(self, name: str):
+        self.stop_calls.append(name)
+
+    def unfreeze(self, name: str):
+        self.unfreeze_calls.append(name)
+
+    def exec(self, name: str, command, **kwargs):
+        if self.exec_should_raise:
+            raise RuntimeError("simulated exec failure")
+        self.exec_calls.append(list(command))
+        return ""
+
+
+def _iptables_scripts(runtime: _RecordingRuntime) -> list[str]:
+    return [
+        cmd[-1] for cmd in runtime.exec_calls if cmd[:2] == ["bash", "-c"] and "iptables" in cmd[-1]
+    ]
+
+
+class TestReapplyNetworkAfterRestart:
+    def test_reapplies_with_stored_extra_domains(self, tmp_data_dir, monkeypatch):
+        register_bubble(
+            "lean4-master",
+            "leanprover/lean4",
+            network_enabled=True,
+            extra_domains=["releases.lean-lang.org"],
+        )
+        runtime = _RecordingRuntime("lean4-master", state="running")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        reapply_network_after_restart(runtime, "lean4-master")
+
+        scripts = _iptables_scripts(runtime)
+        assert scripts
+        joined = "\n".join(scripts)
+        assert "iptables -P OUTPUT DROP" in joined
+        assert "ip6tables -P OUTPUT DROP" in joined
+        assert "releases.lean-lang.org" in joined
+
+    def test_skips_when_network_disabled(self, tmp_data_dir, monkeypatch):
+        register_bubble("plain", "org/repo", network_enabled=False)
+        runtime = _RecordingRuntime("plain", state="running")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        reapply_network_after_restart(runtime, "plain")
+
+        assert runtime.exec_calls == []
+
+    def test_legacy_entry_defaults_to_reapplying(self, tmp_data_dir, monkeypatch):
+        register_bubble("legacy", "org/repo")  # no network kwargs
+        runtime = _RecordingRuntime("legacy", state="running")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        reapply_network_after_restart(runtime, "legacy")
+
+        assert _iptables_scripts(runtime), "expected legacy bubble to re-apply allowlist"
+
+    def test_persists_empty_domains_distinct_from_legacy(self, tmp_data_dir):
+        register_bubble("py-bubble", "org/repo", network_enabled=True, extra_domains=[])
+        from bubble.lifecycle import get_bubble_info
+
+        info = get_bubble_info("py-bubble")
+        assert info["extra_domains"] == []  # explicit empty list, not missing
+
+
+class TestRecoverExtraDomains:
+    def test_returns_none_without_org_repo(self, tmp_data_dir):
+        assert recover_extra_domains({}) is None
+
+    def test_returns_none_when_no_bare_repo(self, tmp_data_dir):
+        assert recover_extra_domains({"org_repo": "unknown/repo"}) is None
+
+    def test_prefers_commit_over_branch(self, tmp_data_dir, monkeypatch):
+        # Verify that recovery passes ``commit`` (not ``branch``) as the ref so
+        # branch tip drift in the bare mirror doesn't widen the allowlist.
+        bare_repo = tmp_data_dir / "git" / "repo.git"
+        bare_repo.mkdir(parents=True)
+
+        seen_refs = []
+
+        def fake_select_hook(path, ref):
+            seen_refs.append(ref)
+            return None
+
+        monkeypatch.setattr("bubble.hooks.select_hook", fake_select_hook)
+
+        recover_extra_domains({"org_repo": "owner/repo", "branch": "main", "commit": "deadbeef"})
+        assert seen_refs == ["deadbeef"]
+
+
+class TestEnsureRunningReapplies:
+    def test_stopped_container_replays_iptables(self, tmp_data_dir, monkeypatch):
+        register_bubble(
+            "stopped-bubble",
+            "org/repo",
+            network_enabled=True,
+            extra_domains=["example.com"],
+        )
+        runtime = _RecordingRuntime("stopped-bubble", state="stopped")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        ensure_running(runtime, "stopped-bubble")
+
+        assert runtime.start_calls == ["stopped-bubble"]
+        assert _iptables_scripts(runtime), "expected iptables replay"
+
+    def test_frozen_container_does_not_replay(self, tmp_data_dir, monkeypatch):
+        register_bubble(
+            "paused",
+            "org/repo",
+            network_enabled=True,
+            extra_domains=["example.com"],
+        )
+        runtime = _RecordingRuntime("paused", state="frozen")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        ensure_running(runtime, "paused")
+
+        # Frozen containers preserve their network namespace; no replay needed.
+        assert runtime.unfreeze_calls == ["paused"]
+        assert _iptables_scripts(runtime) == []
+
+    def test_running_container_does_not_replay(self, tmp_data_dir, monkeypatch):
+        register_bubble(
+            "live",
+            "org/repo",
+            network_enabled=True,
+            extra_domains=["example.com"],
+        )
+        runtime = _RecordingRuntime("live", state="running")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        ensure_running(runtime, "live")
+
+        assert runtime.start_calls == []
+        assert _iptables_scripts(runtime) == []
+
+    def test_replay_failure_stops_container(self, tmp_data_dir, monkeypatch):
+        """Fail-closed: a failing replay must not leave an unprotected container up."""
+        register_bubble(
+            "fail-bubble",
+            "org/repo",
+            network_enabled=True,
+            extra_domains=["example.com"],
+        )
+        runtime = _RecordingRuntime("fail-bubble", state="stopped")
+        runtime.exec_should_raise = True
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+
+        with pytest.raises(Exception):
+            ensure_running(runtime, "fail-bubble")
+
+        assert runtime.start_calls == ["fail-bubble"]
+        assert runtime.stop_calls == ["fail-bubble"], "container must be stopped on replay failure"


### PR DESCRIPTION
This PR fixes #285. After a Mac/Colima reboot, after `bubble cleanup` re-stops a clean bubble it briefly started, or after any direct `incus stop`, the next `bubble open <name>` used to silently bring the bubble up with default-ACCEPT iptables — full outbound IPv4/IPv6/SSH, no allowlist, no DNS restriction. `incus stop` destroys the container's network namespace, and the rules from `apply_allowlist` are not persisted, so the next start recreates an empty namespace and the editor opens against an unprotected container.

Persist network state (`network_enabled` and the hook-contributed `extra_domains`) in the bubble registry at provision time, then have `ensure_running` replay the allowlist whenever a stopped container is started. Frozen containers (`incus pause`/`start`) keep their namespace, so the freeze path is unaffected. On replay failure the container is stopped again so we fail closed instead of leaving an unprotected bubble running.

The same path is now used by `cleanup --all` (which starts stopped bubbles for inspection) and `bubble network apply` (which now honours stored `extra_domains`), so all stop/start transitions go through one place. Legacy registry entries that predate the new fields fall back to re-detecting the language hook against the bare repo, preferring the recorded commit over the branch tip so a moved branch can't widen the allowlist.

🤖 Prepared with Claude Code