### PR TITLE
fix: replace forkproxy reproducer with one that actually reproduces

### DIFF
--- a/scratch/forkproxy-repro.sh
+++ b/scratch/forkproxy-repro.sh
@@ -1,127 +1,66 @@
 #!/usr/bin/env bash
-# Repro for incus forkproxy leak on container stop/start.
+# Reproducer: incusd does not reap orphaned `forkproxy` helpers after an
+# ungraceful daemon restart, leaking one per (OOM-kill + container-exit)
+# cycle. Confirmed on incus 6.0.6 and 7.0.0.
 #
-# Background: incusd spawns a `forkproxy` helper process per proxy device.
-# On a normal container stop, the helper is expected to be killed (see
-# `internal/server/device/proxy.go` `Stop()` -> `killProxyProc()`). In
-# practice on incus 6.0.6 LTS (NixOS build 2026-03-27), some stop/start
-# paths leave the helper running and reparented to PID 1, while the next
-# `incus start` spawns a fresh helper. Helpers accumulate linearly with
-# stop/start cycles.
+# Mechanism: a proxy device's `forkproxy` helper is a child of incusd.
+# If incusd is killed without its cgroup — exactly what the kernel OOM
+# killer does, it kills the single incusd process, not the unit's whole
+# control group — the forkproxy survives and reparents to PID 1. If the
+# container then stops while incusd is down, the restarted incusd has no
+# running instance to associate the orphan with and never kills it. The
+# orphan lives forever (holding its FDs/RSS). On a busy host that
+# OOM-kills incusd repeatedly while containers churn, these accumulate
+# (observed: ~270/day, tens of GiB RSS).
 #
-# This script demonstrates the leak. Run as a user in the `incus-admin`
-# group on a Linux host with a default incus install. It uses a unique
-# container name including a UUID so its forkproxy processes can be
-# filtered out of the global ps output, and prints per-iteration
-# snapshots so growth is visible.
-#
-# Usage: ./forkproxy-repro.sh [ITERATIONS]
-#   Default ITERATIONS=5.
-#
-# Cleanup: always runs (trap on EXIT). Records before- and
-# after-cleanup forkproxy state.
-
+# Run as root on a host with incus + a default bridge. Self-contained.
 set -euo pipefail
+ITERS="${1:-4}"
+MARK="fpleak-$$"   # unique listen port base picks this up via /proc args
 
