### PR TITLE
fix: lower-case push_repos in validate_path so mixed-case forks aren't 403'd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Fix `--allow-push` fork validation rejecting mixed-case fork names
+  - `validate_path` now lower-cases `push_repos` entries before the allow-set membership test, so a fork like `kim-em/TauCeti` is no longer 403'd as a `Repository mismatch` when passed un-normalized (the token-creation path already normalized; this makes the validator self-contained)
 - Remove `--native` mode entirely
   - `bubble --native <target>` is no longer accepted (use `bubble open` for containerized bubbles)
   - `bubble.native` module deleted; `check_native_clean`, `open_editor_native`, and `NATIVE_DIR` removed

--- a/bubble/auth_proxy.py
+++ b/bubble/auth_proxy.py
@@ -344,9 +344,11 @@ def validate_path(
     if path_repo.endswith(".git"):
         path_repo = path_repo[:-4]
 
-    # Validate owner/repo matches the base repo or one of the allowed forks.
+    # Validate owner/repo matches the base repo or an allowed fork, case-insensitively on all three.
+    # push_repos is lower-cased at token creation; lower-case it here too so validate_path is self-
+    # contained — a caller passing a mixed-case fork (e.g. "Login/Fork") isn't 403'd as a mismatch.
     allowed = {f"{owner.lower()}/{repo.lower()}"}
-    allowed.update(push_repos or [])
+    allowed.update(r.lower() for r in (push_repos or []))
     if f"{path_owner.lower()}/{path_repo.lower()}" not in allowed:
         return f"Repository mismatch: {path_owner}/{path_repo} != {owner}/{repo}"
 

--- a/tests/test_auth_proxy.py
+++ b/tests/test_auth_proxy.py
@@ -285,6 +285,18 @@ class TestValidatePath:
         )
         assert err is None
 
+    def test_fork_match_mixed_case_push_repos(self):
+        # A mixed-case fork passed straight to validate_path must still match (the allow-set is
+        # case-insensitive). Regression guard for the "kim-em/TauCeti" 403 seen in the worker.
+        err = validate_path(
+            "/git/kim-em/TauCeti/git-receive-pack",
+            "",
+            "FormalFrontier",
+            "TauCeti",
+            push_repos=["kim-em/TauCeti"],
+        )
+        assert err is None
+
     def test_base_still_allowed_with_push_repos(self):
         err = validate_path(
             "/git/base-owner/base-repo/git-receive-pack",


### PR DESCRIPTION
This PR lower-cases `push_repos` entries in `validate_path` before the allow-set membership test, so a mixed-case fork passed un-normalized (for example `kim-em/TauCeti`) is no longer rejected as a `Repository mismatch`. The validator already lower-cases the base owner/repo and the request path; the forks were the one side compared verbatim. Token creation normalizes via `normalize_push_repos`, so this was latent for the in-process path, but `validate_path` is a public validator and should be self-contained — a direct caller with a mixed-case fork hit a spurious 403. A regression test passes a mixed-case fork straight to `validate_path`.

🤖 Prepared with Claude Code