### PR TITLE
fix: let --no-<x>-credentials opt out under auto/on security

### DIFF
--- a/bubble/security.py
+++ b/bubble/security.py
@@ -224,12 +224,20 @@ def get_github_level(config: dict) -> str:
 def should_include_credentials(requested: bool, config: dict, setting_name: str) -> bool:
     """Resolve whether credentials should be included.
 
-    Locked-off always wins.  Otherwise, include if the resolved requested
-    flag is True or the security setting enables them.
+    ``requested`` is the resolved per-launch preference (CLI flag > per-provider
+    config > default on), so it already carries the intended default. Precedence:
+
+    1. locked off (``security <x>-credentials = off``) always wins -> no credentials
+    2. otherwise honour ``requested`` verbatim
+
+    This makes an explicit opt-out win over an ``auto``/``on`` security setting:
+    ``--no-<x>-credentials`` (or ``[<provider>] credentials = false``) suppresses
+    the mount even though credentials are enabled by default. Only the hard
+    lockdown (``off``) can force credentials off against an explicit request.
     """
     if is_locked_off(config, setting_name):
         return False
-    return requested or is_enabled(config, setting_name)
+    return requested
 
 
 def has_auto_settings(config: dict) -> bool:

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1155,7 +1155,7 @@ class TestCredentialOptOutEndToEnd:
     """`--no-<x>-credentials` suppresses the mount even under default (auto)
     security, exercised end-to-end through `bubble open`."""
 
-    def _capture_vibe_mounts(self, tmp_path, monkeypatch, *cli_args):
+    def _capture_vibe_mounts(self, tmp_path, monkeypatch, *cli_args, config=None):
         from contextlib import ExitStack
         from unittest.mock import patch
 
@@ -1176,8 +1176,8 @@ class TestCredentialOptOutEndToEnd:
             raise SystemExit(0)
 
         with ExitStack() as stack:
-            # Default (auto) security posture: nothing locked off.
-            stack.enter_context(patch("bubble.cli.load_config", return_value={}))
+            # Default posture is auto (nothing locked off) unless config overrides.
+            stack.enter_context(patch("bubble.cli.load_config", return_value=config or {}))
             stack.enter_context(
                 patch("bubble.cli.get_host_git_identity", return_value=("T", "t@t.com"))
             )
@@ -1213,6 +1213,20 @@ class TestCredentialOptOutEndToEnd:
     def test_no_vibe_credentials_suppresses_mount_under_auto(self, tmp_path, monkeypatch):
         mounts = self._capture_vibe_mounts(
             tmp_path, monkeypatch, "--no-vibe-credentials", "kim-em/bubble"
+        )
+        assert mounts == []
+
+    def test_provider_config_opt_out_wins_over_security_on(self, tmp_path, monkeypatch):
+        """`[vibe] credentials = false` suppresses the mount even with
+        security.vibe_credentials = on (the config opt-out wins, not just the flag)."""
+        mounts = self._capture_vibe_mounts(
+            tmp_path,
+            monkeypatch,
+            "kim-em/bubble",
+            config={
+                "security": {"vibe_credentials": "on"},
+                "vibe": {"credentials": False},
+            },
         )
         assert mounts == []
 

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1151,6 +1151,72 @@ class TestVibeConfigProvisioning:
         assert [c for c in disk_calls if "vibe" in c[2]] == []
 
 
