### PR TITLE
fix: rebuild the lean base under its build lock before building a toolchain image

### DIFF
--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.23"
+__version__ = "0.7.24"

--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -566,13 +566,10 @@ def build_lean_toolchain_image(
     if not LEAN_VERSION_RE.fullmatch(version):
         raise ValueError(f"Invalid Lean toolchain version: {version!r}")
 
-    # Ensure base lean image exists
-    if not runtime.image_exists(base_lean_image):
-        if base_lean_image in IMAGES:
-            build_image(runtime, base_lean_image)
-        elif not runtime.image_exists("lean"):
-            build_image(runtime, "lean")
-            base_lean_image = "lean"
+    # If the requested base lean image is unknown and absent, fall back to the
+    # plain `lean` image (which we know how to rebuild from scratch).
+    if base_lean_image not in IMAGES and not runtime.image_exists(base_lean_image):
+        base_lean_image = "lean"
 
     alias = f"lean-{version}"
     # Incus container names only allow alphanumeric + hyphens
@@ -583,10 +580,35 @@ def build_lean_toolchain_image(
     # (root-first to avoid deadlock), preventing any ancestor rebuild
     # from racing with this toolchain build.
     with ExitStack() as stack:
-        # Lock ancestors of the base lean image first (e.g. "base" for "lean")
         if base_lean_image in IMAGES:
-            for ancestor in _ancestor_chain(base_lean_image):
+            ancestors = _ancestor_chain(base_lean_image)
+            # Build any missing managed ancestors (e.g. "base") *before* taking
+            # their shared locks. build_image() acquires its own exclusive lock
+            # per image, so building an ancestor while we already hold its shared
+            # lock would self-deadlock (flock conflicts across fds, even within
+            # one process). After this, the shared-lock acquisitions below wait
+            # out any in-flight rebuild, leaving every ancestor present.
+            for ancestor in ancestors:
+                if not runtime.image_exists(ancestor):
+                    build_image(runtime, ancestor, quiet=True)
+            # Hold shared locks on the ancestors (root-first to avoid deadlock)
+            # for the rest of the build.
+            for ancestor in ancestors:
                 stack.enter_context(_build_lock(ancestor, shared=True))
+
+        # Ensure the base lean image itself exists, now that its ancestors are
+        # present and locked. Building it here, *while holding the ancestor
+        # locks*, closes the race in issue #314: a concurrent base rebuild purges
+        # `lean` right after rebuilding `base`, so if we built `lean` unlocked
+        # and then launched from it, the rebuild could delete `lean` in between
+        # and the launch would fail with `Image "lean" not found`. The ancestor
+        # locks block that rebuild until this toolchain build completes. The
+        # ancestors already exist, so build_image() won't recurse into them and
+        # only needs an exclusive lock on `base_lean_image` (which we don't yet
+        # hold) — no self-deadlock.
+        if base_lean_image in IMAGES and not runtime.image_exists(base_lean_image):
+            build_image(runtime, base_lean_image, quiet=True)
+
         # Then the base lean image itself
         stack.enter_context(_build_lock(base_lean_image, shared=True))
         stack.enter_context(_build_lock(safe_alias))

--- a/tests/test_build_lock.py
+++ b/tests/test_build_lock.py
@@ -156,6 +156,108 @@ def test_build_lean_toolchain_lock(mock_runtime, monkeypatch, tmp_data_dir):
     assert len(launch_calls) == 0
 
 
+def test_toolchain_build_rebuilds_missing_lean_base_under_base_lock(
+    mock_runtime, monkeypatch, tmp_data_dir
+):
+    """Regression for issue #314.
+
+    When a base rebuild has purged the ``lean`` image, building a toolchain
+    image must (a) rebuild ``lean`` first, and (b) hold the ``base`` build lock
+    across the whole base->toolchain dependency so a concurrent base rebuild
+    can't delete ``lean`` between the rebuild and the launch-from-lean. We
+    assert the ``base`` lock is still held immediately after the ``lean``
+    rebuild — in the old code the lean rebuild ran outside the lock, leaving
+    ``base`` unlocked and lettable a concurrent rebuild purge ``lean``.
+    """
+    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
+    monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
+
+    from bubble.config import load_config, save_config
+
+    config = load_config()
+    config["tools"] = {"claude": "no", "codex": "no"}
+    save_config(config)
+
+    from bubble.images import builder
+
+    # base exists, lean was just purged by a base rebuild
+    mock_runtime._images = {"base"}
+
+    observed = {}
+    real_build_image = builder.build_image
+
+    def wrapped_build_image(runtime, image_name, **kwargs):
+        result = real_build_image(runtime, image_name, **kwargs)
+        if image_name == "lean":
+            # We're now in the window between rebuilding `lean` and launching
+            # the toolchain builder from it. The `base` lock must be held so a
+            # concurrent base rebuild can't purge `lean` here.
+            observed["base_locked_after_lean_rebuild"] = is_build_locked("base")
+        return result
+
+    monkeypatch.setattr("bubble.images.builder.build_image", wrapped_build_image)
+
+    # Fail loudly if the toolchain builder launches from a missing image —
+    # exactly the `Image "lean" not found` failure from the issue.
+    real_launch = mock_runtime.launch
+
+    def strict_launch(name, image, **kwargs):
+        if image not in mock_runtime._images:
+            raise RuntimeError(f'Image "{image}" not found')
+        return real_launch(name, image, **kwargs)
+
+    monkeypatch.setattr(mock_runtime, "launch", strict_launch)
+
+    build_lean_toolchain_image(mock_runtime, "v4.16.0")
+
+    assert mock_runtime.image_exists("lean")  # lean rebuilt first
+    assert mock_runtime.image_exists("lean-v4.16.0")  # toolchain built from it
+    assert observed.get("base_locked_after_lean_rebuild") is True
+
+
+def test_toolchain_build_builds_missing_base_and_lean_without_deadlock(
+    mock_runtime, monkeypatch, tmp_data_dir
+):
+    """When both `base` and `lean` are absent, building a toolchain image must
+    build base, then lean, then the toolchain — without self-deadlocking.
+
+    The lean rebuild runs while we hold a shared `base` lock; the recursive
+    build of the missing `base` must therefore happen *before* that shared lock
+    is taken, or build_image("base")'s exclusive lock would deadlock against our
+    shared one (flock is per-fd).
+    """
+    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
+    monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
+    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
+
+    from bubble.config import load_config, save_config
+
+    config = load_config()
+    config["tools"] = {"claude": "no", "codex": "no"}
+    save_config(config)
+
+    # Nothing built yet — fresh setup.
+    mock_runtime._images = set()
+
+    # Run in a worker thread so a deadlock surfaces as a join timeout rather
+    # than hanging the whole test session.
+    done = threading.Event()
+
+    def build():
+        build_lean_toolchain_image(mock_runtime, "v4.16.0")
+        done.set()
+
+    t = threading.Thread(target=build, daemon=True)
+    t.start()
+    t.join(timeout=10)
+
+    assert done.is_set(), "build_lean_toolchain_image deadlocked"
+    assert mock_runtime.image_exists("base")
+    assert mock_runtime.image_exists("lean")
+    assert mock_runtime.image_exists("lean-v4.16.0")
+
+
 def test_shared_lock_blocks_exclusive():
     """A shared lock on an image should block an exclusive lock on that image."""
     order = []


### PR DESCRIPTION
This PR fixes a race where building a Lean toolchain image (`lean-vX.Y.Z`) could fail with `Image "lean" not found` after a base-image rebuild. A base rebuild deletes the derived `lean` image and rebuilds it only on next use; `build_lean_toolchain_image` rebuilt the missing `lean` base outside its `ExitStack` lock and re-acquired the shared lock afterward, leaving a window in which a concurrent base rebuild (holding the exclusive `base` lock and purging derived images) could delete `lean` between the rebuild and the `incus launch` from it. Under the network allowlist this meant a project pinning a not-yet-baked toolchain could not open, since the in-container elan download is blocked.

The rebuild of the `lean` base now happens inside the lock context, so the shared `base` ancestor lock is held continuously across the base→toolchain dependency: a concurrent base rebuild blocks until the toolchain build finishes rather than deleting `lean` out from under it. Missing managed ancestors are built before their shared locks are taken, so the recursive `build_image` never needs an exclusive lock on an image we already hold shared, which would self-deadlock (flock conflicts across file descriptors within a single process).

Closes https://github.com/kim-em/bubble/issues/314

🤖 Prepared with Claude Code