-ITERATIONS="${1:-5}"
-UUID="$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)"
-NAME="fproxy-repro-${UUID:0:8}"
-
-# Unique listen addresses so we filter only our processes.
-TCP_PORT=17$((RANDOM % 900 + 100))   # 17100-17999
-SOCK_PATH="/tmp/${NAME}-gh.sock"
-
-cleanup() {
-    echo "=== cleanup ==="
-    echo "--- forkproxy processes before cleanup ---"
-    ps_match || true
-    echo "--- incus delete ${NAME} ---"
-    incus delete -f "${NAME}" 2>&1 || true
-    sleep 1
-    echo "--- forkproxy processes after cleanup ---"
-    ps_match || true
-}
-trap cleanup EXIT
-
-ps_match() {
-    # Match incusd forkproxy processes whose argv references our
-    # specific listen addresses. Print PID, PPID, elapsed seconds,
-    # full argv.
-    ps -eo pid,ppid,etimes,args \
-      | grep -E "[i]ncusd forkproxy.*(${TCP_PORT}|${NAME}-gh\\.sock)" \
-      | sort -k3 -n
+# Count live forkproxy helpers in our dedicated port range. We match on
+# the helper's argv and confirm comm==incusd, so this never counts the
+# reproducer's own shell (whose argv happens to contain the pattern).
+count() {
+    local n=0 p
+    for p in $(pgrep -f "incusd forkproxy -- .*127.0.0.1:39[0-9][0-9][0-9]" 2>/dev/null); do
+        [ "$(cat /proc/$p/comm 2>/dev/null)" = incusd ] && n=$((n+1))
+    done
+    echo "$n"
 }
 
-count_match() {
-    ps -eo args \
-      | grep -cE "[i]ncusd forkproxy.*(${TCP_PORT}|${NAME}-gh\\.sock)" \
-      || echo 0
-}
-
-echo "=== repro: ${NAME}  (TCP port ${TCP_PORT}, sock ${SOCK_PATH}) ==="
-echo "incus version: $(incus version 2>/dev/null | head -1)"
+echo "incus: $(incus version | tr '\n' ' ')"
 echo "kernel: $(uname -r)"
-echo "iterations: ${ITERATIONS}"
+echo "start: forkproxy helpers in our port range = $(count)"
+echo
 
-echo "=== launch container ==="
-incus launch images:ubuntu/noble "${NAME}" 2>&1 | tail -5
-# Wait for container to be ready
-for _ in $(seq 1 30); do
-    if incus exec "${NAME}" -- true 2>/dev/null; then break; fi
+for i in $(seq 1 "$ITERS"); do
+    n="${MARK}-${i}"; port=$((39000 + i))
+    incus launch images:ubuntu/24.04 "$n" >/dev/null 2>&1
+    for _ in $(seq 1 30); do incus exec "$n" -- true 2>/dev/null && break; sleep 1; done
+    incus config device add "$n" p proxy \
+        listen="tcp:127.0.0.1:${port}" connect="tcp:127.0.0.1:${port}" bind=container >/dev/null
     sleep 1
-done
+    cpid=$(incus info "$n" | awk '/^PID:/{print $2}')
 
-echo "=== install persistent listener (python -m http.server on 9999) ==="
-# Use python3 which is in the base image, served from /, port 9999.
-incus exec "${NAME}" -- bash -c "
-    apt-get update -qq >/dev/null 2>&1 || true
-    nohup python3 -m http.server 9999 --bind 127.0.0.1 >/var/log/repro.log 2>&1 &
-    disown
+    # (1) OOM-style: SIGKILL only the main incusd process (not the cgroup,
+    #     so the forkproxy child survives and reparents to PID 1).
+    kill -9 "$(systemctl show -p MainPID --value incus)" 2>/dev/null || true
     sleep 1
-"
-# Verify listener is up
-if ! incus exec "${NAME}" -- bash -c "exec 3<>/dev/tcp/127.0.0.1/9999 && echo ok" >/dev/null 2>&1; then
-    echo "!! listener not reachable inside container; aborting" >&2
-    exit 1
-fi
-echo "listener OK"
-
-echo "=== add proxy devices ==="
-incus config device add "${NAME}" repro-auth proxy \
-    listen="tcp:127.0.0.1:${TCP_PORT}" \
-    connect="tcp:127.0.0.1:9999" \
-    bind=container 2>&1 | head -3
-incus config device add "${NAME}" repro-gh proxy \
-    listen="unix:${SOCK_PATH}" \
-    connect="tcp:127.0.0.1:9999" \
-    bind=container \
-    uid=0 gid=0 mode=0660 2>&1 | head -3
-
-echo "=== baseline (after device add) ==="
-echo "forkproxy count: $(count_match)"
-ps_match
-
-# We expect 2 helpers at baseline (one per device).
-
-for i in $(seq 1 "${ITERATIONS}"); do
-    echo
-    echo "=== iteration ${i}: stop + start ==="
-    incus stop "${NAME}"
-    incus start "${NAME}"
-    # Re-spawn listener (gone with the stop).
-    incus exec "${NAME}" -- bash -c "
-        nohup python3 -m http.server 9999 --bind 127.0.0.1 >/var/log/repro.log 2>&1 &
-        disown
-        sleep 1
-    " 2>/dev/null || true
-    sleep 1
-    echo "forkproxy count: $(count_match)"
-    ps_match
+    # (2) container exits while incusd is down (incusd never sees the stop).
+    kill -9 "$cpid" 2>/dev/null || true
+    # (3) bring incusd back.
+    systemctl start incus 2>/dev/null || true
+    for _ in $(seq 1 30); do incus info >/dev/null 2>&1 && break; sleep 1; done
+    sleep 2
+    echo "iter $i: container exited while incusd was down -> leaked forkproxy helpers = $(count)"
 done
 
 echo
-echo "=== summary ==="
-echo "Expected on a correct incus: 2 helpers (one live per device)."
-echo "Observed: $(count_match) helpers."
-echo "Argv references container init PIDs that may or may not be alive."
-echo "Per-iteration ps output above shows growth pattern."
+echo "Leaked orphans (PPID=1, referencing now-dead container init PIDs):"
+pgrep -f "bin/incusd forkproxy -- .*127.0.0.1:39[0-9][0-9][0-9]" \
+  | while read -r p; do ps -o pid,ppid,stat,etimes,args --no-headers -p "$p"; done
+echo
+echo "Cleanup: kill leaked orphans (incusd won't) + delete any leftover containers."
+pgrep -f "bin/incusd forkproxy -- .*127.0.0.1:39[0-9][0-9][0-9]" | xargs -r kill -9 2>/dev/null || true
+incus list -c n --format csv 2>/dev/null | grep "^${MARK}-" | xargs -r -n1 incus delete -f 2>/dev/null || true


### PR DESCRIPTION
This PR replaces the forkproxy reproducer committed in #297 with one
that actually triggers the leak. The original did a clean stop/start
loop, which I have since confirmed does not reproduce the leak on
either incus 6.0.6 or 7.0.0 (verified on fresh Hetzner boxes).

The real trigger is an ungraceful incusd kill (out-of-cgroup — the
way the kernel OOM killer kills the main process only) followed by
the container exiting while incusd is down. The orphaned forkproxy
reparents to PID 1 and is never reaped when incusd restarts. This
matches what's been observed on chungus, where incusd is OOM-killed
under load and containers churn independently.

The new script triggers the race deterministically and prints per-
iteration leak counts. Confirmed reproducing on incus 6.0.6 and 7.0.0,
Ubuntu 24.04, kernel 6.8.

🤖 Prepared with Claude Code