### PR TITLE
feat: auto-detect Lean projects in subdirectories

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f232c45d-689c-409c-a8e1-be4a33f16795","pid":37911,"procStart":"Tue May 12 12:53:44 2026","acquiredAt":1778590993161}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f232c45d-689c-409c-a8e1-be4a33f16795","pid":37911,"procStart":"Tue May 12 12:53:44 2026","acquiredAt":1778590993161}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ uv.lock
 .vscode/claude-prompt.txt
 .vscode/tasks.json
 .vscode/settings.json
+.claude/scheduled_tasks.lock

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -38,7 +38,9 @@ def finalize_bubble(
     before any clone/fetch operations.
     """
     q_short = shlex.quote(short)
-    project_dir = f"/home/user/{short}"
+    repo_dir = f"/home/user/{short}"
+    subdir = hook.project_subdir() if hook else ""
+    project_dir = f"{repo_dir}/{subdir}" if subdir else repo_dir
     if hook:
         hook.post_clone(runtime, name, project_dir)
 
@@ -50,7 +52,7 @@ def finalize_bubble(
     # letting gh discover the host without needing to actually use the remote.
     if t.owner and t.repo:
         q_repo = shlex.quote(f"git@github.com:{t.owner}/{t.repo}.git")
-        q_dir = shlex.quote(project_dir)
+        q_dir = shlex.quote(repo_dir)
         add_cmd = f"cd {q_dir} && git remote add github {q_repo} 2>/dev/null || true"
         try:
             runtime.exec(name, ["su", "-", "user", "-c", add_cmd])

--- a/bubble/hooks/__init__.py
+++ b/bubble/hooks/__init__.py
@@ -69,6 +69,14 @@ class Hook(ABC):
         """Return absolute path to a .code-workspace file to open, or None."""
         return None
 
+    def project_subdir(self) -> str:
+        """Subdirectory within the repo where the project lives.
+
+        Returns "" if the project is at the repo root (the common case).
+        Only populated after detect() returns True.
+        """
+        return ""
+
 
 def discover_hooks() -> list[Hook]:
     """Return all registered hooks in priority order."""

--- a/bubble/hooks/lean.py
+++ b/bubble/hooks/lean.py
@@ -17,11 +17,15 @@ from . import GitDependency, Hook
 _SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
-def _read_lean_toolchain(bare_repo_path: Path, ref: str) -> str | None:
-    """Read the lean-toolchain file content from a bare repo at a given ref."""
+def _read_lean_toolchain(bare_repo_path: Path, ref: str, subdir: str = "") -> str | None:
+    """Read the lean-toolchain file content from a bare repo at a given ref.
+
+    ``subdir`` is "" for the repo root, or a relative path like "foo" or "foo/bar".
+    """
+    path = f"{subdir}/lean-toolchain" if subdir else "lean-toolchain"
     try:
         result = subprocess.run(
-            ["git", "-C", str(bare_repo_path), "show", f"{ref}:lean-toolchain"],
+            ["git", "-C", str(bare_repo_path), "show", f"{ref}:{path}"],
             capture_output=True,
             text=True,
             check=True,
@@ -29,6 +33,37 @@ def _read_lean_toolchain(bare_repo_path: Path, ref: str) -> str | None:
         return result.stdout.strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
+
+
+def _find_lean_toolchain_subdir(bare_repo_path: Path, ref: str) -> str | None:
+    """Search for a non-root `lean-toolchain` file in the bare repo at `ref`.
+
+    Returns the relative directory containing the file, or None if there are
+    zero or multiple matches. The root is handled separately by the caller;
+    this only fires on the slow path when root has no lean-toolchain.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(bare_repo_path), "ls-tree", "-r", "--name-only", ref],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    matches = [line for line in result.stdout.splitlines() if line.endswith("/lean-toolchain")]
+    if len(matches) == 1:
+        # Strip the trailing "/lean-toolchain".
+        return matches[0][: -len("/lean-toolchain")]
+    if len(matches) > 1:
+        dirs = sorted(m[: -len("/lean-toolchain")] for m in matches)
+        click.echo(
+            f"Multiple lean-toolchain files found ({', '.join(dirs)}); "
+            "cannot auto-detect Lean project subdirectory.",
+            err=True,
+        )
+    return None
 
 
 def _parse_lean_version(toolchain_str: str) -> str | None:
