### PR TITLE
fix: read incus remote address from Addrs list, not Addr

### DIFF
--- a/bubble/runtime/colima.py
+++ b/bubble/runtime/colima.py
@@ -206,11 +206,20 @@ def _ensure_incus_remote():
             remotes = {}
 
     if BUBBLE_INCUS_REMOTE in remotes:
-        existing_addr = remotes[BUBBLE_INCUS_REMOTE].get("Addr", "")
-        if existing_addr != expected_addr:
+        # `incus remote list --format=json` reports addresses under `Addrs`
+        # (a list). Older/other formats may use a scalar `Addr`, so accept
+        # both.
+        entry = remotes[BUBBLE_INCUS_REMOTE]
+        existing_addrs = entry.get("Addrs") or []
+        if isinstance(existing_addrs, str):
+            existing_addrs = [existing_addrs]
+        scalar_addr = entry.get("Addr")
+        if scalar_addr:
+            existing_addrs = [*existing_addrs, scalar_addr]
+        if expected_addr not in existing_addrs:
             print(
                 f"Refusing to overwrite incus remote '{BUBBLE_INCUS_REMOTE}': "
-                f"its address is {existing_addr!r}, expected {expected_addr!r}. "
+                f"its address is {existing_addrs!r}, expected {expected_addr!r}. "
                 f"Remove it (`incus remote remove {BUBBLE_INCUS_REMOTE}`) and "
                 "retry.",
                 file=sys.stderr,

--- a/tests/test_colima.py
+++ b/tests/test_colima.py
@@ -121,7 +121,7 @@ class TestEnsureIncusRemote:
         from bubble.runtime import colima as colima_mod
 
         bogus_remotes = {
-            colima_mod.BUBBLE_INCUS_REMOTE: {"Addr": "unix:///somewhere/else.sock"},
+            colima_mod.BUBBLE_INCUS_REMOTE: {"Addrs": ["unix:///somewhere/else.sock"]},
         }
         fake = _FakeRun(
             {
@@ -139,12 +139,36 @@ class TestEnsureIncusRemote:
         err = capsys.readouterr().err
         assert "Refusing to overwrite" in err
 
+    def test_noop_when_alias_points_at_us_via_scalar_addr(self, fake_socket, monkeypatch):
+        from bubble.runtime import colima as colima_mod
+
+        # Accept a legacy/scalar `Addr` as a fallback for the `Addrs` list.
+        expected_addr = f"unix://{fake_socket}"
+        good_remotes = {
+            colima_mod.BUBBLE_INCUS_REMOTE: {"Addr": expected_addr},
+        }
+        fake = _FakeRun(
+            {
+                ("incus", "remote", "list"): _completed(stdout=json.dumps(good_remotes)),
+            }
+        )
+        monkeypatch.setattr(colima_mod.subprocess, "run", fake)
+        colima_mod._ensure_incus_remote()
+
+        cmds = [tuple(c[:3]) for c in fake.calls]
+        assert ("incus", "remote", "add") not in cmds
+        assert ("incus", "remote", "switch") not in cmds
+
     def test_noop_when_alias_already_points_at_us(self, fake_socket, monkeypatch):
         from bubble.runtime import colima as colima_mod
 
         expected_addr = f"unix://{fake_socket}"
         good_remotes = {
-            colima_mod.BUBBLE_INCUS_REMOTE: {"Addr": expected_addr},
+            colima_mod.BUBBLE_INCUS_REMOTE: {
+                "Addrs": [expected_addr],
+                "LastWorkingAddr": "http://unix.socket",
+                "AuthType": "tls",
+            },
         }
         fake = _FakeRun(
             {


### PR DESCRIPTION
This PR fixes a spurious \"Refusing to overwrite incus remote\" warning that printed on every macOS/Colima bubble invocation. \`_ensure_incus_remote\` read each remote's address from a non-existent \`Addr\` key, but \`incus remote list --format=json\` reports the address under \`Addrs\` (a list). The missing key meant \`existing_addr\` was always empty, never matched the expected unix socket, and the refusal branch fired even when the remote was correct, pointing the user at a config problem that did not exist. The fix reads \`Addrs\` (normalizing a stray scalar string to a list), keeps \`Addr\` as a fallback, and checks membership against the expected address.

Closes https://github.com/kim-em/bubble/issues/301

🤖 Prepared with Claude Code