### PR TITLE
feat: mount ~/.vibe/config.toml into bubbles for Mistral Vibe

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,7 @@ Images are defined in `builder.py`'s `IMAGES` dict with script and parent refere
 Tools are installed in container images via the `[tools]` config section. Each tool has a self-contained install script in `bubble/images/scripts/tools/` and is registered in the `TOOLS` dict in `tools.py` with its script filename, host detection command, required network domains, and a priority for install ordering. Tools include:
 
 - **Language tools** (priority 10): `elan` — auto-detected if elan is on the host
-- **Coding agents** (priority 50): `claude`, `codex`, `pi`, `vibe` — auto-detected via host commands. `vibe` is Mistral Vibe, the home of the Leanstral Lean 4 agent; unlike the npm-based agents it is Python and installed via `uv`.
+- **Coding agents** (priority 50): `claude`, `codex`, `pi`, `vibe` — auto-detected via host commands. `vibe` is Mistral Vibe, the home of the Leanstral Lean 4 agent; unlike the npm-based agents it is Python and installed via `uv`. Vibe keeps its whole configuration (Mistral auth plus the `/leanstall` agent setup) in a single `~/.vibe/config.toml`, which bubble mounts read-only into containers (`VIBE_CONFIG` in `config.py`, gated by the `vibe_credentials` security setting and the `--vibe-credentials` flag) so a host-side `/leanstall` carries in with no per-container setup.
 - **General tools** (priority 50): `gh` — auto-detected via host commands
 - **Editors** (priority 90): `vscode`, `emacs`, `neovim` — driven by the `editor` config key
 

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -20,6 +20,7 @@ from .config import (
     maybe_symlink_ai_projects,
     parse_mounts,
     repo_short_name,
+    vibe_config_mounts,
 )
 from .container_helpers import (
     detect_project_dir,
@@ -381,6 +382,7 @@ def _open_remote(
     ai_config=True,
     claude_credentials=None,
     codex_credentials=None,
+    vibe_credentials=None,
     claude_config=None,
     codex_config=None,
     new_branch=None,
@@ -406,6 +408,7 @@ def _open_remote(
             ai_config=ai_config,
             claude_credentials=claude_credentials,
             codex_credentials=codex_credentials,
+            vibe_credentials=vibe_credentials,
             claude_config=claude_config,
             codex_config=codex_config,
             new_branch=new_branch,
@@ -662,6 +665,11 @@ def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=Fal
     help="Mount ~/.codex credentials into container (default: from config or enabled)",
 )
 @click.option(
+    "--vibe-credentials/--no-vibe-credentials",
+    default=None,
+    help="Mount ~/.vibe/config.toml into container (default: from config or enabled)",
+)
+@click.option(
     "--claude-config/--no-claude-config",
     default=None,
     help=(
@@ -738,6 +746,7 @@ def open_cmd(
     ai_config,
     claude_credentials,
     codex_credentials,
+    vibe_credentials,
     claude_config,
     codex_config,
     github_security,
@@ -803,6 +812,7 @@ def open_cmd(
                 ai_config=ai_config,
                 claude_credentials=claude_credentials,
                 codex_credentials=codex_credentials,
+                vibe_credentials=vibe_credentials,
                 claude_config=claude_config,
                 codex_config=codex_config,
                 github_security=github_security,
@@ -862,6 +872,7 @@ def _open_single(
     ai_config,
     claude_credentials,
     codex_credentials,
+    vibe_credentials,
     claude_config,
     codex_config,
     github_security,
@@ -915,6 +926,15 @@ def _open_single(
         click.echo(
             "Error: --codex-credentials rejected because security.codex-credentials=off. "
             "Re-enable: bubble security set codex-credentials on",
+            err=True,
+        )
+        sys.exit(1)
+
+    # Enforce security: reject --vibe-credentials when locked off
+    if vibe_credentials and is_locked_off(config, "vibe_credentials"):
+        click.echo(
+            "Error: --vibe-credentials rejected because security.vibe-credentials=off. "
+            "Re-enable: bubble security set vibe-credentials on",
             err=True,
         )
         sys.exit(1)
@@ -1008,6 +1028,10 @@ def _open_single(
     if codex_credentials is None:
         codex_credentials = config.get("codex", {}).get("credentials", True)
 
+    # Resolve vibe_credentials: CLI flag > config > default (True)
+    if vibe_credentials is None:
+        vibe_credentials = config.get("vibe", {}).get("credentials", True)
+
     # Resolve claude_config / codex_config: CLI flag > config > default (True)
     if claude_config is None:
         claude_config = config.get("claude", {}).get("config", True)
@@ -1039,6 +1063,7 @@ def _open_single(
             ai_config=ai_config,
             claude_credentials=claude_credentials,
             codex_credentials=codex_credentials,
+            vibe_credentials=vibe_credentials,
             claude_config=claude_config,
             codex_config=codex_config,
             new_branch=new_branch,
@@ -1079,6 +1104,16 @@ def _open_single(
         )
         if cx_mounts:
             cx_mounts = [m for m in cx_mounts if not mount_overlaps(Path(m.target), user_targets)]
+
+    # Vibe config mount (~/.vibe/config.toml — also gated by --no-ai-config)
+    vb_mounts = []
+    if ai_config:
+        include_vibe_creds = should_include_credentials(
+            vibe_credentials, config, "vibe_credentials"
+        )
+        if include_vibe_creds:
+            vb_mounts = vibe_config_mounts(include_credentials=True)
+            vb_mounts = [m for m in vb_mounts if not mount_overlaps(Path(m.target), user_targets)]
 
     # Editor config mounts (emacs/neovim only — suppress if user mounts overlap)
     ec_mounts = editor_config_mounts(editor, config)
@@ -1213,6 +1248,7 @@ def _open_single(
             user_mounts=mount_specs,
             claude_mounts=cc_mounts,
             codex_mounts=cx_mounts,
+            vibe_mounts=vb_mounts,
             editor_mounts=ec_mounts,
             skip_auth_setup=skip_auth_setup,
         )

--- a/bubble/commands/settings.py
+++ b/bubble/commands/settings.py
@@ -131,7 +131,7 @@ def register_settings_commands(main):
     @click.argument("setting", required=False, type=click.Choice(["on", "off"]))
     @click.option(
         "--provider",
-        type=click.Choice(["claude", "codex"]),
+        type=click.Choice(["claude", "codex", "vibe"]),
         default=None,
         help="Provider to configure (default: preferred provider from config)",
     )

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -493,6 +493,26 @@ def codex_config_mounts(
     )
 
 
+VIBE_CONFIG_DIR = Path.home() / ".vibe"
+
+# Mistral Vibe (home of the Leanstral agent) stores its whole configuration —
+# including the Mistral API key and the `/leanstall` agent setup — in a single
+# ~/.vibe/config.toml. Unlike Claude/Codex there is no separate credential file,
+# so config.toml is treated as the credential item: mounting it read-only lets a
+# host-side `/leanstall` carry into the bubble with no in-container setup.
+VIBE_CONFIG = SafeConfigDir(
+    base_dir=VIBE_CONFIG_DIR,
+    container_dir="/home/user/.vibe",
+    config_items=[],
+    credential_items=["config.toml"],
+)
+
+
+def vibe_config_mounts(include_credentials: bool = True) -> list[MountSpec]:
+    """Return read-only mounts for Mistral Vibe config files that exist on the host."""
+    return VIBE_CONFIG.config_mounts(include_credentials=include_credentials)
+
+
 AI_PROJECTS_DIR = DATA_DIR / "ai-projects"
 
 

--- a/bubble/provisioning.py
+++ b/bubble/provisioning.py
@@ -154,6 +154,7 @@ def provision_container(
     user_mounts=None,
     claude_mounts=None,
     codex_mounts=None,
+    vibe_mounts=None,
     editor_mounts=None,
     skip_auth_setup=False,
 ):
@@ -308,6 +309,23 @@ def provision_container(
             runtime.add_disk(
                 name,
                 f"codex-config-{i}",
+                m.source,
+                m.target,
+                readonly=m.readonly,
+            )
+
+    # Mount Vibe config (read-only ~/.vibe/config.toml — holds Mistral auth
+    # and the Leanstral agent setup). The rest of ~/.vibe stays container-local
+    # so vibe can write sessions/logs.
+    if vibe_mounts:
+        runtime.exec(
+            name,
+            ["bash", "-c", "mkdir -p /home/user/.vibe && chown user:user /home/user/.vibe"],
+        )
+        for i, m in enumerate(vibe_mounts):
+            runtime.add_disk(
+                name,
+                f"vibe-config-{i}",
                 m.source,
                 m.target,
                 readonly=m.readonly,

--- a/bubble/remote.py
+++ b/bubble/remote.py
@@ -417,6 +417,7 @@ def remote_open(
     ai_config: bool = True,
     claude_credentials: bool | None = None,
     codex_credentials: bool | None = None,
+    vibe_credentials: bool | None = None,
     claude_config: bool | None = None,
     codex_config: bool | None = None,
     new_branch: str | None = None,
@@ -447,6 +448,10 @@ def remote_open(
         args.append("--codex-credentials")
     elif codex_credentials is False:
         args.append("--no-codex-credentials")
+    if vibe_credentials is True:
+        args.append("--vibe-credentials")
+    elif vibe_credentials is False:
+        args.append("--no-vibe-credentials")
     if claude_config is True:
         args.append("--claude-config")
     elif claude_config is False:

--- a/bubble/security.py
+++ b/bubble/security.py
@@ -127,6 +127,12 @@ SETTINGS: dict[str, SecuritySettingDef] = {
         warning="credentials give containers access to OpenAI/Codex API auth",
         category="Authentication",
     ),
+    "vibe_credentials": SecuritySettingDef(
+        description="Mount ~/.vibe credentials into containers",
+        auto_default="on",
+        warning="credentials give containers access to Mistral/Vibe API auth",
+        category="Authentication",
+    ),
     "github": SecuritySettingDef(
         description="GitHub access level for containers",
         auto_default="on",  # not "off"; actual level resolved by get_github_level()

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -10,6 +10,7 @@ from bubble.config import (
     codex_config_mounts,
     editor_config_mounts,
     parse_mounts,
+    vibe_config_mounts,
 )
 
 
@@ -1034,6 +1035,120 @@ class TestCodexConfigProvisioning:
         disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
         codex_disk_calls = [c for c in disk_calls if "codex" in c[2]]
         assert len(codex_disk_calls) == 0
+
+
+class TestVibeConfigMounts:
+    """Test automatic ~/.vibe config mounting."""
+
+    def test_returns_config_toml(self, tmp_path, monkeypatch):
+        """config.toml (the single credential-bearing file) is mounted read-only."""
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        (vibe_dir / "config.toml").write_text("[mistral]")
+
+        monkeypatch.setattr("bubble.config.VIBE_CONFIG.base_dir", vibe_dir)
+
+        mounts = vibe_config_mounts()
+
+        assert len(mounts) == 1
+        assert mounts[0].target == "/home/user/.vibe/config.toml"
+        assert mounts[0].readonly
+
+    def test_excluded_without_credentials(self, tmp_path, monkeypatch):
+        """config.toml is a credential item, so nothing mounts without credentials."""
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        (vibe_dir / "config.toml").write_text("[mistral]")
+
+        monkeypatch.setattr("bubble.config.VIBE_CONFIG.base_dir", vibe_dir)
+
+        assert vibe_config_mounts(include_credentials=False) == []
+
+    def test_no_vibe_dir(self, tmp_path, monkeypatch):
+        """Returns empty when ~/.vibe doesn't exist."""
+        monkeypatch.setattr("bubble.config.VIBE_CONFIG.base_dir", tmp_path / "nonexistent")
+
+        assert vibe_config_mounts() == []
+
+    def test_rejects_symlink_escaping_vibe_dir(self, tmp_path, monkeypatch):
+        """Symlinks that escape ~/.vibe are rejected."""
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        secret = tmp_path / "secret.toml"
+        secret.write_text("token = 'leak'")
+        (vibe_dir / "config.toml").symlink_to(secret)
+
+        monkeypatch.setattr("bubble.config.VIBE_CONFIG.base_dir", vibe_dir)
+
+        assert vibe_config_mounts() == []
+
+
+class TestVibeConfigProvisioning:
+    """Test that vibe config mounts are applied during container provisioning."""
+
+    def test_vibe_mounts_applied(self, mock_runtime, tmp_path, tmp_data_dir):
+        """Verify add_disk call with a vibe-config device name."""
+        from bubble.provisioning import provision_container as _provision_container
+
+        ref_path = tmp_path / "repo.git"
+        ref_path.mkdir()
+
+        vibe_mounts = [
+            MountSpec(
+                source="/home/testuser/.vibe/config.toml",
+                target="/home/user/.vibe/config.toml",
+                readonly=True,
+            ),
+        ]
+
+        _provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            {},
+            vibe_mounts=vibe_mounts,
+        )
+
+        disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
+        vibe_disk_calls = [c for c in disk_calls if "vibe-config" in c[2]]
+        assert vibe_disk_calls == [
+            (
+                "add_disk",
+                "test-container",
+                "vibe-config-0",
+                "/home/testuser/.vibe/config.toml",
+                "/home/user/.vibe/config.toml",
+                True,
+            ),
+        ]
+
+        exec_calls = [c for c in mock_runtime.calls if c[0] == "exec"]
+        mkdir_calls = [c for c in exec_calls if ".vibe" in " ".join(c[2])]
+        assert len(mkdir_calls) == 1
+        assert "mkdir -p /home/user/.vibe" in " ".join(mkdir_calls[0][2])
+        assert "chown user:user" in " ".join(mkdir_calls[0][2])
+
+    def test_no_vibe_mounts(self, mock_runtime, tmp_path, tmp_data_dir):
+        """No vibe mount calls when vibe_mounts is empty."""
+        from bubble.provisioning import provision_container as _provision_container
+
+        ref_path = tmp_path / "repo.git"
+        ref_path.mkdir()
+
+        _provision_container(
+            mock_runtime,
+            "test-container",
+            "base",
+            ref_path,
+            "repo.git",
+            {},
+            vibe_mounts=[],
+        )
+
+        disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
+        assert [c for c in disk_calls if "vibe" in c[2]] == []
 
 
 class TestMountOverlaps:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -285,6 +285,19 @@ class TestRemoteOpenFlagForwarding:
         assert "--codex-credentials" not in cmd_str
         assert "--no-codex-credentials" not in cmd_str
 
+    def test_vibe_credentials_forwarded(self):
+        cmd_str = self._run_remote_open(vibe_credentials=True)
+        assert "--vibe-credentials" in cmd_str
+
+    def test_no_vibe_credentials_forwarded(self):
+        cmd_str = self._run_remote_open(vibe_credentials=False)
+        assert "--no-vibe-credentials" in cmd_str
+
+    def test_vibe_credentials_none_not_forwarded(self):
+        cmd_str = self._run_remote_open(vibe_credentials=None)
+        assert "--vibe-credentials" not in cmd_str
+        assert "--no-vibe-credentials" not in cmd_str
+
     def test_claude_config_forwarded(self):
         cmd_str = self._run_remote_open(claude_config=True)
         assert "--claude-config" in cmd_str

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -258,6 +258,25 @@ def test_filter_github_domains_no_github():
 # --- CLI tests ---
 
 
+def test_open_vibe_credentials_rejected_when_locked_off():
+    """`--vibe-credentials` is rejected with an explanatory error when the host
+    has `security.vibe-credentials=off` (must not silently mount them)."""
+    from unittest.mock import patch
+
+    from bubble.cli import main
+
+    runner = CliRunner()
+    with patch(
+        "bubble.cli.load_config",
+        return_value={"security": {"vibe_credentials": "off"}},
+    ):
+        result = runner.invoke(main, ["open", "--vibe-credentials", "kim-em/bubble"])
+    assert result.exit_code != 0
+    assert "rejected because security.vibe-credentials=off" in (
+        result.output + (result.stderr or "")
+    )
+
+
 def test_security_cli_shows_posture(tmp_data_dir):
     from bubble.cli import main
 
@@ -797,6 +816,16 @@ def test_should_include_credentials_requested_false_security_auto():
 def test_should_include_credentials_requested_true_security_auto():
     config = {}
     assert should_include_credentials(True, config, "claude_credentials") is True
+
+
+def test_should_include_credentials_vibe_locked_off_overrides_true():
+    config = {"security": {"vibe_credentials": "off"}}
+    assert should_include_credentials(True, config, "vibe_credentials") is False
+
+
+def test_should_include_credentials_vibe_auto_enables():
+    """Vibe credentials behave like Claude/Codex: auto (default) enables them."""
+    assert should_include_credentials(False, {}, "vibe_credentials") is True
 
 
 # --- shared_cache overlay tests ---


### PR DESCRIPTION
This PR mounts the host's `~/.vibe/config.toml` read-only into containers so Mistral Vibe (the home of the Leanstral Lean 4 agent) works inside a bubble with no per-container setup. A host-side `/leanstall` writes that single file (Mistral auth plus the agent config), and mounting it carries the whole setup in, matching how bubble already brings in Claude and Codex credentials.

It adds `VIBE_CONFIG` (a `SafeConfigDir`) and `vibe_config_mounts()` alongside the existing Claude/Codex config mounts, gated by a new `vibe_credentials` security setting and a `--vibe-credentials/--no-vibe-credentials` flag, plumbed through the local and remote/cloud open paths. Vibe keeps everything in `config.toml` with no separate credential file, so that file is treated as the credential item. `bubble ai credentials --provider vibe` and the `vibe_credentials` security setting control it.

🤖 Prepared with Claude Code