@@ -52,11 +87,14 @@ def _parse_lean_version(toolchain_str: str) -> str | None:
     return None
 
 
-def _parse_git_dependencies(bare_repo_path: Path, ref: str) -> list[GitDependency]:
+def _parse_git_dependencies(
+    bare_repo_path: Path, ref: str, subdir: str = ""
+) -> list[GitDependency]:
     """Parse git dependencies from lake-manifest.json in the bare repo."""
+    path = f"{subdir}/lake-manifest.json" if subdir else "lake-manifest.json"
     try:
         result = subprocess.run(
-            ["git", "-C", str(bare_repo_path), "show", f"{ref}:lake-manifest.json"],
+            ["git", "-C", str(bare_repo_path), "show", f"{ref}:{path}"],
             capture_output=True,
             text=True,
             check=True,
@@ -100,30 +138,49 @@ class LeanHook(Hook):
         self._needs_cache: bool = False
         self._is_lean4: bool = False
         self._git_deps: list[GitDependency] = []
+        self._subdir: str = ""
 
     def name(self) -> str:
         return "Lean 4"
 
     def detect(self, bare_repo_path: Path, ref: str) -> bool:
-        """Check for lean-toolchain file at the given ref in the bare repo."""
+        """Check for lean-toolchain file at the given ref in the bare repo.
+
+        Tries the repo root first (the common case). If that fails, scans the
+        tree for a single non-root `lean-toolchain` file and uses its
+        directory. Bails out (returns False) when there are multiple matches.
+        """
         content = _read_lean_toolchain(bare_repo_path, ref)
+        subdir = ""
+        if content is None:
+            found = _find_lean_toolchain_subdir(bare_repo_path, ref)
+            if found is not None:
+                content = _read_lean_toolchain(bare_repo_path, ref, found)
+                if content is not None:
+                    subdir = found
+
         if content is not None:
             self._toolchain = content
+            self._subdir = subdir
             self._is_lean4 = bare_repo_path.name == "lean4.git"
             if self._is_lean4:
                 self._git_deps = []
                 self._needs_cache = False
             else:
-                self._git_deps = _parse_git_dependencies(bare_repo_path, ref)
+                self._git_deps = _parse_git_dependencies(bare_repo_path, ref, subdir)
                 self._needs_cache = bare_repo_path.name == "mathlib4.git" or any(
                     d.name == "mathlib" for d in self._git_deps
                 )
             return True
         self._toolchain = None
+        self._subdir = ""
         self._needs_cache = False
         self._is_lean4 = False
         self._git_deps = []
         return False
+
+    def project_subdir(self) -> str:
+        return self._subdir
 
     def image_name(self) -> str:
         """Return the image name based on the lean-toolchain version.

--- a/bubble/hooks/lean.py
+++ b/bubble/hooks/lean.py
@@ -17,6 +17,41 @@ from . import GitDependency, Hook
 _SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
+def _is_safe_subdir(subdir: str) -> bool:
+    """Validate a detected project subdirectory.
+
+    The string flows into shell commands and into paths under /home/user/, so
+    each path component must match the same conservative policy used for Lake
+    package names. Reject absolute paths, leading/trailing slashes, empty
+    components, and any '.' / '..' segments.
+    """
+    if not subdir or subdir.startswith("/") or subdir.endswith("/"):
+        return False
+    for part in subdir.split("/"):
+        if not part or part in (".", "..") or not _SAFE_NAME_RE.match(part):
+            return False
+    return True
+
+
+def _has_lakefile(bare_repo_path: Path, ref: str, subdir: str) -> bool:
+    """Confirm a sibling lakefile exists next to a discovered lean-toolchain.
+
+    Filters out vendored/example/doc directories that happen to ship a
+    lean-toolchain without being the project root.
+    """
+    for name in ("lakefile.toml", "lakefile.lean"):
+        try:
+            subprocess.run(
+                ["git", "-C", str(bare_repo_path), "cat-file", "-e", f"{ref}:{subdir}/{name}"],
+                capture_output=True,
+                check=True,
+            )
+            return True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+    return False
+
+
 def _read_lean_toolchain(bare_repo_path: Path, ref: str, subdir: str = "") -> str | None:
     """Read the lean-toolchain file content from a bare repo at a given ref.
 
@@ -39,31 +74,75 @@ def _find_lean_toolchain_subdir(bare_repo_path: Path, ref: str) -> str | None:
     """Search for a non-root `lean-toolchain` file in the bare repo at `ref`.
 
     Returns the relative directory containing the file, or None if there are
-    zero or multiple matches. The root is handled separately by the caller;
-    this only fires on the slow path when root has no lean-toolchain.
+    zero or multiple matches, or if the unique match doesn't sit next to a
+    lakefile. The root is handled separately by the caller; this only fires
+    on the slow path when root has no lean-toolchain.
+
+    Uses `git ls-tree -z` (NUL-delimited) and streams output, stopping after
+    the second match so a huge tree with no Lean project doesn't pay for the
+    full listing. NUL-delimited mode also avoids git's quotePath escaping for
+    paths with unusual bytes.
     """
     try:
-        result = subprocess.run(
-            ["git", "-C", str(bare_repo_path), "ls-tree", "-r", "--name-only", ref],
-            capture_output=True,
-            text=True,
-            check=True,
+        proc = subprocess.Popen(
+            ["git", "-C", str(bare_repo_path), "ls-tree", "-rz", "--name-only", ref],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (OSError, FileNotFoundError):
         return None
 
-    matches = [line for line in result.stdout.splitlines() if line.endswith("/lean-toolchain")]
-    if len(matches) == 1:
-        # Strip the trailing "/lean-toolchain".
-        return matches[0][: -len("/lean-toolchain")]
-    if len(matches) > 1:
+    matches: list[str] = []
+    try:
+        assert proc.stdout is not None
+        buf = b""
+        suffix = b"/lean-toolchain"
+        while True:
+            chunk = proc.stdout.read(65536)
+            if not chunk:
+                buf += b""
+                # Flush whatever's left.
+                for entry in buf.split(b"\0"):
+                    if entry.endswith(suffix):
+                        matches.append(entry.decode("utf-8", "replace"))
+                        if len(matches) >= 2:
+                            break
+                break
+            buf += chunk
+            parts = buf.split(b"\0")
+            buf = parts[-1]  # last fragment may be incomplete
+            for entry in parts[:-1]:
+                if entry.endswith(suffix):
+                    matches.append(entry.decode("utf-8", "replace"))
+            if len(matches) >= 2:
+                break
+    finally:
+        try:
+            proc.stdout.close()
+        except Exception:
+            pass
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+
+    if not matches:
+        return None
+    if len(matches) >= 2:
         dirs = sorted(m[: -len("/lean-toolchain")] for m in matches)
         click.echo(
             f"Multiple lean-toolchain files found ({', '.join(dirs)}); "
             "cannot auto-detect Lean project subdirectory.",
             err=True,
         )
-    return None
+        return None
+    subdir = matches[0][: -len("/lean-toolchain")]
+    if not _is_safe_subdir(subdir):
+        return None
+    if not _has_lakefile(bare_repo_path, ref, subdir):
+        return None
+    return subdir
 
 
 def _parse_lean_version(toolchain_str: str) -> str | None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -28,7 +28,9 @@ def _make_hook_repo(tmp_path, work_name, files):
     work = tmp_path / work_name
     subprocess.run([GIT, "clone", str(repo), str(work)], capture_output=True, check=True)
     for name, content in files.items():
-        (work / name).write_text(content)
+        path = work / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
     subprocess.run([GIT, "-C", str(work), "add", "."], capture_output=True, check=True)
     subprocess.run(
         [GIT, "-C", str(work), "commit", "-m", "init"],
@@ -221,6 +223,101 @@ class TestLean4Detection:
         hook = LeanHook()
         hook.detect(mathlib4_repo, "HEAD")
         assert hook.workspace_file("/home/user/mathlib4") is None
+
+
+@pytest.fixture
+def subdir_lean_repo(tmp_path):
+    """Create a bare git repo with lean-toolchain in a subdirectory."""
+    return _make_hook_repo(
+        tmp_path,
+        "subdir-work",
+        {
+            "README.md": "# Root\n",
+            "myproj/lean-toolchain": "leanprover/lean4:v4.20.0\n",
+            "myproj/lakefile.toml": "name = 'myproj'\n",
+        },
+    )
+
+
+@pytest.fixture
+def nested_subdir_lean_repo(tmp_path):
+    """Create a bare git repo with lean-toolchain in a nested subdirectory."""
+    return _make_hook_repo(
+        tmp_path,
+        "nested-work",
+        {
+            "docs/README.md": "# Docs\n",
+            "src/lean/lean-toolchain": "leanprover/lean4:v4.21.0\n",
+        },
+    )
+
+
+@pytest.fixture
+def ambiguous_lean_repo(tmp_path):
+    """Create a bare git repo with multiple non-root lean-toolchain files."""
+    return _make_hook_repo(
+        tmp_path,
+        "ambig-work",
+        {
+            "a/lean-toolchain": "leanprover/lean4:v4.20.0\n",
+            "b/lean-toolchain": "leanprover/lean4:v4.20.0\n",
+        },
+    )
+
+
+@pytest.fixture
+def root_and_subdir_lean_repo(tmp_path):
+    """Repo with lean-toolchain at root AND in a subdirectory.
+
+    The root file should win — we don't enter the slow scan path when root
+    has lean-toolchain, even if other copies exist deeper in the tree.
+    """
+    return _make_hook_repo(
+        tmp_path,
+        "root-and-sub",
+        {
+            "lean-toolchain": "leanprover/lean4:v4.19.0\n",
+            "vendor/lean-toolchain": "leanprover/lean4:v4.10.0\n",
+        },
+    )
+
+
+class TestSubdirDetection:
+    def test_detect_subdir_lean_repo(self, subdir_lean_repo):
+        hook = LeanHook()
+        assert hook.detect(subdir_lean_repo, "HEAD") is True
+        assert hook.project_subdir() == "myproj"
+        assert hook.image_name() == "lean-v4.20.0"
+
+    def test_detect_nested_subdir(self, nested_subdir_lean_repo):
+        hook = LeanHook()
+        assert hook.detect(nested_subdir_lean_repo, "HEAD") is True
+        assert hook.project_subdir() == "src/lean"
+        assert hook.image_name() == "lean-v4.21.0"
+
+    def test_ambiguous_repo_not_detected(self, ambiguous_lean_repo):
+        hook = LeanHook()
+        assert hook.detect(ambiguous_lean_repo, "HEAD") is False
+        assert hook.project_subdir() == ""
+
+    def test_root_wins_over_subdir(self, root_and_subdir_lean_repo):
+        hook = LeanHook()
+        assert hook.detect(root_and_subdir_lean_repo, "HEAD") is True
+        assert hook.project_subdir() == ""
+        assert hook.image_name() == "lean-v4.19.0"
+
+    def test_root_repo_has_empty_subdir(self, lean_repo):
+        hook = LeanHook()
+        hook.detect(lean_repo, "HEAD")
+        assert hook.project_subdir() == ""
+
+    def test_subdir_cleared_on_redetect_failure(self, subdir_lean_repo, non_lean_repo):
+        """Re-running detect() on a non-Lean repo must clear stale subdir state."""
+        hook = LeanHook()
+        hook.detect(subdir_lean_repo, "HEAD")
+        assert hook.project_subdir() == "myproj"
+        assert hook.detect(non_lean_repo, "HEAD") is False
+        assert hook.project_subdir() == ""
 
 
 @pytest.fixture

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -248,6 +248,20 @@ def nested_subdir_lean_repo(tmp_path):
         {
             "docs/README.md": "# Docs\n",
             "src/lean/lean-toolchain": "leanprover/lean4:v4.21.0\n",
+            "src/lean/lakefile.lean": "package myproj\n",
+        },
+    )
+
+
+@pytest.fixture
+def subdir_no_lakefile_repo(tmp_path):
+    """Subdirectory has lean-toolchain but no sibling lakefile (vendored/doc dir)."""
+    return _make_hook_repo(
+        tmp_path,
+        "no-lakefile",
+        {
+            "README.md": "# Root\n",
+            "vendor/lean-toolchain": "leanprover/lean4:v4.20.0\n",
         },
     )
 
@@ -318,6 +332,42 @@ class TestSubdirDetection:
         assert hook.project_subdir() == "myproj"
         assert hook.detect(non_lean_repo, "HEAD") is False
         assert hook.project_subdir() == ""
+
+    def test_subdir_without_lakefile_rejected(self, subdir_no_lakefile_repo):
+        """A lean-toolchain in a subdir with no sibling lakefile is ignored."""
+        hook = LeanHook()
+        assert hook.detect(subdir_no_lakefile_repo, "HEAD") is False
+        assert hook.project_subdir() == ""
+
+
+class TestSafeSubdir:
+    def test_safe_names(self):
+        from bubble.hooks.lean import _is_safe_subdir
+
+        assert _is_safe_subdir("myproj")
+        assert _is_safe_subdir("src/lean")
+        assert _is_safe_subdir("a.b-c_d/e1")
+
+    def test_rejects_traversal(self):
+        from bubble.hooks.lean import _is_safe_subdir
+
+        assert not _is_safe_subdir("..")
+        assert not _is_safe_subdir("../etc")
+        assert not _is_safe_subdir("foo/../bar")
+        assert not _is_safe_subdir(".")
+        assert not _is_safe_subdir("./foo")
+
+    def test_rejects_absolute_and_edge_cases(self):
+        from bubble.hooks.lean import _is_safe_subdir
+
+        assert not _is_safe_subdir("")
+        assert not _is_safe_subdir("/abs")
+        assert not _is_safe_subdir("trailing/")
+        assert not _is_safe_subdir("foo//bar")
+        assert not _is_safe_subdir("foo bar")
+        assert not _is_safe_subdir("foo;bar")
+        assert not _is_safe_subdir("foo\nbar")
+        assert not _is_safe_subdir("café")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR teaches the Lean hook to find `lean-toolchain` (and `lake-manifest.json`) when they live in a subdirectory of the repo rather than at the root, so bubbles of repos like that one Alex asked about pick up elan, the mathlib cache mount, and auto-build correctly.

Detection still tries the repo root first — that's the common case and remains a single `git show`. On a miss, it falls back to `git ls-tree -r --name-only <ref>` and looks for files ending in `/lean-toolchain`. A unique match wins; multiple matches bail out (rather than guessing) and print a one-line message naming the candidate directories.

The hook exposes the resolved subdirectory via a new `Hook.project_subdir()` method (default `""` for hooks that don't care), and `finalize_bubble` now splits `repo_dir` from `project_dir`. `repo_dir` is the git checkout; `project_dir` is where VS Code opens, where the Claude settings trust list points, and where the AI task injection writes `.vscode/tasks.json`. When the project sits at the root, the two are identical and behaviour is unchanged.

Out of scope: an explicit `--project-dir` flag for ambiguous cases, and honoring `GitDependency.sub_dir` for Lake deps that live in a subdir of their own repo (already parsed, never used).

🤖 Prepared with Claude Code