### PR TITLE
fix: resolve auth-proxy files against the daemon's fixed home, not the caller's BUBBLE_HOME

### DIFF
--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.20"
+__version__ = "0.7.21"

--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -76,14 +76,18 @@ from urllib.request import (
     build_opener,
 )
 
-from .config import DATA_DIR
+from .config import AUTH_PROXY_DIR
 from .token_store import RateLimiter as _RateLimiter
 from .token_store import RateWindow, TokenStore, setup_file_logging
 
-AUTH_PROXY_PORT_FILE = DATA_DIR / "auth-proxy.port"
-AUTH_PROXY_ENDPOINT_FILE = DATA_DIR / "auth-proxy.endpoint"
-AUTH_PROXY_LOG = DATA_DIR / "auth-proxy.log"
-AUTH_PROXY_TOKENS = DATA_DIR / "auth-tokens.json"
+# The daemon is a host singleton that always uses ~/.bubble (see
+# AUTH_PROXY_DIR in config.py). Both the daemon and callers running under a
+# custom BUBBLE_HOME must resolve these files against that fixed location so
+# they agree on where the endpoint and per-container tokens live.
+AUTH_PROXY_PORT_FILE = AUTH_PROXY_DIR / "auth-proxy.port"
+AUTH_PROXY_ENDPOINT_FILE = AUTH_PROXY_DIR / "auth-proxy.endpoint"
+AUTH_PROXY_LOG = AUTH_PROXY_DIR / "auth-proxy.log"
+AUTH_PROXY_TOKENS = AUTH_PROXY_DIR / "auth-tokens.json"
 
 # Default port (configurable via config.toml)
 DEFAULT_PORT = 7654
