### PR TITLE
feat: fork-PR write support via per-token push_repos

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,7 +149,9 @@ The auth proxy (`auth_proxy.py`) provides repo-scoped GitHub authentication with
 
 **Remote/cloud bubbles:** SSH reverse tunnel forwards the local proxy port. Incus proxy devices on the remote expose both TCP and Unix socket endpoints.
 
-**Token management:** Per-container tokens in `~/.bubble/auth-tokens.json` map to `{container, owner, repo, rest_api, graphql_read, graphql_write}`. Tokens are cleaned up on `bubble pop`. The daemon is managed via launchd/systemd.
+**Token management:** Per-container tokens in `~/.bubble/auth-tokens.json` map to `{container, owner, repo, rest_api, graphql_read, graphql_write, push_repos}`. Tokens are cleaned up on `bubble pop`. The daemon is managed via launchd/systemd.
+
+**Fork-PR write support:** `push_repos` is a set of additional `owner/repo` forks the container may git **fetch and push** to (REST/GraphQL stay scoped to the base `owner/repo`). It is populated from two sources: a fork-headed PR target's head repo (auto-detected via the GitHub API in `clone.pr_fork_repo`), and the repeatable `--allow-push owner/repo` flag (an explicit, human-declared grant validated for shape only). This unblocks the standard fork-PR workflow — push commits to the contributor's own fork while reviews/CI live on the base repo. Push to the base repo is unchanged (the proxy forwards it; GitHub rejects it when the host token lacks base write). `createPullRequest` is a base mutation (`repositoryId` = base, head as `headRefName` like `login:branch`), so a cross-repo PR opens under the base scope with no fork GraphQL. Forks must be resolved into the token *before* clone, because local bubbles strip github.com from the egress allowlist and route the fork-PR fetch through the proxy.
 
 ### Security Model
 The `user` account has no sudo and a locked password. Network allowlisting is applied on container creation. SSH keys are injected via `incus file push` (not shell interpolation). All user-supplied values in shell commands are quoted with `shlex.quote()`. Each container mounts only its specific bare repo, not the entire git store.

--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.24"
+__version__ = "0.7.25"

--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -13,6 +13,8 @@ Access policies (per-container):
   rest_api:       whether repo-scoped REST API access is allowed
   graphql_read:   "whitelisted", "unrestricted", or "none"
   graphql_write:  "whitelisted", "unrestricted", or "none"
+  push_repos:     additional owner/repo forks allowed for git fetch+push
+                  only (REST/GraphQL stay scoped to the base owner/repo)
 
 Security model:
 - Git: strict 4-pattern allowlist (git smart HTTP protocol only)
@@ -199,6 +201,26 @@ logger = logging.getLogger("bubble.auth_proxy")
 # ---------------------------------------------------------------------------
 
 
+def normalize_push_repos(push_repos) -> list[str]:
+    """Normalize a list of ``owner/repo`` fork specs for token storage.
+
+    Lower-cases each entry, drops blanks and anything not shaped like
+    ``owner/repo``, and de-duplicates while preserving order. Returns a
+    list of lower-cased ``owner/repo`` strings (possibly empty).
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in push_repos or []:
+        spec = (raw or "").strip().lower()
+        parts = spec.split("/")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            continue
+        if spec not in seen:
+            seen.add(spec)
+            result.append(spec)
+    return result
+
+
 def generate_auth_token(
     container_name: str,
     owner: str,
@@ -206,12 +228,19 @@ def generate_auth_token(
     rest_api: bool = True,
     graphql_read: str = "whitelisted",
     graphql_write: str = "whitelisted",
+    push_repos: list[str] | None = None,
 ) -> str:
     """Generate an auth proxy token for a container.
 
     The token maps to (container_name, owner, repo, rest_api, graphql_read,
-    graphql_write) — the proxy uses this to validate requests and enforce
-    the access policy.
+    graphql_write, push_repos) — the proxy uses this to validate requests
+    and enforce the access policy.
+
+    ``push_repos`` is a set of additional ``owner/repo`` forks the
+    container may git fetch from and push to. REST and GraphQL stay scoped
+    to the base ``owner/repo``; the forks get git access only. This
+    unblocks the fork-PR workflow (push commits to the contributor's fork
+    while reviews/CI live on the base repo).
 
     The token is a 256-bit bearer credential: possession grants the
     scoped access. It lives only in the issuing container's filesystem
