### PR TITLE
fix: give macOS overlay-mode shared cache a writable clonefile copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 - **Per-repo git mount**: Each container only sees its own bare repo, not the entire git store
 - **Bubble-in-bubble relay**: Containers can open new bubbles on the host, but only for repos already cloned in `~/.bubble/git/`. Disable with `bubble security set relay off`
 - **GitHub auth proxy**: Host token never enters containers. Git and REST API are repo-scoped. **GraphQL queries are read-only but account-wide** — can read any data the host token can access. API access can be set to `off`, `on` (read-only, the default), or `read-write` (enables mutations) via `bubble security set github-api`
-- **Shared mathlib cache**: The mathlib cache at `~/.bubble/mathlib-cache/` is shared across Lean containers. Modes: `on` (default) = read-write (a compromised container could poison cached artifacts), `off` = read-only (prevents poisoning), `overlay` = read-only with per-container writable overlay. This cache is *not* shared with `lake exe cache` run outside a bubble. Configure with `bubble security set shared-cache`. If you suspect poisoning, delete `~/.bubble/mathlib-cache/`.
+- **Shared mathlib cache**: The mathlib cache at `~/.bubble/mathlib-cache/` is shared across Lean containers. Modes: `on` (default) = read-write (a compromised container could poison cached artifacts), `off` = read-only (prevents poisoning), `overlay` = per-container writable view with isolated writes (overlayfs on Linux; a clonefile-seeded writable copy on macOS/Colima, where overlayfs can't run over virtiofs). This cache is *not* shared with `lake exe cache` run outside a bubble. Configure with `bubble security set shared-cache`. If you suspect poisoning, delete `~/.bubble/mathlib-cache/`.
 
 ## Images
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -346,9 +346,12 @@ of the versioned image for next time.
 > Three modes are available via `bubble security set shared-cache`:
 > - `on` (default): shared read-write — fastest, but vulnerable to cache
 >   poisoning across containers
-> - `overlay`: shared cache mounted read-only with a per-container writable
->   overlayfs layer — fast reads from the shared cache with isolated writes
->   that don't affect other containers (recommended for security-conscious use)
+> - `overlay`: per-container writable view of the shared cache with isolated
+>   writes that don't affect other containers — fast reads with no cross-
+>   container poisoning (recommended for security-conscious use). On Linux this
+>   is an overlayfs mount (shared cache as lowerdir); on macOS/Colima, where
+>   overlayfs can't run over virtiofs, each bubble instead gets a writable copy
+>   seeded from the shared cache via APFS clonefile (cheap, copy-on-write).
 > - `off`: shared cache mounted read-only — prevents future poisoning
 >
 > If you suspect the cache has already been compromised, delete

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -1247,6 +1247,11 @@ def _open_single(
             runtime.delete(name, force=True)
         except Exception:
             pass
+        # Drop any per-bubble shared-cache copy seeded before the failure
+        # (macOS overlay path) so it isn't orphaned on host disk.
+        from .provisioning import remove_cache_copies
+
+        remove_cache_copies(name)
         raise
 
 

--- a/bubble/commands/lifecycle.py
+++ b/bubble/commands/lifecycle.py
@@ -82,8 +82,25 @@ def destroy_bubble(name: str, info: dict | None = None, on_progress=None) -> tup
 
     remove_ssh_config(name)
     _cleanup_tokens(name)
+    _cleanup_cache_copies(name)
     unregister_bubble(name)
     return True, ""
+
+
+def _cleanup_cache_copies(name: str):
+    """Remove any per-bubble shared-cache copies seeded for this container.
+
+    These are created by the macOS/Colima overlay path (issue #306) under
+    ``~/.bubble/shared-cache-copies/<name>/``. No-op when the directory is
+    absent (Linux hosts, or non-overlay bubbles).
+    """
+    import shutil
+
+    from ..provisioning import cache_copies_dir
+
+    copies = cache_copies_dir(name)
+    if copies.exists():
+        shutil.rmtree(copies, ignore_errors=True)
 
 
 def _cleanup_tokens(name: str, remote_host_spec: str = ""):

--- a/bubble/commands/lifecycle.py
+++ b/bubble/commands/lifecycle.py
@@ -94,13 +94,9 @@ def _cleanup_cache_copies(name: str):
     ``~/.bubble/shared-cache-copies/<name>/``. No-op when the directory is
     absent (Linux hosts, or non-overlay bubbles).
     """
-    import shutil
+    from ..provisioning import remove_cache_copies
 
-    from ..provisioning import cache_copies_dir
-
-    copies = cache_copies_dir(name)
-    if copies.exists():
-        shutil.rmtree(copies, ignore_errors=True)
+    remove_cache_copies(name)
 
 
 def _cleanup_tokens(name: str, remote_host_spec: str = ""):

--- a/bubble/provisioning.py
+++ b/bubble/provisioning.py
@@ -2,12 +2,23 @@
 
 import platform
 import shlex
+import shutil
+import subprocess
 from pathlib import Path
 
 import click
 
 from .config import DATA_DIR
 from .security import SETTINGS, get_setting, is_enabled
+
+
+def cache_copies_dir(container_name: str) -> Path:
+    """Host directory holding a bubble's per-container shared-cache copies.
+
+    Used by the macOS/Colima seeded-copy path (see :func:`seed_cache_copy`) and
+    cleaned up on ``bubble pop``.
+    """
+    return DATA_DIR / "shared-cache-copies" / container_name
 
 
 def mount_overlaps(target: Path, user_targets: set[Path]) -> bool:
@@ -61,6 +72,42 @@ def _setup_overlay(runtime, container: str, lower_path: str, mount_path: str):
             f" && chown user:user {q_upper}",
         ],
     )
+
+
+def seed_cache_copy(host_path: Path, container_name: str, host_dir_name: str) -> Path:
+    """Create a per-bubble writable copy of a shared cache, seeded from it.
+
+    Used on macOS/Colima, where the shared cache reaches the container over
+    virtiofs and overlayfs-over-virtiofs can't perform copy-up (issue #306) —
+    writes through the overlay fail with EACCES even though the mount is rw.
+    Instead we hand the container its own writable copy of the cache.
+
+    The copy is seeded with ``cp -c`` so APFS clonefile makes it cheap: it is
+    created instantly and shares storage with the shared cache until a file is
+    modified, preserving the speedup that overlay mode exists for. On a
+    filesystem without clone support we fall back to a plain recursive copy.
+    Writes stay isolated to this bubble and are dropped on ``bubble pop``.
+    """
+    seed_path = cache_copies_dir(container_name) / host_dir_name
+    # Start fresh in case a stale copy lingers from a crashed run; cp needs the
+    # destination to not exist so it clones host_path *as* seed_path.
+    if seed_path.exists():
+        shutil.rmtree(seed_path)
+    seed_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["cp", "-cR", str(host_path), str(seed_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Some cp builds reject -c on unsupported filesystems instead of
+        # falling back to a normal copy; retry without clonefile.
+        shutil.rmtree(seed_path, ignore_errors=True)
+        subprocess.run(["cp", "-R", str(host_path), str(seed_path)], check=True)
+    # Match the shared cache's group-writable mode so the UID-mapped container
+    # user can write to the copy.
+    seed_path.chmod(0o770)
+    return seed_path
 
 
 def provision_container(
@@ -136,7 +183,25 @@ def provision_container(
             host_path.mkdir(parents=True, exist_ok=True)
             # Make group-writable so container user can write with UID mapping
             host_path.chmod(0o770)
-            if use_overlay:
+            if use_overlay and platform.system() == "Darwin":
+                # macOS/Colima: overlayfs-over-virtiofs can't copy-up, so a
+                # real overlay is unwritable (issue #306). Give the container a
+                # per-bubble writable copy seeded (cheaply, via clonefile) from
+                # the shared cache instead — same read-from-cache + isolated-
+                # writes behaviour overlay mode promises.
+                from .output import detail
+
+                detail("Seeding per-bubble cache copy (overlay unavailable on macOS)...", nl=False)
+                seed_path = seed_cache_copy(host_path, name, host_dir_name)
+                click.echo(" done.")
+                runtime.add_disk(
+                    name,
+                    f"shared-{host_dir_name}",
+                    str(seed_path),
+                    container_path,
+                    readonly=False,
+                )
+            elif use_overlay:
                 # Mount shared cache read-only at a staging path; overlayfs
                 # will provide writable access at the expected container_path
                 lower_path = f"{container_path}-ro"

--- a/bubble/provisioning.py
+++ b/bubble/provisioning.py
@@ -17,8 +17,39 @@ def cache_copies_dir(container_name: str) -> Path:
 
     Used by the macOS/Colima seeded-copy path (see :func:`seed_cache_copy`) and
     cleaned up on ``bubble pop``.
+
+    Custom bubble names (``--name``) reach here unsanitized, and this directory
+    feeds a ``shutil.rmtree`` on pop, so assert the resolved path stays under the
+    base — a name containing ``/`` or ``..`` must not let a delete escape.
     """
-    return DATA_DIR / "shared-cache-copies" / container_name
+    base = (DATA_DIR / "shared-cache-copies").resolve()
+    target = (base / container_name).resolve()
+    if target != base and base not in target.parents:
+        raise ValueError(f"Unsafe container name for cache copies: {container_name!r}")
+    return target
+
+
+def remove_cache_copies(container_name: str) -> None:
+    """Best-effort removal of a bubble's seeded shared-cache copies.
+
+    No-op when the directory is absent (Linux hosts, non-overlay bubbles, or
+    bubbles opened before this existed). Pop must stay robust, so a failed
+    delete warns rather than aborting — an orphaned copy is recoverable disk
+    space, not a correctness problem.
+    """
+    try:
+        copies = cache_copies_dir(container_name)
+    except ValueError:
+        return
+    if not copies.exists():
+        return
+    try:
+        shutil.rmtree(copies)
+    except OSError as e:
+        click.echo(
+            f"Warning: could not remove cache copies at {copies}: {e}",
+            err=True,
+        )
 
 
 def mount_overlaps(target: Path, user_targets: set[Path]) -> bool:

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1886,3 +1886,22 @@ class TestSharedCacheOverlay:
 
         # Should not raise even though nothing was seeded.
         _cleanup_cache_copies("never-seeded")
+
+    def test_cache_copies_dir_rejects_path_traversal(self, tmp_data_dir):
+        """A custom name with separators/.. can't escape the cache-copies base."""
+        import pytest
+
+        from bubble.provisioning import cache_copies_dir
+
+        # Names that resolve outside the base must be rejected. (A name like
+        # "a/b" stays under the base and is harmless, so it is not listed here.)
+        for evil in ("../escape", "../../etc", "..", "foo/../../bar"):
+            with pytest.raises(ValueError, match="Unsafe container name"):
+                cache_copies_dir(evil)
+
+    def test_remove_cache_copies_ignores_unsafe_name(self, tmp_data_dir):
+        """remove_cache_copies swallows unsafe names rather than deleting outside base."""
+        from bubble.provisioning import remove_cache_copies
+
+        # Must not raise and must not touch anything outside the base.
+        remove_cache_copies("../escape")

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1692,9 +1692,15 @@ class TestSharedCacheOverlay:
         assert shared_calls[0][4] == "/shared/mathlib-cache"  # path
         assert shared_calls[0][5] is True  # readonly=True
 
-    def test_shared_cache_overlay_mounts_readonly_at_staging(self, mock_runtime, tmp_data_dir):
+    def test_shared_cache_overlay_mounts_readonly_at_staging(
+        self, mock_runtime, tmp_data_dir, monkeypatch
+    ):
         """shared_cache=overlay mounts read-only at a staging path, not the final path."""
+        import bubble.provisioning as provisioning
         from bubble.provisioning import provision_container
+
+        # Force the Linux overlayfs path regardless of the host running the test.
+        monkeypatch.setattr(provisioning.platform, "system", lambda: "Linux")
 
         ref_path = tmp_data_dir / "repo.git"
         ref_path.mkdir()
@@ -1717,9 +1723,12 @@ class TestSharedCacheOverlay:
         assert shared_calls[0][4] == "/shared/mathlib-cache-ro"
         assert shared_calls[0][5] is True  # readonly=True
 
-    def test_shared_cache_overlay_sets_up_overlayfs(self, mock_runtime, tmp_data_dir):
+    def test_shared_cache_overlay_sets_up_overlayfs(self, mock_runtime, tmp_data_dir, monkeypatch):
         """shared_cache=overlay runs overlayfs mount command inside container."""
+        import bubble.provisioning as provisioning
         from bubble.provisioning import provision_container
+
+        monkeypatch.setattr(provisioning.platform, "system", lambda: "Linux")
 
         ref_path = tmp_data_dir / "repo.git"
         ref_path.mkdir()
@@ -1771,3 +1780,109 @@ class TestSharedCacheOverlay:
         env_cmd = " ".join(env_execs[0][2])
         assert "MATHLIB_CACHE_DIR" in env_cmd
         assert "/shared/mathlib-cache" in env_cmd
+
+    def test_shared_cache_overlay_macos_seeds_writable_copy(
+        self, mock_runtime, tmp_data_dir, monkeypatch
+    ):
+        """On macOS, overlay mode mounts a per-bubble writable copy, not overlayfs."""
+        import bubble.provisioning as provisioning
+        from bubble.provisioning import provision_container
+
+        monkeypatch.setattr(provisioning.platform, "system", lambda: "Darwin")
+
+        # Seed the shared cache with a file so we can confirm it's cloned.
+        shared = tmp_data_dir / "mathlib-cache"
+        shared.mkdir()
+        (shared / "seed.txt").write_text("cached olean")
+
+        ref_path = tmp_data_dir / "repo.git"
+        ref_path.mkdir()
+        config = {"security": {"shared_cache": "overlay"}}
+
+        provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            config,
+            hook=self._make_hook(),
+        )
+
+        # The cache is mounted read-write at the final path (no -ro staging).
+        disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
+        shared_calls = [c for c in disk_calls if "shared-mathlib" in c[2]]
+        assert len(shared_calls) == 1
+        assert shared_calls[0][4] == "/shared/mathlib-cache"  # final path
+        assert shared_calls[0][5] is False  # read-write
+
+        # The mount source is a per-bubble copy, not the shared cache itself.
+        seed_source = Path(shared_calls[0][3])
+        assert seed_source != shared
+        expected = tmp_data_dir / "shared-cache-copies" / "test-container" / "mathlib-cache"
+        assert seed_source == expected
+        # And it was seeded from the shared cache contents.
+        assert (seed_source / "seed.txt").read_text() == "cached olean"
+        assert seed_source.stat().st_mode & 0o777 == 0o770
+
+        # No overlayfs mount is attempted on macOS.
+        exec_calls = [c for c in mock_runtime.calls if c[0] == "exec"]
+        overlay_execs = [c for c in exec_calls if "mount -t overlay" in " ".join(c[2])]
+        assert overlay_execs == []
+
+    def test_shared_cache_overlay_macos_replaces_stale_copy(
+        self, mock_runtime, tmp_data_dir, monkeypatch
+    ):
+        """A leftover copy from a crashed run is replaced, not nested into."""
+        import bubble.provisioning as provisioning
+        from bubble.provisioning import provision_container
+
+        monkeypatch.setattr(provisioning.platform, "system", lambda: "Darwin")
+
+        shared = tmp_data_dir / "mathlib-cache"
+        shared.mkdir()
+        (shared / "fresh.txt").write_text("new")
+
+        # Pre-existing stale copy with different contents.
+        stale = tmp_data_dir / "shared-cache-copies" / "test-container" / "mathlib-cache"
+        stale.mkdir(parents=True)
+        (stale / "stale.txt").write_text("old")
+
+        ref_path = tmp_data_dir / "repo.git"
+        ref_path.mkdir()
+        config = {"security": {"shared_cache": "overlay"}}
+
+        provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            config,
+            hook=self._make_hook(),
+        )
+
+        assert (stale / "fresh.txt").read_text() == "new"
+        assert not (stale / "stale.txt").exists()
+        # Not nested: no mathlib-cache/mathlib-cache directory.
+        assert not (stale / "mathlib-cache").exists()
+
+    def test_cleanup_cache_copies_removes_seed_dir(self, tmp_data_dir):
+        """destroy_bubble's cleanup removes a bubble's seeded cache copies."""
+        from bubble.commands.lifecycle import _cleanup_cache_copies
+        from bubble.provisioning import cache_copies_dir
+
+        copies = cache_copies_dir("test-container")
+        (copies / "mathlib-cache").mkdir(parents=True)
+        (copies / "mathlib-cache" / "x").write_text("data")
+        assert copies.exists()
+
+        _cleanup_cache_copies("test-container")
+        assert not copies.exists()
+
+    def test_cleanup_cache_copies_noop_when_absent(self, tmp_data_dir):
+        """Cleanup is a no-op when no seeded copies exist (Linux/non-overlay)."""
+        from bubble.commands.lifecycle import _cleanup_cache_copies
+
+        # Should not raise even though nothing was seeded.
+        _cleanup_cache_copies("never-seeded")


