### PR TITLE
feat: ship jq in the base image

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,7 +39,7 @@ bubble/
 ├── images/
 │   ├── builder.py      # Image build via IMAGES registry dict (recursive parent building)
 │   └── scripts/
-│       ├── base.sh     # Ubuntu 24.04 + git + ssh + build-essential (user: "user")
+│       ├── base.sh     # Ubuntu 24.04 + git + curl + jq + ssh + build-essential (user: "user")
 │       ├── lean.sh     # Fallback elan install (skipped if elan tool already installed)
 │       ├── lean-toolchain.sh  # Installs one specific Lean toolchain (for versioned images)
 │       └── tools/      # Per-tool install scripts (claude.sh, codex.sh, elan.sh, emacs.sh, neovim.sh, vscode.sh)

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Images are built automatically on first use. Any enabled [tools](#tools) are ins
 
 | Image | Contents |
 |-------|----------|
-| `base` | Ubuntu 24.04, git, openssh-server, build-essential, plus configured tools |
+| `base` | Ubuntu 24.04, git, curl, jq, openssh-server, build-essential, plus configured tools |
 | `lean` | base + leantar (+ elan fallback if not installed as a tool) |
 | `python` | base + uv, ruff |
 | `lean-v4.X.Y` | lean + specific toolchain pre-installed (built lazily on demand) |

--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.21"
+__version__ = "0.7.22"

--- a/bubble/image_management.py
+++ b/bubble/image_management.py
@@ -82,7 +82,7 @@ def maybe_rebuild_tools(runtime: ContainerRuntime, notices=None):
 
     if notices:
         notices.begin()
-    step("Tools configuration changed, rebuilding base image...")
+    step("Base image configuration changed, rebuilding base image...")
     build_image(runtime, "base", force=True, still_needed=_tools_still_stale, quiet=True)
 
 

--- a/bubble/images/scripts/base.sh
+++ b/bubble/images/scripts/base.sh
@@ -8,7 +8,7 @@ echo "BUBBLE_PROGRESS: Installing system packages..."
 apt-get update -qq
 apt-get install -y -qq \
     git curl build-essential cmake openssh-server \
-    ca-certificates netcat-openbsd iptables < /dev/null
+    ca-certificates netcat-openbsd iptables jq < /dev/null
 
 # Create user (no sudo, no password)
 echo "BUBBLE_PROGRESS: Creating user account..."

--- a/bubble/tools.py
+++ b/bubble/tools.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).parent / "images" / "scripts" / "tools"
 PINS_FILE = SCRIPTS_DIR / "pins.json"
+BASE_SCRIPT = SCRIPTS_DIR.parent / "base.sh"
 
 # Registry of available tools.
 # Each entry maps a tool name to:
@@ -186,13 +187,21 @@ def resolve_tools(config: dict) -> list[str]:
 def tools_hash(enabled_tools: list[str]) -> str:
     """Compute a stable hash of the enabled tool set, their scripts, and pins.
 
-    Includes tool names, script contents, and pinned versions so that changes
-    to install scripts or version pins trigger rebuilds.
+    Includes tool names, script contents, pinned versions, and the base image
+    script so that changes to install scripts, version pins, or the base image
+    setup (e.g. adding a system package) trigger rebuilds. The base image
+    script is folded in here because base.sh content is not otherwise tracked
+    for drift, so edits to it would not reach existing users without a manual
+    rebuild.
     """
     h = hashlib.sha256()
     # Include pins so version bumps trigger rebuilds
     pins = load_pins()
     h.update(json.dumps(pins, sort_keys=True).encode())
+    h.update(b"\x00")
+    # Include the base image script so base.sh edits trigger a rebuild
+    if BASE_SCRIPT.exists():
+        h.update(BASE_SCRIPT.read_bytes())
     h.update(b"\x00")
     for name in _sort_by_priority(enabled_tools):
         h.update(name.encode())

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -209,6 +209,30 @@ def test_tool_script_verifies_node_checksum():
     assert "nodejs.org/dist" in script
 
 