@@ -228,6 +257,7 @@ def generate_auth_token(
             "rest_api": rest_api,
             "graphql_read": graphql_read,
             "graphql_write": graphql_write,
+            "push_repos": normalize_push_repos(push_repos),
         }
     )
 
@@ -274,8 +304,18 @@ class ProxyRateLimiter(_RateLimiter):
 # ---------------------------------------------------------------------------
 
 
-def validate_path(path: str, query: str, owner: str, repo: str) -> str | None:
+def validate_path(
+    path: str,
+    query: str,
+    owner: str,
+    repo: str,
+    push_repos: list[str] | None = None,
+) -> str | None:
     """Validate a request path against the git smart HTTP allowlist.
+
+    Git (both fetch and push) is allowed against the base ``owner/repo``
+    and against any repo in ``push_repos`` (the contributor's forks). REST
+    and GraphQL remain base-scoped and are validated elsewhere.
 
     Returns an error message string, or None if the path is valid.
     """
@@ -304,8 +344,10 @@ def validate_path(path: str, query: str, owner: str, repo: str) -> str | None:
     if path_repo.endswith(".git"):
         path_repo = path_repo[:-4]
 
-    # Validate owner/repo matches the allowed repo
-    if path_owner.lower() != owner.lower() or path_repo.lower() != repo.lower():
+    # Validate owner/repo matches the base repo or one of the allowed forks.
+    allowed = {f"{owner.lower()}/{repo.lower()}"}
+    allowed.update(push_repos or [])
+    if f"{path_owner.lower()}/{path_repo.lower()}" not in allowed:
         return f"Repository mismatch: {path_owner}/{path_repo} != {owner}/{repo}"
 
     # Validate query string
@@ -765,6 +807,7 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
         rest_api = info.get("rest_api", False)
         graphql_read = info.get("graphql_read", "none")
         graphql_write = info.get("graphql_write", "none")
+        push_repos = info.get("push_repos") or []
 
         # Rate limit
         if not self.rate_limiter.check(container):
@@ -786,7 +829,7 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
 
         # Route: git smart HTTP (/git/...)
         if path.startswith("/git/"):
-            self._handle_git_request(method, path, query, body, container, owner, repo)
+            self._handle_git_request(method, path, query, body, container, owner, repo, push_repos)
             return
 
         # Route: GraphQL (/graphql)
@@ -818,9 +861,14 @@ class AuthProxyHandler(BaseHTTPRequestHandler):
             return self._read_chunked()
         return b""
 
-    def _handle_git_request(self, method, path, query, body, container, owner, repo):
-        """Handle git smart HTTP requests (always allowed for valid tokens)."""
-        error = validate_path(path, query, owner, repo)
+    def _handle_git_request(
+        self, method, path, query, body, container, owner, repo, push_repos=None
+    ):
+        """Handle git smart HTTP requests (always allowed for valid tokens).
+
+        Git is allowed against the base repo and any fork in ``push_repos``.
+        """
+        error = validate_path(path, query, owner, repo, push_repos)
         if error:
             self._send_error(403, error)
             logger.info("BLOCKED %s %s container=%s reason=%s", method, path, container, error)

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import click
 
 from . import __version__