### PR DESCRIPTION
This PR fixes `shared-cache overlay` on macOS/Colima, where the shared cache reaches containers over virtiofs and overlayfs-over-virtiofs cannot perform copy-up. The result was a mount that was unwritable even though it was mounted read-write and owned by the container user: every write failed with `Permission denied`, which broke `lake exe cache get` (it could not write its `curl.cfg` or decompressed oleans) and forced the container to build Mathlib from source. This only affected users who opted into `overlay` mode; the default `on` mode (read-write shared cache) was never affected. The bug has been present since `overlay` mode shipped in v0.7.2 — it was developed and tested on Linux, where overlayfs works.

On Darwin, back overlay mode with a per-bubble writable copy seeded from the shared cache via `cp -c` (APFS clonefile: created instantly, copy-on-write, sharing storage with the shared cache until a file is modified), mounted read-write at the cache path. This preserves both properties overlay mode exists for: fast reads from the shared cache, and writes isolated from other containers so a compromised container can't poison the shared cache. Linux continues to use a real overlayfs mount. The per-bubble copy is removed on `bubble pop`.

Closes https://github.com/kim-em/bubble/issues/306 — shared-cache overlay is unwritable on macOS/Colima (overlayfs-over-virtiofs) → breaks lake exe cache get

🤖 Prepared with Claude Code