### PR TITLE
fix: refresh mirror and build exact toolchain image before opening Lean bubbles

### DIFF
--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.22"
+__version__ = "0.7.23"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -38,6 +38,7 @@ from .git_store import (
     ensure_rev_available,
     fetch_ref,
     init_bare_repo,
+    refresh_mirror_ref,
 )
 from .image_management import (
     detect_and_build_image,
@@ -250,6 +251,11 @@ def _resolve_ref_source(t, no_clone: bool) -> tuple[Path, str]:
                 fetch_ref(t.org_repo, f"refs/pull/{t.ref}/head:refs/pull/{t.ref}/head")
             except subprocess.CalledProcessError:
                 click.echo("  Warning: could not prefetch PR ref; continuing with normal clone.")
+        else:
+            # Refresh the branch / default-branch ref so language and toolchain
+            # detection reads the current commit rather than a stale mirror
+            # snapshot (which would otherwise pick the wrong toolchain image).
+            refresh_mirror_ref(t.org_repo, t.kind, t.ref)
 
     return ref_path, mount_name
 
@@ -1075,7 +1081,7 @@ def _open_single(
         notices.finish()
     ensure_dirs()
     ref_path, mount_name = _resolve_ref_source(t, no_clone)
-    hook, image_name = detect_and_build_image(runtime, ref_path, t)
+    hook, image_name = detect_and_build_image(runtime, ref_path, t, restricted_network=network)
 
     # Pre-fetch dependency bare repos for Lake pre-population
     dep_mounts = {}  # repo_name -> host_path

--- a/bubble/git_store.py
+++ b/bubble/git_store.py
@@ -163,6 +163,71 @@ def fetch_ref(org_repo: str, ref: str):
         )
 
 
+def refresh_mirror_ref(org_repo: str, kind: str, ref: str) -> None:
+    """Refresh the bare-mirror ref used for language/toolchain detection.
+
+    Hook detection reads files (e.g. ``lean-toolchain``) straight from the
+    bare mirror at the hook ref. If the repo pushed new commits since the last
+    periodic ``update_all_repos`` run, that snapshot is stale, so a toolchain
+    bump isn't seen and the wrong toolchain image gets selected. Refreshing the
+    one relevant ref here closes that window without a full ``fetch --all``.
+
+    PR refs are fetched separately (and freshly) by the caller, and commit
+    targets are immutable, so only ``branch`` and default-branch (``repo`` /
+    ``issue``) targets need refreshing. Best effort: a failed fetch (offline,
+    deleted branch) leaves the existing mirror in place and emits a warning.
+
+    For ``repo`` / ``issue`` the refreshed branch is whatever the mirror's HEAD
+    points at, matching what detection reads (``git show HEAD:...``). If the
+    upstream default branch changed since the mirror was cloned, the mirror's
+    HEAD is itself stale; that is rare and the periodic ``update_all_repos``
+    refresh corrects it.
+    """
+    path = bare_repo_path(org_repo)
+    if not path.exists():
+        return
+
+    if kind == "branch":
+        branch = ref
+    elif kind in ("repo", "issue"):
+        # These detect against the mirror's HEAD, i.e. its default branch.
+        result = subprocess.run(
+            ["git", "-C", str(path), "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        branch = result.stdout.strip() if result.returncode == 0 else ""
+        if not branch:
+            return
+    else:
+        # "pr" is fetched separately by the caller; "commit" is immutable.
+        return
+
+    with _repo_lock(org_repo):
+        # The "+refs/heads/<branch>:" refspec updates the stored branch ref in
+        # place. The leading "+refs/heads/" guarantees the argument can't be
+        # read as an option even if the branch name starts with "-".
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(path),
+                "fetch",
+                "origin",
+                f"+refs/heads/{branch}:refs/heads/{branch}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    if result.returncode != 0:
+        # Non-fatal, but surface it: stale detection can still pick the wrong
+        # toolchain image, so the user should know the mirror wasn't refreshed.
+        from .output import detail
+
+        detail(f"Warning: could not refresh '{branch}' from {org_repo}; using cached mirror.")
+
+
 def update_all_repos():
     """Update all bare repos found in the git store directory."""
     if not GIT_DIR.exists():

--- a/bubble/image_management.py
+++ b/bubble/image_management.py
@@ -4,6 +4,8 @@ import shutil
 import subprocess
 import sys
 
+import click
+
 from .config import load_config
 from .hooks import select_hook
 from .images.builder import VSCODE_COMMIT_FILE, get_vscode_commit, is_build_locked
@@ -128,8 +130,15 @@ def maybe_rebuild_customize(notices=None):
     )
 
 
-def detect_and_build_image(runtime, ref_path, t):
-    """Detect language hook and ensure image exists. Returns (hook, image_name)."""
+def detect_and_build_image(runtime, ref_path, t, restricted_network: bool = True):
+    """Detect language hook and ensure image exists. Returns (hook, image_name).
+
+    ``restricted_network`` is True when the container will run under the
+    network allowlist (the default). It governs the missing-toolchain-image
+    fallback: under the allowlist, elan cannot download a toolchain inside the
+    container, so a missing ``lean-vX.Y.Z`` image is built synchronously rather
+    than falling back to the plain ``lean`` image.
+    """
     if t.kind == "pr":
         hook_ref = f"refs/pull/{t.ref}/head"
     elif t.kind in ("branch", "commit"):
@@ -149,15 +158,42 @@ def detect_and_build_image(runtime, ref_path, t):
     is_toolchain_image = image_name.startswith("lean-v")
     if not runtime.image_exists(image_name):
         if is_toolchain_image:
-            # Toolchain-specific image doesn't exist yet — fall back to base lean
-            # and build the toolchain image in the background for next time.
             version = image_name[len("lean-") :]
-            detail(
-                f"Toolchain {version} image not cached, using lean image"
-                f" (building {image_name} in background for next time)"
-            )
-            pending_toolchain_build = version
-            image_name = "lean"
+            if restricted_network:
+                # Under the network allowlist, falling back to the plain `lean`
+                # image would force elan to download this toolchain inside the
+                # container, where the repo-scoped auth proxy blocks GitHub
+                # release assets and every lake/elan call hangs ~300s. Build the
+                # toolchain image now instead — image builds run with open
+                # network, so the toolchain is fetched and baked in here.
+                step(f"Building {image_name} image (one-time setup, may take a few minutes)...")
+                from .images.builder import build_lean_toolchain_image
+
+                try:
+                    build_lean_toolchain_image(runtime, version)
+                    detail(f"{image_name} image ready.")
+                except Exception as e:
+                    # Fail fast: falling back to the plain `lean` image here
+                    # would put us right back in the blocked-download hang this
+                    # build was meant to avoid. Surface an actionable error
+                    # instead.
+                    raise click.ClickException(
+                        f"Could not build the {image_name} toolchain image ({e}).\n"
+                        f"Without it, elan would try to download {version} inside"
+                        " the container, which the network allowlist blocks.\n"
+                        "Retry once the network recovers, or rerun with"
+                        " --no-network to allow the in-container download."
+                    ) from e
+            else:
+                # No network restriction — elan can download the toolchain in
+                # the container, so use the plain lean image immediately and
+                # build the toolchain image in the background for next time.
+                detail(
+                    f"Toolchain {version} image not cached, using lean image"
+                    f" (building {image_name} in background for next time)"
+                )
+                pending_toolchain_build = version
+                image_name = "lean"
         if not runtime.image_exists(image_name):
             step(f"Building {image_name} image (one-time setup, may take a few minutes)...")
             from .images.builder import build_image

--- a/tests/test_toolchain_image_selection.py
+++ b/tests/test_toolchain_image_selection.py
@@ -1,0 +1,241 @@
+"""Tests for issue #312: stale mirror / wrong toolchain image selection.
+
+Two fixes are covered:
+
+1. ``refresh_mirror_ref`` refreshes the bare-mirror ref used for toolchain
+   detection, so a freshly pushed ``lean-toolchain`` bump is seen on the next
+   ``bubble open`` instead of waiting for the hourly mirror refresh.
+
+2. ``detect_and_build_image`` builds the exact ``lean-vX.Y.Z`` image
+   synchronously when it is missing and the container will run under the
+   network allowlist (so elan never has to download a blocked toolchain inside
+   the container). With no network restriction it keeps the fast plain-``lean``
+   fallback plus a background build.
+"""
+
+import subprocess
+from dataclasses import dataclass
+
+import pytest
+
+from bubble import image_management
+from bubble.git_store import bare_repo_path, refresh_mirror_ref
+from bubble.images import builder as builder_mod
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+def _init_origin(path, toolchain):
+    path.mkdir(parents=True)
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "lean-toolchain").write_text(toolchain)
+    (path / "lakefile.toml").write_text('name = "demo"\n')
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "initial")
+
+
+def _mirror_from(origin, mirror):
+    subprocess.run(
+        ["git", "clone", "--bare", "-q", str(origin), str(mirror)],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _read_toolchain(mirror, ref):
+    return subprocess.run(
+        ["git", "-C", str(mirror), "show", f"{ref}:lean-toolchain"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+class TestRefreshMirrorRef:
+    def test_branch_ref_refreshed(self, tmp_data_dir, tmp_path):
+        origin = tmp_path / "origin"
+        _init_origin(origin, "leanprover/lean4:v4.31.0-rc2\n")
+        mirror = bare_repo_path("owner/demo")
+        _mirror_from(origin, mirror)
+        # Reconfigure the mirror's origin to the local origin path so the
+        # refresh fetch reaches it (clone --bare records the same URL already).
+        assert _read_toolchain(mirror, "main") == "leanprover/lean4:v4.31.0-rc2"
+
+        # Bump the toolchain upstream after the mirror was taken.
+        (origin / "lean-toolchain").write_text("leanprover/lean4:v4.31.0\n")
+        _git(origin, "commit", "-aqm", "bump toolchain")
+
+        # Stale mirror still sees the old toolchain.
+        assert _read_toolchain(mirror, "main") == "leanprover/lean4:v4.31.0-rc2"
+
+        refresh_mirror_ref("owner/demo", "branch", "main")
+
+        # After refresh the mirror's branch ref reflects the bump.
+        assert _read_toolchain(mirror, "main") == "leanprover/lean4:v4.31.0"
+
+    def test_default_branch_refreshed_for_repo_kind(self, tmp_data_dir, tmp_path):
+        origin = tmp_path / "origin"
+        _init_origin(origin, "leanprover/lean4:v4.30.0\n")
+        mirror = bare_repo_path("owner/demo")
+        _mirror_from(origin, mirror)
+
+        (origin / "lean-toolchain").write_text("leanprover/lean4:v4.31.0\n")
+        _git(origin, "commit", "-aqm", "bump")
+
+        refresh_mirror_ref("owner/demo", "repo", "")
+
+        # HEAD (the mirror's default branch) now reflects the bump.
+        assert _read_toolchain(mirror, "HEAD") == "leanprover/lean4:v4.31.0"
+
+    def test_pr_kind_is_noop(self, tmp_data_dir, tmp_path):
+        origin = tmp_path / "origin"
+        _init_origin(origin, "leanprover/lean4:v4.30.0\n")
+        mirror = bare_repo_path("owner/demo")
+        _mirror_from(origin, mirror)
+
+        (origin / "lean-toolchain").write_text("leanprover/lean4:v4.31.0\n")
+        _git(origin, "commit", "-aqm", "bump")
+
+        # PR refs are fetched separately by the caller; this must not touch the
+        # branch ref.
+        refresh_mirror_ref("owner/demo", "pr", "5")
+        assert _read_toolchain(mirror, "main") == "leanprover/lean4:v4.30.0"
+
+    def test_branch_with_slash_refreshed(self, tmp_data_dir, tmp_path):
+        # Branch names with slashes are valid and flow into the refspec.
+        origin = tmp_path / "origin"
+        _init_origin(origin, "leanprover/lean4:v4.30.0\n")
+        _git(origin, "checkout", "-q", "-b", "feature/bump")
+        mirror = bare_repo_path("owner/demo")
+        _mirror_from(origin, mirror)
+
+        (origin / "lean-toolchain").write_text("leanprover/lean4:v4.31.0\n")
+        _git(origin, "commit", "-aqm", "bump")
+
+        refresh_mirror_ref("owner/demo", "branch", "feature/bump")
+        assert _read_toolchain(mirror, "feature/bump") == "leanprover/lean4:v4.31.0"
+
+    def test_missing_mirror_is_noop(self, tmp_data_dir):
+        # No exception when the mirror doesn't exist yet.
+        refresh_mirror_ref("owner/never-cloned", "branch", "main")
+
+
+@dataclass
+class _Target:
+    kind: str
+    ref: str
+
+
+class _FakeHook:
+    def name(self):
+        return "Lean 4"
+
+    def image_name(self):
+        return "lean-v4.31.0"
+
+
+@pytest.fixture
+def patch_hook(monkeypatch):
+    monkeypatch.setattr(image_management, "select_hook", lambda ref_path, ref: _FakeHook())
+
+
+class TestToolchainImageBuildPolicy:
+    def test_missing_toolchain_built_synchronously_under_network(
+        self, mock_runtime, patch_hook, monkeypatch
+    ):
+        built = []
+        monkeypatch.setattr(
+            builder_mod,
+            "build_lean_toolchain_image",
+            lambda runtime, version: (
+                built.append(version),
+                mock_runtime._images.add("lean-v4.31.0"),
+            ),
+            raising=False,
+        )
+        bg = []
+        monkeypatch.setattr(
+            image_management,
+            "_background_build_lean_toolchain",
+            lambda version: bg.append(version),
+        )
+
+        hook, image_name = image_management.detect_and_build_image(
+            mock_runtime, "/ref", _Target("branch", "main"), restricted_network=True
+        )
+
+        assert image_name == "lean-v4.31.0"
+        assert built == ["v4.31.0"]
+        assert bg == []  # no background fallback when the sync build succeeds
+
+    def test_missing_toolchain_falls_back_without_network(
+        self, mock_runtime, patch_hook, monkeypatch
+    ):
+        built = []
+        monkeypatch.setattr(
+            builder_mod,
+            "build_lean_toolchain_image",
+            lambda runtime, version: built.append(version),
+            raising=False,
+        )
+        bg = []
+        monkeypatch.setattr(
+            image_management,
+            "_background_build_lean_toolchain",
+            lambda version: bg.append(version),
+        )
+        # plain lean image exists so no synchronous base build happens.
+        mock_runtime._images.add("lean")
+
+        hook, image_name = image_management.detect_and_build_image(
+            mock_runtime, "/ref", _Target("branch", "main"), restricted_network=False
+        )
+
+        assert image_name == "lean"
+        assert built == []  # no synchronous toolchain build off-network
+        assert bg == ["v4.31.0"]  # background build queued for next time
+
+    def test_sync_build_failure_under_network_fails_fast(
+        self, mock_runtime, patch_hook, monkeypatch
+    ):
+        import click
+
+        def _boom(runtime, version):
+            raise RuntimeError("network blip")
+
+        monkeypatch.setattr(builder_mod, "build_lean_toolchain_image", _boom, raising=False)
+        bg = []
+        monkeypatch.setattr(
+            image_management,
+            "_background_build_lean_toolchain",
+            lambda version: bg.append(version),
+        )
+        mock_runtime._images.add("lean")
+
+        # Falling back to plain lean here would reintroduce the blocked-download
+        # hang, so a build failure under the allowlist aborts with a clear error.
+        with pytest.raises(click.ClickException):
+            image_management.detect_and_build_image(
+                mock_runtime, "/ref", _Target("branch", "main"), restricted_network=True
+            )
+        assert bg == []  # no background build scheduled on hard failure
+
+    def test_cached_toolchain_image_used_directly(self, mock_runtime, patch_hook, monkeypatch):
+        built = []
+        monkeypatch.setattr(
+            builder_mod,
+            "build_lean_toolchain_image",
+            lambda runtime, version: built.append(version),
+            raising=False,
+        )
+        mock_runtime._images.add("lean-v4.31.0")
+
+        hook, image_name = image_management.detect_and_build_image(
+            mock_runtime, "/ref", _Target("branch", "main"), restricted_network=True
+        )
+
+        assert image_name == "lean-v4.31.0"
+        assert built == []  # already cached, no build


### PR DESCRIPTION
This PR refreshes the bare-mirror ref used for Lean toolchain detection before selecting the image, and builds the exact `lean-<toolchain>` image synchronously when it is missing under the network allowlist, fixing a wrong-image selection that left Lean bubbles hanging on a proxy-blocked elan download (https://github.com/kim-em/bubble/issues/312).

Toolchain-image selection reads `lean-toolchain` from the per-bubble bare mirror at the hook ref. When a repo bumped its toolchain, the mirror could still be at an old commit (it only refreshed on the hourly job), so bubble picked the previous toolchain image. The container's fresh checkout then disagreed, elan tried to download the real toolchain from GitHub release assets, the repo-scoped auth proxy blocked it, and every `lake`/`elan` call hung ~300s. `refresh_mirror_ref()` now fetches the specific branch or default-branch ref into the mirror before detection, closing that window without a full `fetch --all`. PR refs are already fetched freshly and commit targets are immutable, so neither needs refreshing; a failed refresh warns and leaves the cached mirror in place.

A missing `lean-vX.Y.Z` image previously fell back to the plain `lean` image, which forces elan to download the toolchain inside the network-restricted container, the same blocked download. Image builds run with open network, so under the allowlist `detect_and_build_image()` now builds the toolchain image synchronously instead, baking the toolchain in. With `--no-network` the fast plain-lean plus background-build path is kept. If the synchronous build fails under the allowlist it aborts with an actionable error rather than falling back into the hang.

🤖 Prepared with Claude Code