+class TestCredentialOptOutEndToEnd:
+    """`--no-<x>-credentials` suppresses the mount even under default (auto)
+    security, exercised end-to-end through `bubble open`."""
+
+    def _capture_vibe_mounts(self, tmp_path, monkeypatch, *cli_args):
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from click.testing import CliRunner
+
+        from bubble.cli import main
+        from bubble.target import Target
+
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        (vibe_dir / "config.toml").write_text("[mistral]\napi_key = 'secret'\n")
+        monkeypatch.setattr("bubble.config.VIBE_CONFIG.base_dir", vibe_dir)
+
+        captured = {}
+
+        def _capture_provision(*args, **kw):
+            captured["vibe_mounts"] = kw.get("vibe_mounts")
+            raise SystemExit(0)
+
+        with ExitStack() as stack:
+            # Default (auto) security posture: nothing locked off.
+            stack.enter_context(patch("bubble.cli.load_config", return_value={}))
+            stack.enter_context(
+                patch("bubble.cli.get_host_git_identity", return_value=("T", "t@t.com"))
+            )
+            rt = stack.enter_context(patch("bubble.cli.get_runtime"))
+            rt.return_value.list_containers.return_value = []
+            stack.enter_context(patch("bubble.cli.find_existing_container", return_value=None))
+            stack.enter_context(patch("bubble.cli.print_warnings"))
+            stack.enter_context(patch("bubble.cli.maybe_rebuild_base_image"))
+            stack.enter_context(patch("bubble.cli.maybe_rebuild_tools"))
+            stack.enter_context(patch("bubble.cli.maybe_rebuild_customize"))
+            stack.enter_context(patch("bubble.cli.maybe_symlink_ai_projects"))
+            stack.enter_context(patch("bubble.cli.RepoRegistry"))
+            target = Target(
+                owner="kim-em", repo="bubble", kind="repo", ref="", original="kim-em/bubble"
+            )
+            stack.enter_context(patch("bubble.cli.parse_target", return_value=target))
+            stack.enter_context(
+                patch("bubble.cli._resolve_ref_source", return_value=("/tmp/fake.git", "fake.git"))
+            )
+            stack.enter_context(
+                patch("bubble.cli.detect_and_build_image", return_value=(None, "img"))
+            )
+            stack.enter_context(patch("bubble.cli.generate_name", return_value="test-bubble"))
+            stack.enter_context(patch("bubble.cli.provision_container", _capture_provision))
+            CliRunner().invoke(main, ["open", *cli_args])
+        return captured.get("vibe_mounts")
+
+    def test_default_mounts_vibe_config(self, tmp_path, monkeypatch):
+        mounts = self._capture_vibe_mounts(tmp_path, monkeypatch, "kim-em/bubble")
+        targets = {m.target for m in (mounts or [])}
+        assert "/home/user/.vibe/config.toml" in targets
+
+    def test_no_vibe_credentials_suppresses_mount_under_auto(self, tmp_path, monkeypatch):
+        mounts = self._capture_vibe_mounts(
+            tmp_path, monkeypatch, "--no-vibe-credentials", "kim-em/bubble"
+        )
+        assert mounts == []
+
+
 class TestMountOverlaps:
     """Test path ancestry overlap detection."""
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -331,6 +331,54 @@ class TestRemoteOpenFlagForwarding:
         assert "--skip-auth-setup" in cmd_str
 
 
+class TestOpenSshResolvesConfigOptOut:
+    """`bubble open --ssh` resolves a local `[provider] credentials = false`
+    opt-out and forwards `--no-<x>-credentials` to the remote (must not leak
+    credentials by omitting the negative flag)."""
+
+    def _capture_remote_open_kwargs(self, config, *cli_args):
+        from contextlib import ExitStack
+
+        from click.testing import CliRunner
+
+        from bubble.cli import main
+
+        captured = {}
+
+        def _fake_open_remote(*args, **kw):
+            captured.update(kw)
+            raise SystemExit(0)
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("bubble.cli.load_config", return_value=config))
+            stack.enter_context(
+                patch("bubble.cli.get_host_git_identity", return_value=("T", "t@t.com"))
+            )
+            stack.enter_context(patch("bubble.cli.print_warnings"))
+            stack.enter_context(patch("bubble.cli._open_remote", _fake_open_remote))
+            CliRunner().invoke(main, ["open", "--ssh", "buildhost", *cli_args])
+        return captured
+
+    def test_vibe_config_opt_out_forwards_false(self):
+        kw = self._capture_remote_open_kwargs(
+            {"vibe": {"credentials": False}},
+            "kim-em/bubble",
+        )
+        assert kw.get("vibe_credentials") is False
+
+    def test_default_forwards_true(self):
+        kw = self._capture_remote_open_kwargs({}, "kim-em/bubble")
+        assert kw.get("vibe_credentials") is True
+
+    def test_cli_flag_opt_out_forwards_false(self):
+        kw = self._capture_remote_open_kwargs(
+            {},
+            "--no-claude-credentials",
+            "kim-em/bubble",
+        )
+        assert kw.get("claude_credentials") is False
+
+
 class TestCreateBundle:
     def test_creates_tarball(self):
         bundle = _create_bundle()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -801,16 +801,20 @@ def test_should_include_credentials_requested_true():
     assert should_include_credentials(True, config, "claude_credentials") is True
 
 
