### PR TITLE
chore: refresh pinned tool versions weekly via CI

### DIFF
--- a/.github/workflows/update-pins.yml
+++ b/.github/workflows/update-pins.yml
@@ -1,0 +1,39 @@
+name: Update tool pins
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e .
+
+      - name: Refresh pinned tool versions
+        run: bubble tools update
+
+      - name: Open pull request if pins changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-tool-pins
+          delete-branch: true
+          title: "chore: update pinned tool versions"
+          commit-message: "chore: update pinned tool versions"
+          body: |
+            Automated weekly refresh of `bubble/images/scripts/tools/pins.json`
+            via `bubble tools update`, pulling the latest Node.js LTS and
+            coding-agent releases (Claude Code, Codex, Pi, Mistral Vibe).
+
+            Merging bumps the versions baked into the `base` image on the next
+            rebuild. Review the diff, then merge if the new versions look sane.


### PR DESCRIPTION
This PR adds a scheduled GitHub Actions workflow that runs `bubble tools update` every Monday at 06:00 UTC (with a `workflow_dispatch` button for on-demand runs), then opens a pull request whenever `bubble/images/scripts/tools/pins.json` changes. It keeps the Node.js LTS and coding-agent pins (Claude Code, Codex, Pi, Mistral Vibe) from drifting between manual maintainer refreshes.

Re-runs update the single `chore/update-tool-pins` PR rather than stacking new ones. The PR uses the default `GITHUB_TOKEN`, so the repo setting "Allow GitHub Actions to create and approve pull requests" must be enabled for the PR step to succeed.

🤖 Prepared with Claude Code