### PR TITLE
fix: own the Incus client config dir in integration CI (Incus 7.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
           sudo incus admin init --minimal
           # Allow non-root access (CI-only, ephemeral VM)
           sudo chmod 666 /var/lib/incus/unix.socket
+          # Incus 7.2+ refuses to run without a readable ~/.config/incus, and
+          # the sudo init above can leave that dir root-owned — which makes
+          # client commands (e.g. `incus storage list`) fail for the runner
+          # user and trips bubble's "not initialized" path. Give the runner
+          # ownership of its own config dir.
+          mkdir -p "$HOME/.config/incus"
+          sudo chown -R "$(id -u):$(id -g)" "$HOME/.config/incus"
           # Ensure IP forwarding and NAT for container internet access
           sudo sysctl -w net.ipv4.ip_forward=1
           sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/8 -o eth0 -j MASQUERADE


### PR DESCRIPTION
This PR restores the `integration` CI job, which has failed on every branch (including `master`) since Incus 7.2 landed on 2026-07-01. The 7.2 client refuses to run without a readable `~/.config/incus/config.yml`, and the `sudo incus admin init --minimal` step leaves that directory root-owned. As the `runner` user, `incus storage list` then fails on the config permission, bubble misreads this as "Incus not initialized" and runs `incus admin init --auto`, which dies with `permission denied` on the config file. Giving the runner ownership of its own `~/.config/incus` before bubble touches Incus lets `incus storage list` see the daemon-side pool created by the minimal init, so bubble returns early instead of re-initializing.

The last green integration run was 2026-06-26, before the 7.2 release; no CI or bubble code changed in between, so the break is purely the upstream client upgrade.

🤖 Prepared with Claude Code