@@ -1574,7 +1578,7 @@ def run_daemon(port: int = 0):
         port: Port to listen on. 0 means use config or default.
     """
     _setup_logging()
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    AUTH_PROXY_DIR.mkdir(parents=True, exist_ok=True)
 
     if not port:
         from .config import load_config

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -20,6 +20,15 @@ import tomli_w
 # Override with BUBBLE_HOME environment variable
 DATA_DIR = Path(os.environ.get("BUBBLE_HOME", Path.home() / ".bubble"))
 CONFIG_FILE = DATA_DIR / "config.toml"
+
+# The auth-proxy daemon is a host singleton, installed via launchd/systemd
+# with no BUBBLE_HOME in its environment, so it always runs against the
+# default ~/.bubble and writes its endpoint/port/token/log files there.
+# Callers (e.g. `bubble open`) may run under a custom BUBBLE_HOME, but must
+# resolve those daemon files against the daemon's fixed location rather than
+# their own DATA_DIR — otherwise they look for an endpoint the daemon never
+# wrote and write tokens the daemon never reads. See issue #304.
+AUTH_PROXY_DIR = Path.home() / ".bubble"
 REGISTRY_FILE = DATA_DIR / "registry.json"
 GIT_DIR = DATA_DIR / "git"
 REPOS_FILE = DATA_DIR / "repos.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,7 +156,15 @@ def tmp_data_dir(tmp_path, monkeypatch):
     try:
         import bubble.auth_proxy as auth_proxy_mod
 
+        # These files are pinned to the fixed singleton ~/.bubble
+        # (AUTH_PROXY_DIR), not DATA_DIR, so they don't follow BUBBLE_HOME
+        # (issue #304). Patch all four explicitly to keep tests off the
+        # real ~/.bubble.
         monkeypatch.setattr(auth_proxy_mod, "AUTH_PROXY_PORT_FILE", data_dir / "auth-proxy.port")
+        monkeypatch.setattr(
+            auth_proxy_mod, "AUTH_PROXY_ENDPOINT_FILE", data_dir / "auth-proxy.endpoint"
+        )
+        monkeypatch.setattr(auth_proxy_mod, "AUTH_PROXY_LOG", data_dir / "auth-proxy.log")
         monkeypatch.setattr(auth_proxy_mod, "AUTH_PROXY_TOKENS", data_dir / "auth-tokens.json")
     except ImportError:
         pass

--- a/tests/test_auth_proxy.py
+++ b/tests/test_auth_proxy.py
@@ -25,6 +25,48 @@ from bubble.auth_proxy import (
 )
 
 # ---------------------------------------------------------------------------
+# Daemon file location (issue #304)
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonFileLocation:
+    """The auth-proxy daemon is a host singleton pinned to ~/.bubble.
+
+    Its endpoint/port/token/log files must resolve against that fixed
+    location even when the caller runs under a custom BUBBLE_HOME, or the
+    caller looks for an endpoint the daemon never wrote and writes tokens
+    the daemon never reads (issue #304).
+    """
+
+    def test_files_ignore_bubble_home(self, tmp_path, monkeypatch):
+        import importlib
+        from pathlib import Path
+
+        import bubble.auth_proxy
+        import bubble.config
+
+        fixed = Path.home() / ".bubble"
+        try:
+            monkeypatch.setenv("BUBBLE_HOME", str(tmp_path))
+            importlib.reload(bubble.config)
+            importlib.reload(bubble.auth_proxy)
+
+            # DATA_DIR follows BUBBLE_HOME ...
+            assert bubble.config.DATA_DIR == tmp_path
+            # ... but the daemon's files stay at the fixed singleton location.
+            assert bubble.config.AUTH_PROXY_DIR == fixed
+            assert bubble.auth_proxy.AUTH_PROXY_ENDPOINT_FILE == fixed / "auth-proxy.endpoint"
+            assert bubble.auth_proxy.AUTH_PROXY_PORT_FILE == fixed / "auth-proxy.port"
+            assert bubble.auth_proxy.AUTH_PROXY_TOKENS == fixed / "auth-tokens.json"
+            assert bubble.auth_proxy.AUTH_PROXY_LOG == fixed / "auth-proxy.log"
+        finally:
+            # Restore default module state for subsequent tests.
+            monkeypatch.delenv("BUBBLE_HOME", raising=False)
+            importlib.reload(bubble.config)
+            importlib.reload(bubble.auth_proxy)
+
+
+# ---------------------------------------------------------------------------
 # Token management
 # ---------------------------------------------------------------------------
 
@@ -1669,7 +1711,14 @@ class TestApiProxyIntegration:
 
 @pytest.fixture
 def auth_proxy_env(tmp_path, monkeypatch):
-    """Set BUBBLE_HOME to tmp_path and reload auth_proxy module."""
+    """Isolate the auth_proxy daemon's files into tmp_path.
+
+    The daemon's endpoint/port/token/log files are pinned to the fixed
+    singleton location ~/.bubble (AUTH_PROXY_DIR), independent of
+    BUBBLE_HOME (see issue #304), so setting BUBBLE_HOME alone would leave
+    these tests writing the real ~/.bubble/auth-tokens.json. Monkeypatch
+    the module constants directly to keep the tests hermetic.
+    """
     import importlib
 
     import bubble.auth_proxy
@@ -1678,4 +1727,10 @@ def auth_proxy_env(tmp_path, monkeypatch):
     monkeypatch.setenv("BUBBLE_HOME", str(tmp_path))
     importlib.reload(bubble.config)
     importlib.reload(bubble.auth_proxy)
+    monkeypatch.setattr(bubble.auth_proxy, "AUTH_PROXY_PORT_FILE", tmp_path / "auth-proxy.port")
+    monkeypatch.setattr(
+        bubble.auth_proxy, "AUTH_PROXY_ENDPOINT_FILE", tmp_path / "auth-proxy.endpoint"
+    )
+    monkeypatch.setattr(bubble.auth_proxy, "AUTH_PROXY_LOG", tmp_path / "auth-proxy.log")
+    monkeypatch.setattr(bubble.auth_proxy, "AUTH_PROXY_TOKENS", tmp_path / "auth-tokens.json")
     return tmp_path


### PR DESCRIPTION
This PR fixes GitHub auth failing for `bubble open` run under a non-default `BUBBLE_HOME`. The auth-proxy daemon (`com.bubble.auth-proxy`) is a host singleton: it's installed via launchd/systemd with no `BUBBLE_HOME` in its environment, so it always runs against the default `~/.bubble` and writes its endpoint, port, token, and log files there. The open flow, however, resolved those same files against the caller's `DATA_DIR`, so under a custom `BUBBLE_HOME` it looked for an endpoint the daemon never wrote (reporting "auth proxy failed to start. No GitHub auth configured.") and minted per-container tokens the daemon never reads. With network allowlisting active this left every `git`/`gh` call in the container blocked.

Pin the four daemon files to a fixed `AUTH_PROXY_DIR` (`~/.bubble`), independent of `BUBBLE_HOME`, so the daemon and any caller agree on where the endpoint and per-container tokens live. This matches the singleton design: the daemon is host-global, so its files belong at a host-global location rather than the caller's private home. Tools that drive `bubble` with a private `BUBBLE_HOME` (to avoid inheriting an ambient `~/.bubble/config.toml`) can now use the host auth proxy.

The test fixtures relied on `BUBBLE_HOME` to redirect these files into a temp dir; since they no longer follow `BUBBLE_HOME`, the fixtures now patch all four module constants explicitly to stay hermetic, and a regression test asserts the files resolve to `~/.bubble` regardless of `BUBBLE_HOME`.

Fixes https://github.com/kim-em/bubble/issues/304

🤖 Prepared with Claude Code