-from .clone import clone_and_checkout
+from .clone import clone_and_checkout, fetch_pr_metadata, pr_fork_repo
 from .config import (
     claude_config_mounts,
     codex_config_mounts,
@@ -310,6 +310,63 @@ def _resolve_ai_prompt_locally(target: str, new_branch: str | None = None) -> st
     return prompt
 
 
+def _resolve_push_repos(t, allow_push, pr_meta=None) -> list[str]:
+    """Resolve the set of fork repos the bubble may git fetch/push to.
+
+    Combines explicit ``--allow-push owner/repo`` flags with the head repo
+    of a fork-headed PR target (auto-detected). Returns a normalized,
+    de-duplicated list of lower-cased ``owner/repo`` strings. Malformed
+    ``--allow-push`` values are warned about and skipped.
+
+    ``--allow-push`` is an explicit, human-controlled grant: the named
+    repo gets git fetch+push (no REST/GraphQL). It is validated for shape
+    only, not verified to be a fork of the base — the launcher is trusted
+    to name the contributor's own throwaway fork. The auto-detected PR
+    fork, by contrast, is exactly the PR's head repo from the GitHub API.
+
+    ``pr_meta`` may be a previously-fetched PR metadata tuple to avoid
+    re-querying GitHub.
+    """
+    from .auth_proxy import normalize_push_repos
+
+    repos: list[str] = []
+    for raw in allow_push or ():
+        spec = (raw or "").strip()
+        parts = spec.split("/")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            click.echo(f"Warning: ignoring --allow-push '{raw}' (expected OWNER/REPO)", err=True)
+            continue
+        repos.append(spec)
+
+    if t is not None:
+        try:
+            fork = pr_fork_repo(t, pr_meta)
+        except Exception:
+            fork = None
+        if fork:
+            repos.append(fork)
+
+    return normalize_push_repos(repos)
+
+
+def _resolve_remote_push_repos(target, allow_push) -> list[str]:
+    """Resolve fork repos for a remote bubble, parsing the target locally.
+
+    The PR head repo is detected here (on the local machine, which has the
+    gh CLI) rather than on the remote, so the locally-issued proxy token
+    carries the fork scope.
+    """
+    t = None
+    try:
+        from .repo_registry import RepoRegistry
+        from .target import parse_target
+
+        t = parse_target(target, RepoRegistry())
+    except Exception:
+        t = None
+    return _resolve_push_repos(t, allow_push)
+
+
 def _open_remote(
     remote_host,
     target,
@@ -330,6 +387,7 @@ def _open_remote(
     base_ref=None,
     ephemeral=False,
     github_security=None,
+    allow_push=(),
 ):
     """Open a bubble on a remote host, then connect locally."""
     from .remote import remote_open
@@ -395,6 +453,7 @@ def _open_remote(
         if org_repo and "/" in org_repo:
             owner, repo = org_repo.split("/", 1)
         gh_enabled = "gh" in resolve_tools(config)
+        push_repos = _resolve_remote_push_repos(target, allow_push)
         auth_ok = setup_gh_token(
             None,
             name,
@@ -403,6 +462,7 @@ def _open_remote(
             remote_host=remote_host,
             gh_enabled=gh_enabled,
             config=config,
+            push_repos=push_repos,
         )
         if not auth_ok and network:
             click.echo(
@@ -630,6 +690,18 @@ def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=Fal
     ),
 )
 @click.option(
+    "--allow-push",
+    "allow_push",
+    type=str,
+    multiple=True,
+    metavar="OWNER/REPO",
+    help=(
+        "Allow git fetch/push to an additional fork repo (repeatable)."
+        " REST and GraphQL stay scoped to the base repo. A fork-headed PR"
+        " target adds its head repo automatically."
+    ),
+)
+@click.option(
     "--ai-prompt-stdin",
     is_flag=True,
     hidden=True,
@@ -669,6 +741,7 @@ def open_cmd(
     claude_config,
     codex_config,
     github_security,
+    allow_push,
     ai_prompt_stdin,
     skip_auth_setup,
 ):
@@ -733,6 +806,7 @@ def open_cmd(
                 claude_config=claude_config,
                 codex_config=codex_config,
                 github_security=github_security,
+                allow_push=allow_push,
                 ai_prompt_stdin=ai_prompt_stdin,
                 skip_auth_setup=skip_auth_setup,
             )
@@ -791,7 +865,8 @@ def _open_single(
     claude_config,
     codex_config,
     github_security,
-    ai_prompt_stdin,
+    allow_push=(),
+    ai_prompt_stdin=False,
     skip_auth_setup=False,
 ):
     """Open a single bubble target."""
@@ -970,6 +1045,7 @@ def _open_single(
             base_ref=base_ref,
             ephemeral=ephemeral,
             github_security=github_security,
+            allow_push=allow_push,
         )
         return
 
@@ -1117,6 +1193,12 @@ def _open_single(
 
     # Provision, clone, and finalize
     short = repo_short_name(t.org_repo)
+    # Fetch PR metadata once (fork detection for the auth token + checkout).
+    # Only needed locally: remote orchestration (skip_auth_setup) sets up the
+    # token on the controlling machine and lets clone fetch its own metadata.
+    pr_meta = None
+    if t.kind == "pr" and not skip_auth_setup:
+        pr_meta = fetch_pr_metadata(t)
     try:
         provision_container(
             runtime,
@@ -1163,6 +1245,12 @@ def _open_single(
                 from .tools import resolve_tools
 
                 gh_enabled = "gh" in resolve_tools(config)
+                # Authorize git fetch/push to the contributor's fork(s):
+                # explicit --allow-push flags plus a fork-headed PR's head
+                # repo. Resolved before clone because, for local bubbles,
+                # github.com is stripped from the egress allowlist and the
+                # fork-PR fetch during clone routes through the proxy.
+                push_repos = _resolve_push_repos(t, allow_push, pr_meta)
                 auth_ok = setup_gh_token(
                     runtime,
                     name,
@@ -1171,6 +1259,7 @@ def _open_single(
                     machine_readable=machine_readable,
                     gh_enabled=gh_enabled,
                     config=config,
+                    push_repos=push_repos,
                 )
                 if not auth_ok and network:
                     raise click.ClickException(
@@ -1180,7 +1269,7 @@ def _open_single(
                         "or use `--no-network` to skip network allowlisting."
                     )
 
-        checkout_branch = clone_and_checkout(runtime, name, t, mount_name, short)
+        checkout_branch = clone_and_checkout(runtime, name, t, mount_name, short, pr_meta=pr_meta)
 
         # After clone completes, re-tighten network by removing the temporary
         # github.com access that was granted for the clone. This must happen on

--- a/bubble/clone.py
+++ b/bubble/clone.py
@@ -34,7 +34,43 @@ def _get_pr_metadata(owner: str, repo: str, pr_number: str) -> tuple[str, str, s
     return None
 
 
-def clone_and_checkout(runtime, name, t, mount_name, short) -> str:
+def fetch_pr_metadata(t):
+    """Fetch ``(head_ref, head_repo, clone_url)`` for a PR target, or None.
+
+    Thin public wrapper around :func:`_get_pr_metadata` so callers can
+    fetch PR metadata once and reuse it (for fork detection before auth
+    setup and again for checkout) rather than querying GitHub twice.
+    """
+    if t.kind != "pr":
+        return None
+    return _get_pr_metadata(t.owner, t.repo, t.ref)
+
+
+def pr_fork_repo(t, pr_meta=None) -> str | None:
+    """Return the PR head repo ``owner/repo`` when it's a fork, else None.
+
+    For a PR target whose head lives in a fork (head repo != base repo),
+    returns that fork's ``owner/repo``. Used to auto-authorize git
+    fetch/push to the fork so the standard fork-PR workflow works inside a
+    bubble. Returns None for non-PR targets, same-repo PRs, or when the PR
+    metadata can't be fetched (e.g. gh unavailable).
+
+    ``pr_meta`` may be a previously-fetched ``(head_ref, head_repo,
+    clone_url)`` tuple to avoid re-querying GitHub.
+    """
+    if t.kind != "pr":
+        return None
+    if pr_meta is None:
+        pr_meta = _get_pr_metadata(t.owner, t.repo, t.ref)
+    if not pr_meta:
+        return None
+    _head_ref, head_repo, _clone_url = pr_meta
+    if head_repo and head_repo.lower() != t.org_repo.lower():
+        return head_repo
+    return None
+
+
+def clone_and_checkout(runtime, name, t, mount_name, short, pr_meta=None) -> str:
     """Clone the repo and checkout the appropriate ref. Returns the checkout branch name."""
     url = github_url(t.org_repo)
     q_short = shlex.quote(short)
@@ -68,7 +104,8 @@ def clone_and_checkout(runtime, name, t, mount_name, short) -> str:
         checkout_branch = branch_name
     elif t.kind == "pr":
         step(f"Checking out PR #{t.ref}...")
-        pr_meta = _get_pr_metadata(t.owner, t.repo, t.ref)
+        if pr_meta is None:
+            pr_meta = _get_pr_metadata(t.owner, t.repo, t.ref)
         pr_checkout_ok = False
         if pr_meta:
             head_ref, head_repo, clone_url = pr_meta

--- a/bubble/github_token.py
+++ b/bubble/github_token.py
@@ -368,6 +368,7 @@ def setup_auth_proxy(
     machine_readable: bool = False,
     gh_enabled: bool = False,
     config: dict | None = None,
+    push_repos: list[str] | None = None,
 ) -> bool:
     """Set up auth proxy access for a local container via the bridge flow.
 
@@ -375,6 +376,9 @@ def setup_auth_proxy(
     incus bridge (git) and a bind-mounted Unix socket (gh). No
     ``proxy``-type incus devices are created, so there are no per-bubble
     ``forkproxy`` helpers to leak on stop/start cycles.
+
+    ``push_repos`` lists additional ``owner/repo`` forks the container may
+    git fetch from and push to (REST/GraphQL stay scoped to owner/repo).
 
     (Remote/cloud bubbles use :func:`setup_auth_proxy_remote`, a separate
     SSH-tunnelled transport.)
@@ -401,6 +405,7 @@ def setup_auth_proxy(
         graphql_write,
         machine_readable,
         gh_enabled,
+        push_repos,
     )
 
 
@@ -415,6 +420,7 @@ def _setup_auth_proxy_bridge(
     graphql_write: str,
     machine_readable: bool,
     gh_enabled: bool,
+    push_repos: list[str] | None = None,
 ) -> bool:
     """Bridge-listener setup: no proxy-type devices, just a disk mount
     for the gh socket plus a per-bubble bearer token."""
@@ -461,6 +467,7 @@ def _setup_auth_proxy_bridge(
         rest_api=rest_api,
         graphql_read=graphql_read,
         graphql_write=graphql_write,
+        push_repos=push_repos,
     )
 
     # Configure git: talk to the bridge TCP endpoint directly.
@@ -489,6 +496,8 @@ def _setup_auth_proxy_bridge(
             f"GitHub auth proxy configured via bridge {endpoint_str} "
             f"(scoped to {owner}/{repo}, {mode_desc})."
         )
+        if push_repos:
+            detail(f"  git fetch/push also allowed to fork(s): {', '.join(push_repos)}")
     return True
 
 
@@ -572,12 +581,16 @@ def setup_auth_proxy_remote(
     machine_readable: bool = False,
     gh_enabled: bool = False,
     config: dict | None = None,
+    push_repos: list[str] | None = None,
 ) -> bool:
     """Set up auth proxy access for a container on a remote host.
 
     Tunnels the local auth proxy to the remote host via SSH reverse
     port forwarding, adds an Incus proxy device on the remote to
     expose the tunneled port into the container, and configures git.
+
+    ``push_repos`` lists additional ``owner/repo`` forks the container may
+    git fetch from and push to (REST/GraphQL stay scoped to owner/repo).
 
     The host GitHub token never leaves the local machine.
 
@@ -611,6 +624,7 @@ def setup_auth_proxy_remote(
         rest_api=rest_api,
         graphql_read=graphql_read,
         graphql_write=graphql_write,
+        push_repos=push_repos,
     )
 
     # Add Incus proxy device on the remote: tunneled port → container
@@ -679,6 +693,8 @@ def setup_auth_proxy_remote(
         detail(
             f"GitHub auth proxy configured (scoped to {owner}/{repo}, {mode_desc}, via SSH tunnel)."
         )
+        if push_repos:
+            detail(f"  git fetch/push also allowed to fork(s): {', '.join(push_repos)}")
     return True
 
 
@@ -834,6 +850,7 @@ def setup_gh_token(
     gh_enabled: bool = False,
     config: dict | None = None,
     token_inject: bool = False,
+    push_repos: list[str] | None = None,
 ) -> bool:
     """Set up GitHub auth for a container.
 
@@ -874,6 +891,7 @@ def setup_gh_token(
             machine_readable,
             gh_enabled=gh_enabled,
             config=config,
+            push_repos=push_repos,
         )
 
     if runtime:
@@ -885,6 +903,7 @@ def setup_gh_token(
             machine_readable,
             gh_enabled=gh_enabled,
             config=config,
+            push_repos=push_repos,
         )
 
     return False

--- a/tests/test_auth_proxy.py
+++ b/tests/test_auth_proxy.py
@@ -92,6 +92,30 @@ class TestAuthTokenManagement:
         tokens = bubble.auth_proxy._load_tokens()
         assert tokens[token]["rest_api"] is False
 
+    def test_generate_token_default_no_push_repos(self, auth_proxy_env):
+        import bubble.auth_proxy
+
+        token = bubble.auth_proxy.generate_auth_token("c1", "o", "r")
+        tokens = bubble.auth_proxy._load_tokens()
+        assert tokens[token]["push_repos"] == []
+
+    def test_generate_token_with_push_repos(self, auth_proxy_env):
+        import bubble.auth_proxy
+
+        token = bubble.auth_proxy.generate_auth_token(
+            "c1", "base-owner", "base-repo", push_repos=["Login/Fork", "other/repo"]
+        )
+        tokens = bubble.auth_proxy._load_tokens()
+        # Normalized: lower-cased, de-duplicated, order preserved.
+        assert tokens[token]["push_repos"] == ["login/fork", "other/repo"]
+
+    def test_normalize_push_repos_drops_malformed(self):
+        from bubble.auth_proxy import normalize_push_repos
+
+        assert normalize_push_repos(None) == []
+        assert normalize_push_repos(["", "  ", "noslash", "a/b/c", "/x", "y/"]) == []
+        assert normalize_push_repos(["A/B", "a/b", " c/d "]) == ["a/b", "c/d"]
+
     def test_generate_multiple_tokens(self, auth_proxy_env):
         import bubble.auth_proxy
 
@@ -228,6 +252,59 @@ class TestValidatePath:
             "/git/owner/my-repo/info/refs", "service=git-upload-pack", "owner", "my-repo"
         )
         assert err is None
+
+    # --- Fork (push_repos) patterns ---
+
+    def test_fork_fetch_allowed(self):
+        err = validate_path(
+            "/git/login/fork/info/refs",
+            "service=git-upload-pack",
+            "base-owner",
+            "base-repo",
+            push_repos=["login/fork"],
+        )
+        assert err is None
+
+    def test_fork_push_allowed(self):
+        err = validate_path(
+            "/git/login/fork/git-receive-pack",
+            "",
+            "base-owner",
+            "base-repo",
+            push_repos=["login/fork"],
+        )
+        assert err is None
+
+    def test_fork_match_case_insensitive(self):
+        err = validate_path(
+            "/git/Login/Fork.git/info/refs",
+            "service=git-receive-pack",
+            "base-owner",
+            "base-repo",
+            push_repos=["login/fork"],
+        )
+        assert err is None
+
+    def test_base_still_allowed_with_push_repos(self):
+        err = validate_path(
+            "/git/base-owner/base-repo/git-receive-pack",
+            "",
+            "base-owner",
+            "base-repo",
+            push_repos=["login/fork"],
+        )
+        assert err is None
+
+    def test_third_repo_still_rejected_with_push_repos(self):
+        err = validate_path(
+            "/git/other/repo/info/refs",
+            "service=git-upload-pack",
+            "base-owner",
+            "base-repo",
+            push_repos=["login/fork"],
+        )
+        assert err is not None
+        assert "mismatch" in err.lower()
 
     # --- Blocked patterns ---
 
@@ -393,6 +470,57 @@ class TestAuthProxyHandler:
             "/git/hacker/evil-repo/info/refs?service=git-upload-pack",
             headers={"X-Bubble-Token": "valid-token"},
             token_info={"container": "c1", "owner": "owner", "repo": "repo"},
+        )
+        handler._proxy_request("GET")
+        assert 403 in handler._responses
+
+    def test_fork_push_forwarded(self):
+        """A push to a fork in push_repos is forwarded, not blocked."""
+        handler = self._make_handler(
+            "POST",
+            "/git/login/fork/git-receive-pack",
+            headers={"X-Bubble-Token": "valid-token", "Content-Length": "0"},
+            token_info={
+                "container": "c1",
+                "owner": "owner",
+                "repo": "repo",
+                "push_repos": ["login/fork"],
+            },
+        )
+        forwarded = {}
+        handler._forward_to_github = lambda *a, **kw: forwarded.setdefault("url", a[1])
+        handler._proxy_request("POST")
+        assert 403 not in handler._responses
+        assert forwarded.get("url", "").endswith("/login/fork/git-receive-pack")
+
+    def test_fork_rest_still_blocked(self):
+        """REST stays base-scoped even when the fork is in push_repos."""
+        handler = self._make_handler(
+            "GET",
+            "/repos/login/fork/pulls",
+            headers={"X-Bubble-Token": "valid-token"},
+            token_info={
+                "container": "c1",
+                "owner": "owner",
+                "repo": "repo",
+                "rest_api": True,
+                "push_repos": ["login/fork"],
+            },
+        )
+        handler._proxy_request("GET")
+        assert 403 in handler._responses
+
+    def test_third_repo_git_still_blocked_with_push_repos(self):
+        handler = self._make_handler(
+            "GET",
+            "/git/other/repo/info/refs?service=git-upload-pack",
+            headers={"X-Bubble-Token": "valid-token"},
+            token_info={
+                "container": "c1",
+                "owner": "owner",
+                "repo": "repo",
+                "push_repos": ["login/fork"],
+            },
         )
         handler._proxy_request("GET")
         assert 403 in handler._responses

--- a/tests/test_fork_push.py
+++ b/tests/test_fork_push.py
@@ -1,0 +1,94 @@
+"""Tests for fork-PR push support (issue #319).
+
+Covers the fork-repo resolution helpers that feed the auth proxy token's
+``push_repos`` set: ``pr_fork_repo`` (auto-detect a fork-headed PR's head
+repo) and the CLI's ``_resolve_push_repos`` (combine explicit
+``--allow-push`` flags with the detected fork).
+"""
+
+from unittest.mock import patch
+
+from bubble.target import Target
+
+
+def _pr_target(owner="FormalFrontier", repo="TauCeti", ref="42"):
+    return Target(owner=owner, repo=repo, kind="pr", ref=ref, original=f"{owner}/{repo}/pull/{ref}")
+
+
+def _repo_target(owner="FormalFrontier", repo="TauCeti"):
+    return Target(owner=owner, repo=repo, kind="repo", ref="", original=f"{owner}/{repo}")
+
+
+class TestPrForkRepo:
+    def test_non_pr_target_returns_none(self):
+        from bubble.clone import pr_fork_repo
+
+        assert pr_fork_repo(_repo_target()) is None
+
+    def test_fork_headed_pr_returns_head_repo(self):
+        from bubble import clone
+
+        with patch.object(
+            clone,
+            "_get_pr_metadata",
+            return_value=("branch", "contributor/TauCeti", "https://github.com/x.git"),
+        ):
+            assert clone.pr_fork_repo(_pr_target()) == "contributor/TauCeti"
+
+    def test_same_repo_pr_returns_none(self):
+        from bubble import clone
+
+        with patch.object(
+            clone,
+            "_get_pr_metadata",
+            return_value=("branch", "FormalFrontier/TauCeti", "https://github.com/x.git"),
+        ):
+            assert clone.pr_fork_repo(_pr_target()) is None
+
+    def test_metadata_unavailable_returns_none(self):
+        from bubble import clone
+
+        with patch.object(clone, "_get_pr_metadata", return_value=None):
+            assert clone.pr_fork_repo(_pr_target()) is None
+
+
+class TestResolvePushRepos:
+    def test_explicit_allow_push_only(self):
+        from bubble.cli import _resolve_push_repos
+
+        repos = _resolve_push_repos(_repo_target(), ["Contributor/TauCeti"])
+        assert repos == ["contributor/tauceti"]
+
+    def test_malformed_allow_push_skipped(self):
+        from bubble.cli import _resolve_push_repos
+
+        repos = _resolve_push_repos(_repo_target(), ["noslash", "a/b/c", "good/fork"])
+        assert repos == ["good/fork"]
+
+    def test_combines_flag_and_pr_fork(self):
+        from bubble import cli
+
+        with patch.object(cli, "pr_fork_repo", return_value="contributor/TauCeti"):
+            repos = cli._resolve_push_repos(_pr_target(), ["explicit/fork"])
+        assert repos == ["explicit/fork", "contributor/tauceti"]
+
+    def test_dedupes_flag_and_pr_fork(self):
+        from bubble import cli
+
+        with patch.object(cli, "pr_fork_repo", return_value="Contributor/TauCeti"):
+            repos = cli._resolve_push_repos(_pr_target(), ["contributor/tauceti"])
+        assert repos == ["contributor/tauceti"]
+
+    def test_no_target_no_flags(self):
+        from bubble.cli import _resolve_push_repos
+
+        assert _resolve_push_repos(None, ()) == []
+
+    def test_reuses_supplied_pr_meta_without_refetch(self):
+        from bubble import clone
+
+        pr_meta = ("branch", "contributor/TauCeti", "https://github.com/x.git")
+        with patch.object(clone, "_get_pr_metadata") as mock_fetch:
+            repos = clone.pr_fork_repo(_pr_target(), pr_meta)
+        assert repos == "contributor/TauCeti"
+        mock_fetch.assert_not_called()

--- a/tests/test_github_token.py
+++ b/tests/test_github_token.py
@@ -65,6 +65,7 @@ def test_setup_gh_token_local_with_owner_repo(mock_runtime):
             False,
             gh_enabled=False,
             config=None,
+            push_repos=None,
         )
 
 
@@ -105,6 +106,7 @@ def test_setup_gh_token_remote_calls_proxy_remote():
             False,
             gh_enabled=False,
             config=None,
+            push_repos=None,
         )
 
 
@@ -135,6 +137,7 @@ def test_setup_auth_proxy_remote_starts_tunnel():
             rest_api=False,
             graphql_read="none",
             graphql_write="none",
+            push_repos=None,
         )
 
         # Two SSH calls: incus device add + incus exec (writing .gitconfig)


### PR DESCRIPTION
This PR adds fork-PR write support to the auth proxy. The per-container token previously carried exactly one base `(owner, repo)` pair, so the agent inside a bubble could not push to (or reliably fetch from) a PR's fork head, even though bubble already checks out fork PRs. It now also carries a `push_repos` set of additional forks the container may git **fetch from and push to**, while REST and GraphQL stay scoped to the base repo. This unblocks the standard fork-PR workflow: push commits to the contributor's own fork while reviews and CI live on the base.

The fork set is populated two ways. A fork-headed PR target's head repo is auto-detected (`clone.pr_fork_repo`, from the PR's GitHub metadata), so the existing fork-PR checkout becomes actually usable and push to the fork head works. And a repeatable `--allow-push owner/repo` flag declares an authoring fork explicitly, e.g. `bubble open FormalFrontier/TauCeti --allow-push <login>/TauCeti`.

Per-operation policy: git fetch and push are allowed against the base repo and any repo in `push_repos`; REST and GraphQL remain base-scoped (the fork set is never passed to those validators). Base push policy is unchanged — the proxy forwards it and GitHub rejects it when the host token lacks base write, so no canonical WIP branches. `createPullRequest` is a base mutation (`repositoryId` = base, head expressed as `headRefName` like `login:branch`), so a cross-repo PR opens under the base scope with no fork GraphQL. `--allow-push` is an explicit, human-controlled grant validated for shape only — the launcher is trusted to name the contributor's own throwaway fork; the auto-detected PR fork is exactly the PR head from the API.

Forks are resolved into the token *before* clone, because local bubbles strip github.com from the egress allowlist and route the fork-PR fetch during clone through the proxy. The PR metadata is fetched once on the host and reused for both the token scope and the checkout, rather than queried twice.

Closes https://github.com/kim-em/bubble/issues/319

🤖 Prepared with Claude Code