-def test_should_include_credentials_requested_false_security_on():
-    """Security 'on' enables credentials even when the resolved flag is False."""
+def test_should_include_credentials_explicit_opt_out_wins_over_on():
+    """An explicit opt-out (requested=False) wins over security 'on'.
+
+    Only the hard lockdown ('off') can force credentials off against an
+    explicit request; 'on'/'auto' are the default, not a mandate.
+    """
     config = {"security": {"claude_credentials": "on"}}
-    assert should_include_credentials(False, config, "claude_credentials") is True
+    assert should_include_credentials(False, config, "claude_credentials") is False
 
 
-def test_should_include_credentials_requested_false_security_auto():
-    """Auto with auto_default=on behaves like 'on'."""
+def test_should_include_credentials_explicit_opt_out_wins_over_auto():
+    """An explicit opt-out (requested=False) wins over auto (default on)."""
     config = {}  # auto (default)
-    assert should_include_credentials(False, config, "claude_credentials") is True
+    assert should_include_credentials(False, config, "claude_credentials") is False
 
 
 def test_should_include_credentials_requested_true_security_auto():
@@ -818,14 +822,19 @@ def test_should_include_credentials_requested_true_security_auto():
     assert should_include_credentials(True, config, "claude_credentials") is True
 
 
+def test_should_include_credentials_default_on_when_unspecified():
+    """Resolution defaults requested=True, so credentials mount by default."""
+    assert should_include_credentials(True, {}, "claude_credentials") is True
+
+
 def test_should_include_credentials_vibe_locked_off_overrides_true():
     config = {"security": {"vibe_credentials": "off"}}
     assert should_include_credentials(True, config, "vibe_credentials") is False
 
 
-def test_should_include_credentials_vibe_auto_enables():
-    """Vibe credentials behave like Claude/Codex: auto (default) enables them."""
-    assert should_include_credentials(False, {}, "vibe_credentials") is True
+def test_should_include_credentials_vibe_explicit_opt_out_wins_over_auto():
+    """Vibe behaves like Claude/Codex: an explicit opt-out wins over auto."""
+    assert should_include_credentials(False, {}, "vibe_credentials") is False
 
 
 # --- shared_cache overlay tests ---


### PR DESCRIPTION
This PR makes an explicit per-launch credential opt-out win over an `auto`/`on` security setting. Previously `should_include_credentials` OR-ed the resolved request with the security setting, so `--no-claude-credentials` / `--no-codex-credentials` / `--no-vibe-credentials` (and `[<provider>] credentials = false`) were silently ignored whenever `security.<x>-credentials` was `auto` (the default) or `on` — the credential files mounted into the container anyway. The only working off switch was the hard lockdown `bubble security set <x>-credentials off`.

The resolved request already carries the intended default (CLI flag > per-provider config > default on), so this honours it verbatim: locked-off still wins as a hard ceiling, but otherwise an explicit opt-out suppresses the mount. `on` and `auto` now mean "enabled by default", not "force on against an explicit no". Covered by unit tests for the precedence and an end-to-end test that `bubble open --no-vibe-credentials` mounts nothing under default security while the default invocation still mounts `~/.vibe/config.toml`.

🤖 Prepared with Claude Code