### PR TITLE
fix: guard VSCode launch when bubble runs inside a Remote-SSH session

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -63,6 +63,7 @@ from .target import Target, TargetParseError, parse_target
 from .vscode import (
     add_ssh_config,
     open_editor,
+    remote_vscode_client_detected,
     warn_if_remote_vscode_client,
 )
 
@@ -495,6 +496,30 @@ def _open_remote(
     detail(f"SSH: ssh bubble-{name}")
 
     if not no_interactive:
+        # If we're orchestrating a remote bubble from inside a VSCode Remote-SSH
+        # session, the local `code` would forward to a further-up client that
+        # has no route to this bubble — the same "Could not resolve hostname"
+        # failure. The bubble is ready; guide the user to re-run from their true
+        # local machine rather than launch into the failure.
+        if editor == "vscode" and remote_vscode_client_detected():
+            q_host = shlex.quote(remote_host.ssh_destination)
+            q_target = shlex.quote(target) if target else "<target>"
+            click.echo(
+                "Note: bubble is running inside a VSCode Remote-SSH session, so"
+                f" this remote bubble on {remote_host.ssh_destination} can't be"
+                " opened in your (client-side) VSCode window — `code --remote`"
+                " would fail with 'Could not resolve hostname'. The bubble is"
+                " ready; it was just not launched in VSCode.\n\n"
+                "Run the same command from your local machine (the one your"
+                " VSCode runs on):\n"
+                f"    bubble --ssh {q_host} {q_target}\n\n"
+                "Or connect from this terminal with a non-VSCode editor:\n"
+                f"    bubble --shell --ssh {q_host} {q_target}\n\n"
+                "Set BUBBLE_ALLOW_REMOTE_VSCODE=1 to override if you've wired up"
+                " the client side yourself.",
+                err=True,
+            )
+            return
         echo_editor_opening(editor)
         exit_code = open_editor(
             editor, name, project_dir, workspace_file=workspace_file, command=command

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -63,6 +63,7 @@ from .target import Target, TargetParseError, parse_target
 from .vscode import (
     add_ssh_config,
     open_editor,
+    warn_if_remote_vscode_client,
 )
 
 # ---------------------------------------------------------------------------
@@ -504,7 +505,7 @@ def _open_remote(
             _ephemeral_pop_and_exit(name, exit_code)
 
 
-def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=False):
+def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=False, target_hint=""):
     """Re-attach to an existing container."""
     # ``ensure_running`` re-applies the network allowlist on stop/start
     # transitions; see issue #285.
@@ -555,6 +556,8 @@ def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=Fal
         except RuntimeError:
             pass  # Can't check status, skip pull
 
+    if warn_if_remote_vscode_client(editor, target_hint):
+        return
     echo_editor_opening(editor)
     exit_code = open_editor(editor, name, project_dir, command=command)
     if ephemeral and command:
@@ -1101,7 +1104,15 @@ def _open_single(
             machine_readable_output("reattached", existing, project_dir=project_dir)
             return
         notices.finish()
-        _reattach(runtime, existing, editor, no_interactive, command=command, ephemeral=ephemeral)
+        _reattach(
+            runtime,
+            existing,
+            editor,
+            no_interactive,
+            command=command,
+            ephemeral=ephemeral,
+            target_hint=target,
+        )
         return
 
     # Parse and register target
@@ -1149,7 +1160,15 @@ def _open_single(
             )
             return
         notices.finish()
-        _reattach(runtime, existing, editor, no_interactive, command=command, ephemeral=ephemeral)
+        _reattach(
+            runtime,
+            existing,
+            editor,
+            no_interactive,
+            command=command,
+            ephemeral=ephemeral,
+            target_hint=target,
+        )
         return
 
     # Resolve git source, detect language, and build image

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -8,7 +8,7 @@ import click
 from .container_helpers import setup_git_config, setup_ssh
 from .lifecycle import register_bubble
 from .security import is_enabled
-from .vscode import open_editor
+from .vscode import open_editor, warn_if_remote_vscode_client
 
 
 def finalize_bubble(
@@ -131,6 +131,8 @@ def finalize_bubble(
     detail(f"Pop:  bubble pop {name}")
 
     if not no_interactive:
+        if warn_if_remote_vscode_client(editor, t.original):
+            return
         echo_editor_opening(editor)
         exit_code = open_editor(
             editor, name, project_dir, workspace_file=workspace_file, command=command

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -20,6 +20,65 @@ SSH_MAIN_CONFIG = Path.home() / ".ssh" / "config"
 _SSH_CONFIG_LOCK_FILE = DATA_DIR / "ssh-config.lock"
 
 
+def remote_vscode_client_detected(env=None) -> bool:
+    """Detect that our `code` CLI would drive a VSCode running on another machine.
+
+    True when bubble is invoked from the integrated terminal of a VSCode
+    Remote-SSH session: `VSCODE_IPC_HOOK_CLI` means the `code` CLI forwards to
+    whichever VSCode owns that IPC socket, and `SSH_CONNECTION` means that
+    VSCode's server was reached over SSH — so the actual VSCode window lives on
+    the *client* machine, not here. In that case `code --remote ssh-remote+...`
+    is handed to the client's VSCode, which has no SSH config, ProxyCommand, or
+    trusted key for a container created on *this* host, and fails with
+    "Could not resolve hostname".
+
+    Bypass with BUBBLE_ALLOW_REMOTE_VSCODE=1 for users who have wired up their
+    client side by hand.
+    """
+    env = os.environ if env is None else env
+    if env.get("BUBBLE_ALLOW_REMOTE_VSCODE"):
+        return False
+    return bool(env.get("VSCODE_IPC_HOOK_CLI") and env.get("SSH_CONNECTION"))
+
+
+def warn_if_remote_vscode_client(editor: str, target_hint: str) -> bool:
+    """Guard the local VSCode launch against the Remote-SSH-client scenario.
+
+    When bubble creates a container on this machine but is running inside a
+    VSCode Remote-SSH session, `code --remote` is handed to the VSCode on the
+    *client* machine, which can't resolve or reach the container (no SSH alias,
+    ProxyCommand, or trusted key for it) and fails with "Could not resolve
+    hostname". Rather than launch into that failure, print actionable guidance
+    and return True so the caller skips the launch (the container is left
+    running, reachable via `bubble --shell` or re-opened from the client with
+    `--ssh`). Returns False when the launch should proceed normally.
+    """
+    import socket
+
+    import click
+
+    if editor != "vscode" or not remote_vscode_client_detected():
+        return False
+    hostname = socket.gethostname()
+    click.echo(
+        "Note: bubble is running inside a VSCode Remote-SSH session, so the"
+        f" container created here on '{hostname}' can't be opened in your"
+        " (client-side) VSCode window — `code --remote` would fail with 'Could"
+        " not resolve hostname'. The container is ready; it was just not"
+        " launched in VSCode.\n\n"
+        "To open it in VSCode, run bubble from your local machine and target"
+        " this host:\n"
+        f"    bubble --ssh {hostname} {target_hint}\n"
+        f'(or set [remote] default_host = "{hostname}" in ~/.bubble/config.toml there).\n\n'
+        "Or work in this terminal with a non-VSCode editor:\n"
+        f"    bubble --shell {target_hint}      # or --emacs / --neovim\n\n"
+        "Set BUBBLE_ALLOW_REMOTE_VSCODE=1 to override if you've wired up the"
+        " client side yourself.",
+        err=True,
+    )
+    return True
+
+
 @contextlib.contextmanager
 def _ssh_config_lock():
     """Serialize all SSH-config writes (add/remove + Include directive)."""

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -36,7 +36,7 @@ def remote_vscode_client_detected(env=None) -> bool:
     client side by hand.
     """
     env = os.environ if env is None else env
-    if env.get("BUBBLE_ALLOW_REMOTE_VSCODE"):
+    if env.get("BUBBLE_ALLOW_REMOTE_VSCODE", "").strip().lower() in {"1", "true", "yes", "on"}:
         return False
     return bool(env.get("VSCODE_IPC_HOOK_CLI") and env.get("SSH_CONNECTION"))
 
@@ -59,19 +59,25 @@ def warn_if_remote_vscode_client(editor: str, target_hint: str) -> bool:
 
     if editor != "vscode" or not remote_vscode_client_detected():
         return False
+    # gethostname() is a best-effort hint: the client connected via some SSH
+    # alias/FQDN we can't recover here, so present the detected name as a
+    # placeholder the user replaces with whatever they SSH in with.
     hostname = socket.gethostname()
+    q_host = shlex.quote(hostname)
+    q_target = shlex.quote(target_hint) if target_hint else "<target>"
     click.echo(
         "Note: bubble is running inside a VSCode Remote-SSH session, so the"
         f" container created here on '{hostname}' can't be opened in your"
         " (client-side) VSCode window — `code --remote` would fail with 'Could"
         " not resolve hostname'. The container is ready; it was just not"
         " launched in VSCode.\n\n"
-        "To open it in VSCode, run bubble from your local machine and target"
-        " this host:\n"
-        f"    bubble --ssh {hostname} {target_hint}\n"
-        f'(or set [remote] default_host = "{hostname}" in ~/.bubble/config.toml there).\n\n'
+        "To open it in VSCode, run bubble from your local machine, targeting"
+        " this host with whatever SSH alias/hostname you connect to it with"
+        f" (detected here as {q_host}):\n"
+        f"    bubble --ssh {q_host} {q_target}\n"
+        f"(or set [remote] default_host = {q_host} in ~/.bubble/config.toml there).\n\n"
         "Or work in this terminal with a non-VSCode editor:\n"
-        f"    bubble --shell {target_hint}      # or --emacs / --neovim\n\n"
+        f"    bubble --shell {q_target}      # or --emacs / --neovim\n\n"
         "Set BUBBLE_ALLOW_REMOTE_VSCODE=1 to override if you've wired up the"
         " client side yourself.",
         err=True,

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -5,7 +5,75 @@ import subprocess
 import pytest
 
 from bubble.remote import RemoteHost
-from bubble.vscode import _BUBBLE_NAME_RE, add_ssh_config, open_vscode, remove_ssh_config
+from bubble.vscode import (
+    _BUBBLE_NAME_RE,
+    add_ssh_config,
+    open_vscode,
+    remote_vscode_client_detected,
+    remove_ssh_config,
+)
+
+
+class TestRemoteVscodeClientDetection:
+    """Detect running inside a VSCode Remote-SSH session (client is elsewhere)."""
+
+    def test_ipc_and_ssh_present(self):
+        env = {
+            "VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc.sock",
+            "SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22",
+        }
+        assert remote_vscode_client_detected(env) is True
+
+    def test_local_vscode_terminal_not_flagged(self):
+        # VSCode app terminal on this machine: IPC set, but no SSH session.
+        env = {"VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc.sock"}
+        assert remote_vscode_client_detected(env) is False
+
+    def test_plain_ssh_not_flagged(self):
+        # Plain SSH shell with no VSCode: nothing to forward to.
+        env = {"SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22"}
+        assert remote_vscode_client_detected(env) is False
+
+    def test_empty_env(self):
+        assert remote_vscode_client_detected({}) is False
+
+    def test_override_env_var(self):
+        env = {
+            "VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc.sock",
+            "SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22",
+            "BUBBLE_ALLOW_REMOTE_VSCODE": "1",
+        }
+        assert remote_vscode_client_detected(env) is False
+
+
+class TestWarnIfRemoteVscodeClient:
+    """The launch-site guard: block vscode, pass other editors through."""
+
+    @pytest.fixture(autouse=True)
+    def _nested_session(self, monkeypatch):
+        monkeypatch.setenv("VSCODE_IPC_HOOK_CLI", "/tmp/vscode-ipc.sock")
+        monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5 6.7.8.9 22")
+        monkeypatch.delenv("BUBBLE_ALLOW_REMOTE_VSCODE", raising=False)
+
+    def test_blocks_vscode(self, capsys):
+        from bubble.vscode import warn_if_remote_vscode_client
+
+        assert warn_if_remote_vscode_client("vscode", "owner/repo") is True
+        err = capsys.readouterr().err
+        assert "--ssh" in err
+        assert "owner/repo" in err
+
+    @pytest.mark.parametrize("editor", ["shell", "emacs", "neovim"])
+    def test_allows_non_vscode(self, editor):
+        from bubble.vscode import warn_if_remote_vscode_client
+
+        assert warn_if_remote_vscode_client(editor, "owner/repo") is False
+
+    def test_allows_vscode_when_not_nested(self, monkeypatch):
+        from bubble.vscode import warn_if_remote_vscode_client
+
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        assert warn_if_remote_vscode_client("vscode", "owner/repo") is False
 
 
 class TestBubbleNameValidation:

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -37,13 +37,24 @@ class TestRemoteVscodeClientDetection:
     def test_empty_env(self):
         assert remote_vscode_client_detected({}) is False
 
-    def test_override_env_var(self):
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on", " on "])
+    def test_override_truthy_values_bypass(self, val):
         env = {
             "VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc.sock",
             "SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22",
-            "BUBBLE_ALLOW_REMOTE_VSCODE": "1",
+            "BUBBLE_ALLOW_REMOTE_VSCODE": val,
         }
         assert remote_vscode_client_detected(env) is False
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_override_falsey_values_do_not_bypass(self, val):
+        # "0"/"false"/etc. must NOT disable the guard (surprising otherwise).
+        env = {
+            "VSCODE_IPC_HOOK_CLI": "/tmp/vscode-ipc.sock",
+            "SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22",
+            "BUBBLE_ALLOW_REMOTE_VSCODE": val,
+        }
+        assert remote_vscode_client_detected(env) is True
 
 
 class TestWarnIfRemoteVscodeClient:


### PR DESCRIPTION
This PR stops `bubble <target>` from silently failing with "Could not resolve hostname" when it is run from the integrated terminal of a VSCode Remote-SSH session. In that case the `code` CLI forwards to the VSCode on the client machine, which has no SSH alias, ProxyCommand, or trusted key for a container created on this host, so the Remote-SSH connection can neither resolve nor reach it.

It detects the situation (`VSCODE_IPC_HOOK_CLI` together with `SSH_CONNECTION`) at the local editor-launch sites and, instead of launching into that failure, leaves the container running and prints actionable guidance: run bubble from the local machine with `--ssh <thishost>` (the supported flow, which wires up the client side), or use `--shell`/`--emacs`/`--neovim` to work in the current terminal. The detection is scoped tightly so it does not misfire on a local VSCode terminal, a plain SSH shell, or the `--machine-readable` calls the remote orchestration itself makes, and `BUBBLE_ALLOW_REMOTE_VSCODE=1` overrides it for anyone who has wired up the client side by hand.

🤖 Prepared with Claude Code