+def test_tools_hash_changes_with_base_script(tmp_path, monkeypatch):
+    """Verify that changing the base image script changes the tools hash.
+
+    base.sh content is not otherwise tracked for drift, so folding it into
+    tools_hash ensures edits (e.g. adding a system package) reach existing
+    users via the synchronous tools rebuild path.
+    """
+    h1 = tools_hash(["claude"])
+
+    fake_base = tmp_path / "base.sh"
+    fake_base.write_text("#!/bin/bash\n# different content\n")
+    monkeypatch.setattr("bubble.tools.BASE_SCRIPT", fake_base)
+    h2 = tools_hash(["claude"])
+    assert h1 != h2
+
+
+def test_base_image_installs_jq():
+    """jq must ship in the base image so in-container scripts can parse JSON."""
+    from bubble.tools import BASE_SCRIPT
+
+    contents = BASE_SCRIPT.read_text()
+    assert "jq" in contents.split("apt-get install", 1)[1].split("\n\n", 1)[0]
+
+
 def test_tools_hash_changes_with_pins(tmp_path, monkeypatch):
     """Verify that changing pins changes the tools hash."""
     h1 = tools_hash(["claude"])
@@ -492,6 +516,70 @@ def test_build_base_purges_dynamic_toolchain_images(mock_runtime, monkeypatch, t
     deleted_names = {c[1] for c in delete_calls}
     # Dynamic toolchain images should also be purged
     assert "lean-v4-16-0" in deleted_names
+
+
+def test_maybe_rebuild_tools_triggers_on_stale_hash(mock_runtime, monkeypatch, tmp_data_dir):
+    """A stale tools-hash (e.g. base.sh changed on upgrade) forces a base rebuild.
+
+    This is the path by which existing users with an already-built base image
+    pick up base.sh changes like the newly-added jq package.
+    """
+    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
+
+    from bubble.config import load_config, save_config
+
+    config = load_config()
+    config["editor"] = "shell"
+    save_config(config)
+
+    from bubble.images.builder import TOOLS_HASH_FILE
+
+    TOOLS_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TOOLS_HASH_FILE.write_text("stale-hash\n")
+
+    calls = []
+    monkeypatch.setattr(
+        "bubble.images.builder.build_image",
+        lambda runtime, name, **kw: calls.append((name, kw)),
+    )
+
+    from bubble.image_management import maybe_rebuild_tools
+
+    maybe_rebuild_tools(mock_runtime)
+
+    assert calls, "expected a base rebuild to be triggered"
+    name, kw = calls[0]
+    assert name == "base"
+    assert kw.get("force") is True
+
+
+def test_maybe_rebuild_tools_noop_when_hash_matches(mock_runtime, monkeypatch, tmp_data_dir):
+    """No rebuild when the stored tools-hash already matches the current one."""
+    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
+
+    from bubble.config import load_config, save_config
+
+    config = load_config()
+    config["editor"] = "shell"
+    save_config(config)
+
+    from bubble.images.builder import TOOLS_HASH_FILE
+    from bubble.tools import resolve_tools, tools_hash
+
+    TOOLS_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TOOLS_HASH_FILE.write_text(tools_hash(resolve_tools(config)) + "\n")
+
+    calls = []
+    monkeypatch.setattr(
+        "bubble.images.builder.build_image",
+        lambda runtime, name, **kw: calls.append((name, kw)),
+    )
+
+    from bubble.image_management import maybe_rebuild_tools
+
+    maybe_rebuild_tools(mock_runtime)
+
+    assert calls == []
 
 
 def test_collect_derived_images_recursive():


### PR DESCRIPTION
This PR ships `jq` in the bubble base image so in-container scripts that parse JSON (for example the cooperative `claim.sh` step a roadmap round runs inside the bubble) no longer fail with `jq: command not found`. `jq` is a tiny, ubiquitous dependency, so it joins `git`, `curl`, and `build-essential` in the base apt package set rather than becoming a `bubble tools` toggle.

It also closes a drift-detection gap: `base.sh` content was not tracked anywhere, so a package change would never reach users with an already-built base image without a manual rebuild. The base image script is now folded into `tools_hash`, so editing `base.sh` is detected as drift and triggers the existing synchronous base-image rebuild on the next `bubble open`. The rebuild progress message is broadened from "Tools configuration changed" to "Base image configuration changed" accordingly.

Closes https://github.com/kim-em/bubble/issues/309 (jq missing from the bubble image (breaks in-container scripts like claim.sh)).

🤖 Prepared with Claude Code