### PR TITLE
fix: honor $CLAUDE_CONFIG_DIR for host-side Claude config and skill paths

### DIFF
--- a/bubble/config.py
+++ b/bubble/config.py
@@ -294,7 +294,25 @@ class SafeConfigDir:
         return any((self.base_dir / item).exists() for item in self.credential_items)
 
 
-CLAUDE_CONFIG_DIR = Path.home() / ".claude"
+def claude_config_dir() -> Path:
+    """Resolve Claude Code's host-side config directory.
+
+    Claude Code honors $CLAUDE_CONFIG_DIR for a non-default config location
+    (the standard way to keep separate personal/work logins), falling back to
+    ~/.claude. We mirror that here so the host-side mount source and skill
+    install location track the same directory Claude Code itself uses.
+
+    The path is taken verbatim (matching Claude Code, which does not expand a
+    quoted ~ or normalize the value); the common forms — an absolute path or a
+    shell-expanded unquoted ~ — already arrive resolved. The container side
+    stays /home/user/.claude, since in-container claude reads ~/.claude by
+    default ($CLAUDE_CONFIG_DIR is not set inside the container).
+    """
+    value = os.environ.get("CLAUDE_CONFIG_DIR")
+    return Path(value) if value else Path.home() / ".claude"
+
+
+CLAUDE_CONFIG_DIR = claude_config_dir()
 
 CLAUDE_CONFIG = SafeConfigDir(
     base_dir=CLAUDE_CONFIG_DIR,
@@ -528,7 +546,7 @@ def maybe_symlink_ai_projects(config: dict | None = None, notices=None) -> None:
     if notices:
         notices.begin()
     click.echo(
-        "~/.claude/projects is git-tracked. AI sessions within bubbles are stored\n"
+        f"{claude_projects} is git-tracked. AI sessions within bubbles are stored\n"
         "in ~/.bubble/ai-projects. To link that directory into the git-tracked\n"
         "location (existing data is merged, not overwritten), run:\n"
         "\n"

--- a/bubble/skill.py
+++ b/bubble/skill.py
@@ -2,11 +2,13 @@
 
 import difflib
 from importlib import resources
-from pathlib import Path
+
+from .config import claude_config_dir
 
 SKILL_NAME = "bubble"
 SKILL_FILENAME = "SKILL.md"
-CLAUDE_DIR = Path.home() / ".claude"
+# Honor $CLAUDE_CONFIG_DIR so the skill installs where Claude Code looks.
+CLAUDE_DIR = claude_config_dir()
 SKILLS_DIR = CLAUDE_DIR / "skills" / SKILL_NAME
 INSTALLED_SKILL = SKILLS_DIR / SKILL_FILENAME
 
@@ -18,7 +20,7 @@ def _bundled_skill_content() -> str:
 
 
 def claude_code_detected() -> bool:
-    """Check if Claude Code is set up (i.e. ~/.claude/ exists)."""
+    """Check if Claude Code is set up (i.e. its config dir exists)."""
     return CLAUDE_DIR.is_dir()
 
 
@@ -58,7 +60,7 @@ def diff_skill() -> str:
 def install_skill() -> str:
     """Install or update the skill file. Returns a status message."""
     if not claude_code_detected():
-        return "~/.claude/ not found — Claude Code not detected. Skipping skill install."
+        return f"{CLAUDE_DIR} not found — Claude Code not detected. Skipping skill install."
 
     SKILLS_DIR.mkdir(parents=True, exist_ok=True)
     content = _bundled_skill_content()

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -363,6 +363,65 @@ class TestMountProvisioning:
         assert len(user_disk_calls) == 0
 
 
+class TestClaudeConfigDirEnvVar:
+    """Test that claude_config_dir() honors the $CLAUDE_CONFIG_DIR env var."""
+
+    def test_env_var_overrides_default(self, tmp_path, monkeypatch):
+        """When $CLAUDE_CONFIG_DIR is set, the host-side dir resolves from it."""
+        from bubble.config import claude_config_dir
+
+        work_dir = tmp_path / "work-claude"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(work_dir))
+        assert claude_config_dir() == work_dir
+
+    def test_falls_back_to_home_claude(self, monkeypatch):
+        """Without the env var, the dir falls back to ~/.claude."""
+        from bubble.config import claude_config_dir
+
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        assert claude_config_dir() == Path.home() / ".claude"
+
+    def test_empty_env_var_falls_back(self, monkeypatch):
+        """An empty $CLAUDE_CONFIG_DIR falls back to ~/.claude (not an empty path)."""
+        from bubble.config import claude_config_dir
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
+        assert claude_config_dir() == Path.home() / ".claude"
+
+    def test_value_taken_verbatim(self, monkeypatch):
+        """The value is used verbatim (mirroring Claude Code; no ~ expansion)."""
+        from bubble.config import claude_config_dir
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/work-claude")
+        # Not expanded — Path keeps the literal leading "~" segment.
+        assert claude_config_dir() == Path("~/work-claude")
+
+    def test_mounts_use_env_dir_as_source(self, tmp_path, monkeypatch):
+        """claude_config_mounts() mounts files from the $CLAUDE_CONFIG_DIR dir.
+
+        This exercises the full path the issue is about: with the env var set,
+        credential and config seeding reads from the work directory, not
+        ~/.claude.
+        """
+        work_dir = tmp_path / "work-claude"
+        work_dir.mkdir()
+        (work_dir / "CLAUDE.md").write_text("# work")
+        (work_dir / ".credentials.json").write_text("{}")
+
+        # Point the live SafeConfigDir at the work dir, as the import-time
+        # resolution would when $CLAUDE_CONFIG_DIR is set.
+        monkeypatch.setattr("bubble.config.CLAUDE_CONFIG.base_dir", work_dir)
+
+        mounts = claude_config_mounts()
+        by_target = {m.target: m for m in mounts}
+        assert by_target["/home/user/.claude/.credentials.json"].source == str(
+            work_dir / ".credentials.json"
+        )
+        assert by_target["/home/user/.claude/CLAUDE.md"].source == str(work_dir / "CLAUDE.md")
+        # Container side is unchanged.
+        assert all(m.target.startswith("/home/user/.claude/") for m in mounts)
+
+
 class TestClaudeConfigMounts:
     """Test automatic ~/.claude config mounting."""
 

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -44,6 +44,15 @@ def test_bundled_skill_content():
     assert "name: bubble" in content
 
 
+def test_skill_dir_honors_claude_config_dir(tmp_path, monkeypatch):
+    """The skill install location resolves from $CLAUDE_CONFIG_DIR when set."""
+    from bubble.config import claude_config_dir
+
+    work_dir = tmp_path / "work-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(work_dir))
+    assert claude_config_dir() == work_dir
+
+
 def test_claude_code_detected(tmp_claude_dir):
     assert skill.claude_code_detected() is True
 


### PR DESCRIPTION
This PR makes bubble resolve the host-side Claude config directory from `$CLAUDE_CONFIG_DIR` when it is set, falling back to `~/.claude`. Claude Code itself honors this variable for a non-default config location (the standard way to keep separate personal/work logins), but bubble previously always looked under `~/.claude`. As a result, running `CLAUDE_CONFIG_DIR=/path/to/work-claude bubble ...` seeded no Claude credentials (`has_credentials()` checked the wrong directory) and the in-container `claude` was treated as unconfigured.

The container side stays `/home/user/.claude`, since in-container `claude` reads `~/.claude` by default (`$CLAUDE_CONFIG_DIR` is not set inside the container) — only the host mount source needs to change. A shared `claude_config_dir()` helper backs both the config/credential mount source and the bubble skill install location in `skill.py`, which hardcoded `~/.claude` the same way. The value is taken verbatim, mirroring Claude Code's own resolution.

This surfaced from contributor feedback on the `tauceti` worker, which delegates Claude credential seeding into the bubble via `--claude-credentials` and now fails fast for the bubble path until bubble honors the var (https://github.com/kim-em/TauCetiWorker/pull/37).

Closes https://github.com/kim-em/bubble/issues/317

A related but separate gap remains: on macOS, Claude Code stores credentials in the Keychain rather than `~/.claude/.credentials.json`, so `credential_items=[".credentials.json"]` finds nothing there. That is worth a separate issue if Keychain seeding is in scope.

🤖 Prepared with Claude Code