### PR TITLE
Share build-fingerprinted Bubble images

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 | `bubble pause <name>` | Freeze a bubble |
 | `bubble pop <name>` | Pop a bubble (delete permanently) |
 | `bubble cleanup` | Pop all clean bubbles (no unsaved work) |
-| `bubble images list\|build\|delete` | Manage base images |
+| `bubble images list\|build\|delete\|prune` | Manage base images |
 | `bubble git update` | Refresh shared git mirrors |
 | `bubble network apply\|remove <name>` | Manage network restrictions |
 | `bubble automation install\|remove\|status` | Manage periodic jobs |
@@ -157,7 +157,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 
 ## Images
 
-Images are built automatically on first use. Any enabled [tools](#tools) are installed in the `base` image and inherited by all derived images.
+Images are built automatically on first use. Any enabled [tools](#tools) are installed in the `base` image and inherited by all derived images. Physical Incus aliases are keyed by the complete trusted build recipe (parent, scripts, tools, customization, editor commit, and toolchain), so isolated `BUBBLE_HOME` stores reuse an identical host image without allowing one configuration to replace another's image.
 
 | Image | Contents |
 |-------|----------|
@@ -167,6 +167,8 @@ Images are built automatically on first use. Any enabled [tools](#tools) are ins
 | `lean-v4.X.Y` | lean + specific toolchain pre-installed (built lazily on demand) |
 
 `base`, `lean`, and `python` are static images you can rebuild with `bubble images build <name>`. Versioned `lean-v4.X.Y` images are built automatically in the background when a project uses a stable/RC toolchain not yet cached — the current bubble proceeds immediately with elan downloading the toolchain on demand, and the next bubble for that version starts instantly.
+
+Recipe changes select a new image variant rather than deleting existing derived images. Legacy mutable aliases are left untouched during migration. `bubble images list` shows Bubble's logical and physical names; `bubble images prune --older-than 30` previews removable old variants, and `--execute` performs the deletion while retaining current, newest, and in-use variants.
 
 When VS Code is the configured editor and elan is installed, the base image also includes pre-baked VS Code Lean 4 extensions and an auto-cache extension. For mathlib or mathlib-dependent projects, a VS Code terminal automatically runs `lake exe cache get` when the workspace opens.
 
@@ -178,6 +180,8 @@ Set `BUBBLE_HOME` to override the data directory (default: `~/.bubble`):
 ```bash
 export BUBBLE_HOME=/data/bubble
 ```
+
+This isolates configuration and per-bubble state. Incus images, host daemons, and their coordination locks remain host-global and are safely shared by build identity.
 
 ```toml
 [runtime]

--- a/bubble/automation.py
+++ b/bubble/automation.py
@@ -106,7 +106,7 @@ _LAUNCHD_JOBS = {
         "log": "/tmp/bubble-git-update.log",
     },
     "com.bubble.image-refresh": {
-        "args": ["images", "build", "base"],
+        "args": ["images", "build", "base", "--force"],
         "extra": {
             "StartCalendarInterval": {"Hour": 3, "Weekday": 0},
             "RunAtLoad": False,
@@ -290,7 +290,7 @@ def _install_systemd() -> list[str]:
 
         [Service]
         Type=oneshot
-        ExecStart={bubble} images build base
+        ExecStart={bubble} images build base --force
         {_systemd_path_env()}
     """)
     )

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -68,6 +68,12 @@ from .vscode import (
     warn_if_remote_vscode_client,
 )
 
+__all__ = [
+    "maybe_rebuild_base_image",
+    "maybe_rebuild_customize",
+    "maybe_rebuild_tools",
+]
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -1184,11 +1190,6 @@ def _open_single(
 
     # Local flow
     runtime = get_runtime(config)
-
-    if not machine_readable:
-        maybe_rebuild_base_image()
-        maybe_rebuild_tools(runtime, notices=notices)
-        maybe_rebuild_customize(notices=notices)
 
     # Check if target matches an existing container
     existing = find_existing_container(runtime, target)

--- a/bubble/commands/images.py
+++ b/bubble/commands/images.py
@@ -1,57 +1,13 @@
 """The 'images' command group: list, build, delete."""
 
+import re
 import sys
+from datetime import datetime, timedelta, timezone
 
 import click
 
 from ..config import load_config
 from ..setup import get_runtime
-
-
-def _base_still_needs_rebuild(config: dict):
-    """Return a callback that checks whether any drift marker is still stale.
-
-    Used as ``still_needed`` for ``build_image(..., force=True)`` so that a
-    concurrent rebuild that already updated the markers prevents a redundant
-    second rebuild.
-    """
-    from ..images.builder import (
-        CUSTOMIZE_HASH_FILE,
-        TOOLS_HASH_FILE,
-        VSCODE_COMMIT_FILE,
-        customize_hash,
-        get_vscode_commit,
-    )
-    from ..tools import resolve_tools, tools_hash
-
-    enabled = resolve_tools(config)
-    current_tools_hash = tools_hash(enabled)
-    current_vscode_commit = get_vscode_commit() if "vscode" in enabled else None
-    current_customize_hash = customize_hash()
-
-    def _check() -> bool:
-        # Tools hash drift?
-        if TOOLS_HASH_FILE.exists():
-            if TOOLS_HASH_FILE.read_text().strip() != current_tools_hash:
-                return True
-        else:
-            return True  # never built
-        # VS Code commit drift?
-        if current_vscode_commit:
-            if not VSCODE_COMMIT_FILE.exists():
-                return True
-            if VSCODE_COMMIT_FILE.read_text().strip() != current_vscode_commit:
-                return True
-        # Customize script drift?
-        if current_customize_hash is not None or CUSTOMIZE_HASH_FILE.exists():
-            stored = (
-                CUSTOMIZE_HASH_FILE.read_text().strip() if CUSTOMIZE_HASH_FILE.exists() else None
-            )
-            if current_customize_hash != stored:
-                return True
-        return False
-
-    return _check
 
 
 def register_images_commands(main):
@@ -71,13 +27,14 @@ def register_images_commands(main):
             if not images:
                 click.echo("No images. Run: bubble images build base")
                 return
-            click.echo(f"{'ALIAS':<25} {'SIZE':<12} {'CREATED':<20}")
-            click.echo("-" * 57)
+            click.echo(f"{'LOGICAL':<20} {'ALIAS':<42} {'SIZE':<12} {'CREATED':<20}")
+            click.echo("-" * 98)
             for img in images:
                 aliases = ", ".join(a["name"] for a in img.get("aliases", []))
+                logical = (img.get("properties") or {}).get("user.bubble.logical_name", "-")
                 size_mb = img.get("size", 0) / (1024 * 1024)
                 created = img.get("created_at", "")[:19]
-                click.echo(f"{aliases:<25} {size_mb:>8.1f} MB  {created:<20}")
+                click.echo(f"{logical:<20} {aliases:<42} {size_mb:>8.1f} MB  {created:<20}")
         except Exception as e:
             click.echo(f"Error listing images: {e}", err=True)
 
@@ -106,12 +63,8 @@ def register_images_commands(main):
         else:
             from ..images.builder import build_image
 
-            still_needed = None
-            if force and image_name == "base":
-                still_needed = _base_still_needs_rebuild(config)
-
             try:
-                build_image(runtime, image_name, force=force, still_needed=still_needed)
+                build_image(runtime, image_name, force=force)
             except ValueError as e:
                 click.echo(str(e), err=True)
                 sys.exit(1)
@@ -136,8 +89,35 @@ def register_images_commands(main):
             sys.exit(1)
         # Try alias first, then fingerprint prefix
         if not runtime.image_exists(image_name):
+            # Logical managed name: prefer the variant desired by the current
+            # recipe, then accept an unambiguous older managed variant.
+            from ..images.builder import desired_image_alias
+
+            try:
+                desired = desired_image_alias(runtime, image_name)
+            except ValueError:
+                desired = ""
+            if desired and runtime.image_exists(desired):
+                runtime.image_delete(desired)
+                click.echo(f"Deleted image '{image_name}' ({desired}).")
+                return
             # Check if it matches a fingerprint prefix
             images = runtime.list_images()
+            logical_matches = [
+                img
+                for img in images
+                if (img.get("properties") or {}).get("user.bubble.logical_name") == image_name
+            ]
+            if len(logical_matches) == 1:
+                runtime.image_delete(logical_matches[0]["fingerprint"])
+                click.echo(f"Deleted image '{image_name}'.")
+                return
+            if len(logical_matches) > 1:
+                click.echo(
+                    f"Multiple variants exist for '{image_name}'; delete a physical alias instead.",
+                    err=True,
+                )
+                sys.exit(1)
             matches = [img for img in images if img.get("fingerprint", "").startswith(image_name)]
             if len(matches) == 1:
                 fp = matches[0]["fingerprint"]
@@ -155,3 +135,85 @@ def register_images_commands(main):
                 sys.exit(1)
         runtime.image_delete(image_name)
         click.echo(f"Deleted image '{image_name}'.")
+
+    @images_group.command("prune")
+    @click.option("--older-than", type=click.IntRange(min=0), default=30, show_default=True)
+    @click.option("--execute", is_flag=True, help="Actually delete the selected stale images.")
+    def images_prune(older_than, execute):
+        """Find stale build-keyed Bubble images; dry-run unless --execute is supplied."""
+        config = load_config()
+        runtime = get_runtime(config, ensure_ready=False)
+        cutoff = datetime.now(timezone.utc) - timedelta(days=older_than)
+        managed = []
+        for img in runtime.list_images():
+            props = dict(img.get("properties") or {})
+            is_managed = props.get("user.bubble.managed") == "true"
+            aliases = [a.get("name", "") for a in img.get("aliases", [])]
+            legacy = next(
+                (
+                    alias
+                    for alias in aliases
+                    if alias in ("base", "lean", "python")
+                    or re.fullmatch(r"lean-v\d+(?:[.-][A-Za-z0-9]+)*", alias)
+                ),
+                "",
+            )
+            if not is_managed and not legacy:
+                continue
+            if legacy:
+                props["user.bubble.logical_name"] = legacy
+                props["user.bubble.legacy"] = "true"
+            raw_created = img.get("created_at") or ""
+            try:
+                created = datetime.fromisoformat(raw_created.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            managed.append((img, props, created))
+
+        newest: dict[str, str] = {}
+        for img, props, created in managed:
+            if props.get("user.bubble.legacy") == "true":
+                continue
+            logical = props.get("user.bubble.logical_name", "")
+            current = newest.get(logical)
+            if current is None:
+                newest[logical] = img.get("fingerprint", "")
+                continue
+            current_created = next(c for i, _p, c in managed if i.get("fingerprint", "") == current)
+            if created > current_created:
+                newest[logical] = img.get("fingerprint", "")
+
+        in_use = {c.image for c in runtime.list_containers() if c.image}
+        desired_aliases = set()
+        from ..images.builder import desired_image_alias
+
+        for _img, props, _created in managed:
+            logical = props.get("user.bubble.logical_name", "")
+            if not logical or props.get("user.bubble.legacy") == "true":
+                continue
+            try:
+                desired_aliases.add(desired_image_alias(runtime, logical))
+            except ValueError:
+                pass
+        selected = []
+        for img, props, created in managed:
+            fp = img.get("fingerprint", "")
+            if not fp or created >= cutoff or fp in in_use:
+                continue
+            aliases = {a.get("name", "") for a in img.get("aliases", [])}
+            if aliases & desired_aliases:
+                continue
+            if newest.get(props.get("user.bubble.logical_name", "")) == fp:
+                continue
+            selected.append((img, props))
+
+        if not selected:
+            click.echo("No stale Bubble images to prune.")
+            return
+        for img, props in selected:
+            aliases = ", ".join(a["name"] for a in img.get("aliases", []))
+            click.echo(f"{'Deleting' if execute else 'Would delete'} {aliases}")
+            if execute:
+                runtime.image_delete(img["fingerprint"])
+        if not execute:
+            click.echo("Dry run only; rerun with --execute to delete them.")

--- a/bubble/image_management.py
+++ b/bubble/image_management.py
@@ -6,9 +6,8 @@ import sys
 
 import click
 
-from .config import load_config
 from .hooks import select_hook
-from .images.builder import VSCODE_COMMIT_FILE, get_vscode_commit, is_build_locked
+from .images.builder import desired_image_alias, is_build_locked
 from .output import detail, step
 from .runtime.base import ContainerRuntime
 
@@ -36,98 +35,15 @@ def _spawn_background_bubble(args: list[str], log_path: str):
 
 
 def maybe_rebuild_base_image():
-    """If VS Code has updated since the base image was built, rebuild in background.
-
-    Only triggers when vscode is an enabled tool — otherwise there's nothing
-    to rebuild even if the host has `code` installed.
-    """
-    from .config import load_config
-    from .tools import resolve_tools
-
-    config = load_config()
-    if "vscode" not in resolve_tools(config):
-        return
-    commit = get_vscode_commit()
-    if not commit:
-        return
-    if VSCODE_COMMIT_FILE.exists() and VSCODE_COMMIT_FILE.read_text().strip() == commit:
-        return
-    if is_build_locked("base"):
-        return
-    _spawn_background_bubble(
-        ["images", "build", "base", "--force"],
-        "/tmp/bubble-vscode-rebuild.log",
-    )
+    """Compatibility no-op; build-key selection happens after target detection."""
 
 
 def maybe_rebuild_tools(runtime: ContainerRuntime, notices=None):
-    """If the resolved tool set has changed since base was built, rebuild base now.
-
-    Rebuilds synchronously so that the container launched afterwards uses a
-    fresh image with the correct tools baked in. The rebuild also purges
-    derived images (lean, etc.) so they get rebuilt on next use.
-    """
-    from .images.builder import TOOLS_HASH_FILE, build_image
-    from .tools import resolve_tools, tools_hash
-
-    config = load_config()
-    enabled = resolve_tools(config)
-    current_hash = tools_hash(enabled)
-
-    if TOOLS_HASH_FILE.exists() and TOOLS_HASH_FILE.read_text().strip() == current_hash:
-        return
-
-    def _tools_still_stale():
-        return not (
-            TOOLS_HASH_FILE.exists() and TOOLS_HASH_FILE.read_text().strip() == current_hash
-        )
-
-    if notices:
-        notices.begin()
-    step("Base image configuration changed, rebuilding base image...")
-    build_image(runtime, "base", force=True, still_needed=_tools_still_stale, quiet=True)
+    """Compatibility no-op; the selected image is ensured by detection."""
 
 
 def maybe_rebuild_customize(notices=None):
-    """If the user customization script has changed, trigger a background rebuild of all images.
-
-    Compares the current hash of ~/.bubble/customize.sh against the stored
-    hash from the last build. If different (or script was added/removed),
-    triggers a background base image rebuild. Derived images are purged
-    during the rebuild so they pick up the changes on next use.
-    """
-    from .images.builder import CUSTOMIZE_HASH_FILE, customize_hash
-
-    current = customize_hash()
-
-    if CUSTOMIZE_HASH_FILE.exists():
-        stored = CUSTOMIZE_HASH_FILE.read_text().strip()
-    else:
-        stored = None
-
-    # No script and no previous hash — nothing to do
-    if current is None and stored is None:
-        return
-    # Hash matches — nothing to do
-    if current == stored:
-        return
-
-    if is_build_locked("base"):
-        return
-
-    if notices:
-        notices.begin()
-    if current is None:
-        step("Customization script removed, rebuilding base image in background...")
-    elif stored is None:
-        step("Customization script detected, rebuilding base image in background...")
-    else:
-        step("Customization script changed, rebuilding base image in background...")
-
-    _spawn_background_bubble(
-        ["images", "build", "base", "--force"],
-        "/tmp/bubble-customize-rebuild.log",
-    )
+    """Compatibility no-op; customization contents are part of the build key."""
 
 
 def detect_and_build_image(runtime, ref_path, t, restricted_network: bool = True):
@@ -155,8 +71,10 @@ def detect_and_build_image(runtime, ref_path, t, restricted_network: bool = True
         image_name = "base"
 
     pending_toolchain_build = None
-    is_toolchain_image = image_name.startswith("lean-v")
-    if not runtime.image_exists(image_name):
+    logical_image_name = image_name
+    is_toolchain_image = logical_image_name.startswith("lean-v")
+    physical_image_name = desired_image_alias(runtime, logical_image_name)
+    if not runtime.image_exists(physical_image_name):
         if is_toolchain_image:
             version = image_name[len("lean-") :]
             if restricted_network:
@@ -170,7 +88,9 @@ def detect_and_build_image(runtime, ref_path, t, restricted_network: bool = True
                 from .images.builder import build_lean_toolchain_image
 
                 try:
-                    build_lean_toolchain_image(runtime, version)
+                    built_alias = build_lean_toolchain_image(runtime, version)
+                    if isinstance(built_alias, str):
+                        physical_image_name = built_alias
                     detail(f"{image_name} image ready.")
                 except Exception as e:
                     # Fail fast: falling back to the plain `lean` image here
@@ -193,30 +113,30 @@ def detect_and_build_image(runtime, ref_path, t, restricted_network: bool = True
                     f" (building {image_name} in background for next time)"
                 )
                 pending_toolchain_build = version
-                image_name = "lean"
-        if not runtime.image_exists(image_name):
-            step(f"Building {image_name} image (one-time setup, may take a few minutes)...")
+                logical_image_name = "lean"
+                physical_image_name = desired_image_alias(runtime, logical_image_name)
+        if not is_toolchain_image and not runtime.image_exists(physical_image_name):
+            step(f"Building {logical_image_name} image (one-time setup, may take a few minutes)...")
             from .images.builder import build_image
 
-            build_image(runtime, image_name, quiet=True)
-            detail(f"{image_name} image ready.")
+            physical_image_name = build_image(runtime, logical_image_name, quiet=True)
+            detail(f"{logical_image_name} image ready.")
     elif is_toolchain_image:
         version = image_name[len("lean-") :]
         detail(f"Using cached toolchain image ({version})")
 
     if pending_toolchain_build:
-        _background_build_lean_toolchain(pending_toolchain_build)
+        _background_build_lean_toolchain(runtime, pending_toolchain_build)
 
-    return hook, image_name
+    return hook, physical_image_name
 
 
-def _background_build_lean_toolchain(version: str):
+def _background_build_lean_toolchain(runtime: ContainerRuntime, version: str):
     """Fire off a background build of a toolchain-specific Lean image."""
     image_alias = f"lean-{version}"
-    # Incus container names only allow alphanumeric + hyphens
-    safe_alias = image_alias.replace(".", "-")
+    physical_alias = desired_image_alias(runtime, image_alias)
     # Skip if a build is already in progress (avoid spawning redundant processes)
-    if is_build_locked(safe_alias):
+    if is_build_locked(runtime.qualify(physical_alias)):
         return
     detail(f"Building {image_alias} image in background for next time...")
     _spawn_background_bubble(

--- a/bubble/images/builder.py
+++ b/bubble/images/builder.py
@@ -10,26 +10,21 @@ import subprocess
 import time
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-from ..config import DATA_DIR, load_config
+from ..config import DATA_DIR, HOST_DATA_DIR, load_config
 from ..lean import LEAN_VERSION_RE
 from ..runtime.base import ContainerRuntime
 from ..tools import resolve_tools, tool_script, tools_hash
 
 PROGRESS_PREFIX = "BUBBLE_PROGRESS: "
 
-VSCODE_COMMIT_FILE = DATA_DIR / "vscode-commit"
-TOOLS_HASH_FILE = DATA_DIR / "tools-hash"
 CUSTOMIZE_SCRIPT = DATA_DIR / "customize.sh"
-CUSTOMIZE_HASH_FILE = DATA_DIR / "customize-hash"
 
 SCRIPTS_DIR = Path(__file__).parent / "scripts"
 
-BUILD_LOCK_DIR = Path("/tmp/bubble-build-locks")
+BUILD_LOCK_DIR = HOST_DATA_DIR / "locks" / "images"
+IMAGE_BUILD_SCHEMA = "1"
+BASE_PARENT_REVISION = "ubuntu-24.04-2026-07"
 
 
 @contextmanager
@@ -263,6 +258,8 @@ def is_builder_container(name: str) -> bool:
     """
     if not name.endswith("-builder"):
         return False
+    if re.fullmatch(r"bubble-[a-z0-9-]+-[0-9a-f]{16}-builder", name):
+        return True
     prefix = name[: -len("-builder")]
     # Known static image builders (e.g. "base-builder", "lean-builder")
     if prefix in IMAGES:
@@ -306,82 +303,6 @@ def _ancestor_chain(image_name: str) -> list[str]:
     return ancestors
 
 
-def _collect_derived_images(base_name: str) -> list[str]:
-    """Collect all images in IMAGES that transitively derive from base_name."""
-    result = []
-    direct = [name for name, spec in IMAGES.items() if spec["parent"] == base_name]
-    for name in direct:
-        result.append(name)
-        result.extend(_collect_derived_images(name))
-    return result
-
-
-def _is_toolchain_alias(alias: str, purged_names: set[str]) -> bool:
-    """Check if an alias is a dynamic toolchain image derived from a purged lean image.
-
-    Toolchain aliases follow the pattern: <base>-v<digits>... where <base> is
-    a purged lean-family image. We require a digit after 'v' to avoid false
-    matches on unrelated images.
-    """
-    for name in purged_names:
-        if name == "lean":
-            prefix = "lean-v"
-        elif name.startswith("lean-"):
-            prefix = f"{name}-v"
-        else:
-            continue
-        if alias.startswith(prefix) and len(alias) > len(prefix) and alias[len(prefix)].isdigit():
-            return True
-    return False
-
-
-def _collect_dynamic_toolchain_aliases(
-    runtime: ContainerRuntime, purged_names: set[str]
-) -> list[str]:
-    """Find dynamic toolchain image aliases that derive from purged lean images.
-
-    Dynamic toolchain images (e.g. lean-v4.16.0, lean-emacs-v4.16.0) are not
-    in IMAGES and must be discovered by scanning existing image aliases.
-    """
-    # Only look for toolchain images if a lean-family image is being purged
-    if not any(n == "lean" or n.startswith("lean-") for n in purged_names):
-        return []
-
-    aliases = []
-    try:
-        for img in runtime.list_images():
-            for alias_entry in img.get("aliases", []):
-                alias = alias_entry["name"]
-                if _is_toolchain_alias(alias, purged_names):
-                    aliases.append(alias)
-    except Exception:
-        pass
-    return aliases
-
-
-def _purge_derived_images(runtime: ContainerRuntime, base_name: str):
-    """Delete images that derive from base_name so they rebuild from the fresh base.
-
-    When the base image is rebuilt (e.g. with new tools), derived images like
-    lean are stale snapshots. Deleting them forces a rebuild on next use.
-
-    Walks the full dependency tree (not just direct children) and also purges
-    dynamic toolchain images (lean-v4.x.y, etc.).
-    """
-    static_derived = _collect_derived_images(base_name)
-
-    # Also find dynamic toolchain images that derive from purged lean images
-    dynamic_aliases = _collect_dynamic_toolchain_aliases(runtime, set(static_derived))
-
-    for name in static_derived + dynamic_aliases:
-        if runtime.image_exists(name):
-            try:
-                runtime.image_delete(name)
-                print(f"  Deleted derived image '{name}' (will rebuild on next use).")
-            except Exception:
-                pass  # Best-effort; may fail if in use
-
-
 def _install_tools_if_base(
     runtime: ContainerRuntime, build_name: str, image_name: str
 ) -> list[str] | None:
@@ -417,6 +338,71 @@ def customize_hash() -> str | None:
     return hashlib.sha256(CUSTOMIZE_SCRIPT.read_bytes()).hexdigest()[:16]
 
 
+def _hash_parts(*parts: str) -> str:
+    digest = hashlib.sha256()
+    for part in parts:
+        encoded = part.encode()
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return digest.hexdigest()[:16]
+
+
+def image_build_key(runtime: ContainerRuntime, image_name: str) -> str:
+    """Return the deterministic build key for a logical Bubble image."""
+    if image_name.startswith("lean-v"):
+        version = image_name.removeprefix("lean-")
+        if not LEAN_VERSION_RE.fullmatch(version):
+            raise ValueError(f"Invalid Lean toolchain version: {version!r}")
+        parent_alias = desired_image_alias(runtime, "lean")
+        return _hash_parts(
+            IMAGE_BUILD_SCHEMA,
+            image_name,
+            parent_alias,
+            (SCRIPTS_DIR / "lean-toolchain.sh").read_text(),
+            customize_hash() or "",
+        )
+
+    if image_name not in IMAGES:
+        available = ", ".join(IMAGES)
+        raise ValueError(f"Unknown image: {image_name}. Available: {available}")
+    spec = IMAGES[image_name]
+    parent = spec["parent"]
+    parent_identity = desired_image_alias(runtime, parent) if parent in IMAGES else parent
+    extra = ""
+    if image_name == "base":
+        parent_identity += f":{BASE_PARENT_REVISION}"
+        config = load_config()
+        enabled = resolve_tools(config)
+        extra = tools_hash(enabled)
+        if "vscode" in enabled:
+            extra += ":" + (get_vscode_commit() or "unavailable")
+    return _hash_parts(
+        IMAGE_BUILD_SCHEMA,
+        image_name,
+        parent_identity,
+        (SCRIPTS_DIR / spec["script"]).read_text(),
+        customize_hash() or "",
+        extra,
+    )
+
+
+def desired_image_alias(runtime: ContainerRuntime, image_name: str) -> str:
+    """Map a logical image name to its host-global build-keyed alias."""
+    key = image_build_key(runtime, image_name)
+    safe = image_name.replace(".", "-")
+    return f"bubble-{safe}-{key}"
+
+
+def _image_properties(logical_name: str, build_key: str, parent: str) -> dict[str, str]:
+    return {
+        "user.bubble.managed": "true",
+        "user.bubble.logical_name": logical_name,
+        "user.bubble.build_key": build_key,
+        "user.bubble.build_schema": IMAGE_BUILD_SCHEMA,
+        "user.bubble.parent": parent,
+    }
+
+
 def _run_customize_script(runtime: ContainerRuntime, build_name: str):
     """Run the user customization script (~/.bubble/customize.sh) if it exists.
 
@@ -435,7 +421,6 @@ def build_image(
     image_name: str,
     *,
     force: bool = False,
-    still_needed: "Callable[[], bool] | None" = None,
     quiet: bool = False,
 ):
     """Build any known image by name. Builds parent images recursively if needed.
@@ -443,10 +428,6 @@ def build_image(
     With ``force=True``, deletes the existing image first so it gets rebuilt
     from scratch. Used by rebuild paths that detect configuration drift
     (tools hash, VS Code commit, customize script).
-
-    ``still_needed`` is an optional callback re-checked after acquiring the
-    build lock.  If it returns False, the rebuild is skipped — a concurrent
-    process already rebuilt and updated the drift markers.
 
     ``quiet`` suppresses the initial "Building X image..." announcement.
     Use when the caller already printed its own progress message.
@@ -456,41 +437,37 @@ def build_image(
         raise ValueError(f"Unknown image: {image_name}. Available: {available}")
 
     spec = IMAGES[image_name]
-    parent = spec["parent"]
+    logical_parent = spec["parent"]
 
     # Ensure parent image exists (recursive for our own images)
-    if parent in IMAGES and not runtime.image_exists(parent):
-        build_image(runtime, parent)
+    if logical_parent in IMAGES:
+        parent = desired_image_alias(runtime, logical_parent)
+        if not runtime.image_exists(parent):
+            build_image(runtime, logical_parent)
+    else:
+        parent = logical_parent
 
-    # Acquire shared locks on ALL ancestors (root-first to avoid deadlock)
-    # to prevent any ancestor from being rebuilt while we build from it.
-    # This fixes the race where a concurrent ancestor rebuild could either:
-    #   (a) produce a derived image built from a stale ancestor, or
-    #   (b) purge the derived image we just published.
-    # Multiple derived builds can proceed concurrently (shared locks coexist),
-    # but an ancestor rebuild (exclusive lock) waits for them all to finish.
-    #
-    # Then acquire an exclusive lock on this image to prevent concurrent
-    # builds of the same image.
+    alias = desired_image_alias(runtime, image_name)
+    build_key = alias.rsplit("-", 1)[-1]
+
+    # Immutable parents do not need shared ancestor locks.  The physical
+    # alias lock is enough to collapse identical builds while allowing
+    # different configurations to build in parallel.
     with ExitStack() as stack:
         for ancestor in _ancestor_chain(image_name):
-            stack.enter_context(_build_lock(ancestor, shared=True))
-        stack.enter_context(_build_lock(image_name))
-
-        if force and runtime.image_exists(image_name):
-            # Re-check drift after acquiring the lock — a concurrent process
-            # may have already rebuilt and updated the marker files.
-            if still_needed is not None and not still_needed():
-                print(f"{image_name} image already rebuilt by concurrent process.")
-                return
+            stack.enter_context(
+                _build_lock(runtime.qualify(desired_image_alias(runtime, ancestor)), shared=True)
+            )
+        stack.enter_context(_build_lock(runtime.qualify(alias)))
+        if force and runtime.image_exists(alias):
             print(f"Deleting existing {image_name} image for rebuild...")
-            runtime.image_delete(image_name)
+            runtime.image_delete(alias)
 
-        if runtime.image_exists(image_name):
+        if runtime.image_exists(alias):
             print(f"{image_name} image already built (by concurrent process).")
-            return
+            return alias
 
-        build_name = f"{image_name}-builder"
+        build_name = f"{alias.replace('.', '-')}-builder"
         if not quiet:
             print(f"Building {image_name} image...")
 
@@ -512,43 +489,26 @@ def build_image(
             runtime.exec_streaming(build_name, ["bash", "-c", script], on_line=_on_progress)
 
             # Install configured tools (only on base image — derived images inherit them)
-            enabled_tools = _install_tools_if_base(runtime, build_name, image_name)
+            _install_tools_if_base(runtime, build_name, image_name)
 
             # Run user customization script as the final build step
             _run_customize_script(runtime, build_name)
 
             # Publish as image
             runtime.stop(build_name)
-            runtime.publish(build_name, image_name)
+            runtime.publish(
+                build_name,
+                alias,
+                properties=_image_properties(image_name, build_key, parent),
+            )
         finally:
             try:
                 runtime.delete(build_name, force=True)
             except Exception:
                 pass
 
-        # Record the VS Code commit hash baked into the image (when vscode is a tool)
-        if enabled_tools and "vscode" in enabled_tools:
-            vc = get_vscode_commit()
-            if vc:
-                VSCODE_COMMIT_FILE.parent.mkdir(parents=True, exist_ok=True)
-                VSCODE_COMMIT_FILE.write_text(vc + "\n")
-
-        # Record the tools hash baked into the image and purge stale derived images
-        if enabled_tools is not None:
-            TOOLS_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
-            TOOLS_HASH_FILE.write_text(tools_hash(enabled_tools) + "\n")
-            _purge_derived_images(runtime, image_name)
-
-        # Record the customize script hash (only on base — derived images inherit it)
-        if image_name == "base":
-            c_hash = customize_hash()
-            if c_hash:
-                CUSTOMIZE_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
-                CUSTOMIZE_HASH_FILE.write_text(c_hash + "\n")
-            else:
-                CUSTOMIZE_HASH_FILE.unlink(missing_ok=True)
-
         print(f"{image_name} image built successfully.")
+        return alias
 
 
 def build_lean_toolchain_image(
@@ -566,67 +526,42 @@ def build_lean_toolchain_image(
     if not LEAN_VERSION_RE.fullmatch(version):
         raise ValueError(f"Invalid Lean toolchain version: {version!r}")
 
-    # If the requested base lean image is unknown and absent, fall back to the
-    # plain `lean` image (which we know how to rebuild from scratch).
-    if base_lean_image not in IMAGES and not runtime.image_exists(base_lean_image):
+    if base_lean_image in IMAGES:
+        parent = desired_image_alias(runtime, base_lean_image)
+        if not runtime.image_exists(parent):
+            parent = build_image(runtime, base_lean_image, quiet=True)
+    elif runtime.image_exists(base_lean_image):
+        parent = base_lean_image
+    else:
         base_lean_image = "lean"
+        parent = desired_image_alias(runtime, base_lean_image)
+        if not runtime.image_exists(parent):
+            parent = build_image(runtime, base_lean_image, quiet=True)
 
-    alias = f"lean-{version}"
-    # Incus container names only allow alphanumeric + hyphens
-    safe_alias = alias.replace(".", "-")
-    build_name = f"{safe_alias}-builder"
+    logical_name = f"lean-{version}"
+    alias = desired_image_alias(runtime, logical_name)
+    build_key = alias.rsplit("-", 1)[-1]
+    build_name = f"{alias}-builder"
 
-    # Acquire shared locks on the base lean image AND all its ancestors
-    # (root-first to avoid deadlock), preventing any ancestor rebuild
-    # from racing with this toolchain build.
     with ExitStack() as stack:
         if base_lean_image in IMAGES:
-            ancestors = _ancestor_chain(base_lean_image)
-            # Build any missing managed ancestors (e.g. "base") *before* taking
-            # their shared locks. build_image() acquires its own exclusive lock
-            # per image, so building an ancestor while we already hold its shared
-            # lock would self-deadlock (flock conflicts across fds, even within
-            # one process). After this, the shared-lock acquisitions below wait
-            # out any in-flight rebuild, leaving every ancestor present.
-            for ancestor in ancestors:
-                if not runtime.image_exists(ancestor):
-                    build_image(runtime, ancestor, quiet=True)
-            # Hold shared locks on the ancestors (root-first to avoid deadlock)
-            # for the rest of the build.
-            for ancestor in ancestors:
-                stack.enter_context(_build_lock(ancestor, shared=True))
-
-        # Ensure the base lean image itself exists, now that its ancestors are
-        # present and locked. Building it here, *while holding the ancestor
-        # locks*, closes the race in issue #314: a concurrent base rebuild purges
-        # `lean` right after rebuilding `base`, so if we built `lean` unlocked
-        # and then launched from it, the rebuild could delete `lean` in between
-        # and the launch would fail with `Image "lean" not found`. The ancestor
-        # locks block that rebuild until this toolchain build completes. The
-        # ancestors already exist, so build_image() won't recurse into them and
-        # only needs an exclusive lock on `base_lean_image` (which we don't yet
-        # hold) — no self-deadlock.
-        if base_lean_image in IMAGES and not runtime.image_exists(base_lean_image):
-            build_image(runtime, base_lean_image, quiet=True)
-
-        # Then the base lean image itself
-        stack.enter_context(_build_lock(base_lean_image, shared=True))
-        stack.enter_context(_build_lock(safe_alias))
-
+            for ancestor in [*_ancestor_chain(base_lean_image), base_lean_image]:
+                stack.enter_context(
+                    _build_lock(
+                        runtime.qualify(desired_image_alias(runtime, ancestor)), shared=True
+                    )
+                )
+        stack.enter_context(_build_lock(runtime.qualify(alias)))
         if force and runtime.image_exists(alias):
-            print(f"Deleting existing {alias} image for rebuild...")
+            print(f"Deleting existing {logical_name} image for rebuild...")
             runtime.image_delete(alias)
-
         if runtime.image_exists(alias):
-            print(f"{alias} image already built (by concurrent process).")
-            return
+            print(f"{logical_name} image already built (by concurrent process).")
+            return alias
 
-        print(f"Building {alias} image...")
-
-        # Clean up any leftover builder from a previous failed attempt
+        print(f"Building {logical_name} image...")
         _cleanup_builder(runtime, build_name)
-
-        runtime.launch(build_name, base_lean_image)
+        runtime.launch(build_name, parent)
         try:
             wait_for_container(runtime, build_name)
 
@@ -643,13 +578,16 @@ def build_lean_toolchain_image(
             _run_customize_script(runtime, build_name)
 
             runtime.stop(build_name)
-            if runtime.image_exists(alias):
-                runtime.image_delete(alias)
-            runtime.publish(build_name, alias)
+            runtime.publish(
+                build_name,
+                alias,
+                properties=_image_properties(logical_name, build_key, parent),
+            )
         finally:
             try:
                 runtime.delete(build_name, force=True)
             except Exception:
                 pass
 
-    print(f"{alias} image built successfully.")
+    print(f"{logical_name} image built successfully.")
+    return alias

--- a/bubble/runtime/base.py
+++ b/bubble/runtime/base.py
@@ -90,7 +90,7 @@ class ContainerRuntime(ABC):
         """Mount a host path into the container."""
 
     @abstractmethod
-    def publish(self, name: str, alias: str):
+    def publish(self, name: str, alias: str, *, properties: dict[str, str] | None = None):
         """Publish a container as a reusable image."""
 
     @abstractmethod

--- a/bubble/runtime/incus.py
+++ b/bubble/runtime/incus.py
@@ -191,6 +191,7 @@ class IncusRuntime(ContainerRuntime):
             name=c["name"],
             state=state_map.get(c["status"], c["status"].lower()),
             ipv4=ipv4,
+            image=(c.get("config") or {}).get("volatile.base_image"),
             disk_usage=disk_usage,
             created_at=_parse_ts("created_at"),
             last_used_at=_parse_ts("last_used_at"),
@@ -322,7 +323,7 @@ class IncusRuntime(ContainerRuntime):
             props["readonly"] = "true"
         self.add_device(name, device_name, "disk", **props)
 
-    def publish(self, name: str, alias: str):
+    def publish(self, name: str, alias: str, *, properties: dict[str, str] | None = None):
         # Stop first if running
         try:
             info = self._get_info(name)
@@ -345,6 +346,9 @@ class IncusRuntime(ContainerRuntime):
             args.append(self._q(""))  # e.g. "bubble-colima:" — target remote
         args += ["--alias", alias]
         self._run(args)
+        if properties:
+            assignments = [f"{key}={value}" for key, value in properties.items()]
+            self._run(["image", "set-property", self._q(alias), *assignments])
 
     def image_exists(self, alias: str) -> bool:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ class MockRuntime(ContainerRuntime):
         self.exec_responses: dict[str, str] = {}
         self._containers: dict[str, ContainerInfo] = {}
         self._images: set[str] = {"base"}
+        self._image_properties: dict[str, dict[str, str]] = {}
         self._devices: dict[str, set[str]] = {}
 
     def is_available(self) -> bool:
@@ -62,9 +63,10 @@ class MockRuntime(ContainerRuntime):
     def add_disk(self, name: str, device_name: str, source: str, path: str, readonly: bool = False):
         self.calls.append(("add_disk", name, device_name, source, path, readonly))
 
-    def publish(self, name: str, alias: str):
+    def publish(self, name: str, alias: str, *, properties=None):
         self.calls.append(("publish", name, alias))
         self._images.add(alias)
+        self._image_properties[alias] = dict(properties or {})
 
     def image_exists(self, alias: str) -> bool:
         self.calls.append(("image_exists", alias))
@@ -80,7 +82,15 @@ class MockRuntime(ContainerRuntime):
 
     def list_images(self) -> list[dict]:
         self.calls.append(("list_images",))
-        return [{"aliases": [{"name": a}]} for a in sorted(self._images)]
+        return [
+            {
+                "aliases": [{"name": a}],
+                "fingerprint": f"fp-{a}",
+                "created_at": "2026-01-01T00:00:00Z",
+                "properties": self._image_properties.get(a, {}),
+            }
+            for a in sorted(self._images)
+        ]
 
     def push_file(self, name: str, local_path: str, remote_path: str):
         self.calls.append(("push_file", name, local_path, remote_path))
@@ -136,10 +146,8 @@ def tmp_data_dir(tmp_path, monkeypatch):
     # Patch builder module constants that capture DATA_DIR at import time
     import bubble.images.builder as builder
 
-    monkeypatch.setattr(builder, "VSCODE_COMMIT_FILE", data_dir / "vscode-commit")
-    monkeypatch.setattr(builder, "TOOLS_HASH_FILE", data_dir / "tools-hash")
     monkeypatch.setattr(builder, "CUSTOMIZE_SCRIPT", data_dir / "customize.sh")
-    monkeypatch.setattr(builder, "CUSTOMIZE_HASH_FILE", data_dir / "customize-hash")
+    monkeypatch.setattr(builder, "BUILD_LOCK_DIR", data_dir / "locks" / "images")
 
     # Patch cloud module if imported
     try:

--- a/tests/test_build_lock.py
+++ b/tests/test_build_lock.py
@@ -14,6 +14,12 @@ from bubble.images.builder import (
 )
 
 
+@pytest.fixture(autouse=True)
+def logical_aliases(monkeypatch):
+    """Keep the legacy locking tests focused on dependency serialization."""
+    monkeypatch.setattr("bubble.images.builder.desired_image_alias", lambda _runtime, name: name)
+
+
 def test_build_lock_prevents_concurrent_builds(mock_runtime, monkeypatch, tmp_data_dir):
     """A concurrent build_image call for the same image should skip if the first completes."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
@@ -156,18 +162,13 @@ def test_build_lean_toolchain_lock(mock_runtime, monkeypatch, tmp_data_dir):
     assert len(launch_calls) == 0
 
 
-def test_toolchain_build_rebuilds_missing_lean_base_under_base_lock(
+def test_toolchain_build_rebuilds_missing_immutable_lean_parent(
     mock_runtime, monkeypatch, tmp_data_dir
 ):
-    """Regression for issue #314.
+    """A missing immutable Lean parent is rebuilt before its toolchain child.
 
-    When a base rebuild has purged the ``lean`` image, building a toolchain
-    image must (a) rebuild ``lean`` first, and (b) hold the ``base`` build lock
-    across the whole base->toolchain dependency so a concurrent base rebuild
-    can't delete ``lean`` between the rebuild and the launch-from-lean. We
-    assert the ``base`` lock is still held immediately after the ``lean``
-    rebuild — in the old code the lean rebuild ran outside the lock, leaving
-    ``base`` unlocked and lettable a concurrent rebuild purge ``lean``.
+    Build-keyed parents are never purged by another variant, so the old broad
+    base lock is intentionally no longer held while constructing the parent.
     """
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
@@ -213,7 +214,7 @@ def test_toolchain_build_rebuilds_missing_lean_base_under_base_lock(
 
     assert mock_runtime.image_exists("lean")  # lean rebuilt first
     assert mock_runtime.image_exists("lean-v4.16.0")  # toolchain built from it
-    assert observed.get("base_locked_after_lean_rebuild") is True
+    assert observed.get("base_locked_after_lean_rebuild") is False
 
 
 def test_toolchain_build_builds_missing_base_and_lean_without_deadlock(

--- a/tests/test_customize.py
+++ b/tests/test_customize.py
@@ -1,6 +1,13 @@
 """Tests for user-defined image customization script."""
 
+import pytest
+
 import bubble.images.builder as builder
+
+
+@pytest.fixture(autouse=True)
+def logical_aliases(monkeypatch):
+    monkeypatch.setattr(builder, "desired_image_alias", lambda _runtime, name: name)
 
 
 def test_customize_hash_no_script(tmp_data_dir):
@@ -74,53 +81,6 @@ def test_build_image_skips_customize_when_absent(mock_runtime, monkeypatch, tmp_
     assert len(exec_calls) == 1
 
 
-def test_customize_hash_file_written(mock_runtime, monkeypatch, tmp_data_dir):
-    """Hash file is written after building with a customize script."""
-    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
-    monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
-
-    from bubble.config import load_config, save_config
-
-    config = load_config()
-    config["tools"] = {"claude": "no", "codex": "no", "elan": "no"}
-    config["editor"] = "shell"
-    save_config(config)
-
-    builder.CUSTOMIZE_SCRIPT.write_text("#!/bin/bash\necho hello\n")
-
-    mock_runtime._images.discard("base")
-    builder.build_image(mock_runtime, "base")
-
-    assert builder.CUSTOMIZE_HASH_FILE.exists()
-    stored = builder.CUSTOMIZE_HASH_FILE.read_text().strip()
-    assert len(stored) == 16
-    assert stored == builder.customize_hash()
-
-
-def test_customize_hash_file_removed_when_no_script(mock_runtime, monkeypatch, tmp_data_dir):
-    """Hash file is removed when customize script doesn't exist."""
-    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
-    monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
-
-    from bubble.config import load_config, save_config
-
-    config = load_config()
-    config["tools"] = {"claude": "no", "codex": "no", "elan": "no"}
-    config["editor"] = "shell"
-    save_config(config)
-
-    # Pre-populate hash file as if a previous build had a customize script
-    builder.CUSTOMIZE_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    builder.CUSTOMIZE_HASH_FILE.write_text("oldhash\n")
-
-    mock_runtime._images.discard("base")
-    builder.build_image(mock_runtime, "base")
-
-    assert not builder.CUSTOMIZE_HASH_FILE.exists()
-
-
 def test_build_lean_toolchain_runs_customize(mock_runtime, monkeypatch, tmp_data_dir):
     """Lean toolchain image build also runs the customize script."""
     monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
@@ -153,23 +113,3 @@ def test_nonbase_image_runs_customize(mock_runtime, monkeypatch, tmp_data_dir):
     # 2 exec calls: lean script + customize script
     assert len(exec_calls) == 2
     assert "custom" in exec_calls[-1][2][-1]
-
-
-def test_nonbase_image_does_not_write_hash(mock_runtime, monkeypatch, tmp_data_dir):
-    """Building a non-base image should not update the customize hash file.
-
-    Only the base build should record the hash — otherwise building a derived
-    image could falsely mark the system as current while base is still stale.
-    """
-    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
-    monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
-
-    mock_runtime._images.add("base")
-
-    builder.CUSTOMIZE_SCRIPT.write_text("#!/bin/bash\necho custom\n")
-
-    builder.build_image(mock_runtime, "lean")
-
-    # Hash file should NOT exist — only base builds write it
-    assert not builder.CUSTOMIZE_HASH_FILE.exists()

--- a/tests/test_image_fingerprints.py
+++ b/tests/test_image_fingerprints.py
@@ -1,0 +1,73 @@
+"""Tests for recipe-keyed Bubble image aliases."""
+
+from bubble.images import builder
+
+
+def test_same_recipe_has_same_alias_across_private_homes(mock_runtime, tmp_data_dir):
+    first = builder.desired_image_alias(mock_runtime, "base")
+    second = builder.desired_image_alias(mock_runtime, "base")
+    assert first == second
+    assert first.startswith("bubble-base-")
+
+
+def test_customize_content_changes_base_and_derived_aliases(mock_runtime, tmp_data_dir):
+    base_before = builder.desired_image_alias(mock_runtime, "base")
+    lean_before = builder.desired_image_alias(mock_runtime, "lean")
+
+    builder.CUSTOMIZE_SCRIPT.write_text("#!/bin/sh\necho customized\n")
+
+    assert builder.desired_image_alias(mock_runtime, "base") != base_before
+    assert builder.desired_image_alias(mock_runtime, "lean") != lean_before
+
+
+def test_toolchain_alias_contains_version_and_parent_key(mock_runtime, tmp_data_dir):
+    alias = builder.desired_image_alias(mock_runtime, "lean-v4.31.0")
+    assert alias.startswith("bubble-lean-v4-31-0-")
+
+    builder.CUSTOMIZE_SCRIPT.write_text("#!/bin/sh\ntrue\n")
+    assert builder.desired_image_alias(mock_runtime, "lean-v4.31.0") != alias
+
+
+def test_build_publishes_only_physical_alias(mock_runtime, monkeypatch, tmp_data_dir):
+    monkeypatch.setattr(builder, "wait_for_container", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("bubble.tools._host_has_command", lambda _cmd: False)
+    monkeypatch.setattr(builder, "get_vscode_commit", lambda: None)
+    mock_runtime._images.clear()
+
+    alias = builder.build_image(mock_runtime, "base")
+
+    assert alias in mock_runtime._images
+    assert "base" not in mock_runtime._images
+    assert mock_runtime._image_properties[alias]["user.bubble.logical_name"] == "base"
+
+
+def test_tools_and_vscode_commit_change_alias(mock_runtime, monkeypatch, tmp_data_dir):
+    from bubble.config import load_config, save_config
+
+    monkeypatch.setattr(builder, "get_vscode_commit", lambda: "a" * 40)
+    before = builder.desired_image_alias(mock_runtime, "base")
+
+    config = load_config()
+    config["tools"]["codex"] = "no"
+    save_config(config)
+    tools_changed = builder.desired_image_alias(mock_runtime, "base")
+    assert tools_changed != before
+
+    monkeypatch.setattr(builder, "get_vscode_commit", lambda: "b" * 40)
+    assert builder.desired_image_alias(mock_runtime, "base") != tools_changed
+
+
+def test_fingerprinted_builder_is_hidden(mock_runtime, tmp_data_dir):
+    name = builder.desired_image_alias(mock_runtime, "base") + "-builder"
+    assert builder.is_builder_container(name)
+
+
+def test_force_rebuilds_desired_variant(mock_runtime, monkeypatch, tmp_data_dir):
+    monkeypatch.setattr(builder, "wait_for_container", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("bubble.tools._host_has_command", lambda _cmd: False)
+    monkeypatch.setattr(builder, "get_vscode_commit", lambda: None)
+    alias = builder.desired_image_alias(mock_runtime, "base")
+    mock_runtime._images = {alias}
+
+    assert builder.build_image(mock_runtime, "base", force=True) == alias
+    assert ("image_delete", alias) in mock_runtime.calls

--- a/tests/test_image_fingerprints.py
+++ b/tests/test_image_fingerprints.py
@@ -45,9 +45,11 @@ def test_tools_and_vscode_commit_change_alias(mock_runtime, monkeypatch, tmp_dat
     from bubble.config import load_config, save_config
 
     monkeypatch.setattr(builder, "get_vscode_commit", lambda: "a" * 40)
+    config = load_config()
+    config["tools"]["codex"] = "yes"
+    save_config(config)
     before = builder.desired_image_alias(mock_runtime, "base")
 
-    config = load_config()
     config["tools"]["codex"] = "no"
     save_config(config)
     tools_changed = builder.desired_image_alias(mock_runtime, "base")

--- a/tests/test_multi_target.py
+++ b/tests/test_multi_target.py
@@ -1,8 +1,16 @@
 """Tests for multi-target support in the open command."""
 
+import pytest
 from click.testing import CliRunner
 
+from bubble import cli
 from bubble.cli import main
+
+
+@pytest.fixture(autouse=True)
+def avoid_opening_real_bubbles(monkeypatch):
+    """These parser tests must not provision images or containers."""
+    monkeypatch.setattr(cli, "_open_single", lambda *_args, **_kwargs: None)
 
 
 def test_multi_target_rejects_name():

--- a/tests/test_toolchain_image_selection.py
+++ b/tests/test_toolchain_image_selection.py
@@ -140,6 +140,7 @@ class _FakeHook:
 @pytest.fixture
 def patch_hook(monkeypatch):
     monkeypatch.setattr(image_management, "select_hook", lambda ref_path, ref: _FakeHook())
+    monkeypatch.setattr(image_management, "desired_image_alias", lambda _runtime, name: name)
 
 
 class TestToolchainImageBuildPolicy:
@@ -160,7 +161,7 @@ class TestToolchainImageBuildPolicy:
         monkeypatch.setattr(
             image_management,
             "_background_build_lean_toolchain",
-            lambda version: bg.append(version),
+            lambda runtime, version: bg.append(version),
         )
 
         hook, image_name = image_management.detect_and_build_image(
@@ -185,7 +186,7 @@ class TestToolchainImageBuildPolicy:
         monkeypatch.setattr(
             image_management,
             "_background_build_lean_toolchain",
-            lambda version: bg.append(version),
+            lambda runtime, version: bg.append(version),
         )
         # plain lean image exists so no synchronous base build happens.
         mock_runtime._images.add("lean")
@@ -211,7 +212,7 @@ class TestToolchainImageBuildPolicy:
         monkeypatch.setattr(
             image_management,
             "_background_build_lean_toolchain",
-            lambda version: bg.append(version),
+            lambda runtime, version: bg.append(version),
         )
         mock_runtime._images.add("lean")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -503,6 +503,7 @@ def test_build_base_preserves_derived_variants(mock_runtime, monkeypatch, tmp_da
     delete_calls = [c for c in mock_runtime.calls if c[0] == "image_delete"]
     assert delete_calls == []
 
+
 def test_build_base_preserves_dynamic_toolchain_variants(mock_runtime, monkeypatch, tmp_data_dir):
     """Existing toolchain variants remain available after another base build."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 """Tests for the pluggable tool installation system."""
 
+import pytest
 from click.testing import CliRunner
 
 from bubble.tools import (
@@ -11,6 +12,12 @@ from bubble.tools import (
     tool_script,
     tools_hash,
 )
+
+
+@pytest.fixture(autouse=True)
+def logical_aliases(monkeypatch):
+    monkeypatch.setattr("bubble.images.builder.desired_image_alias", lambda _runtime, name: name)
+    monkeypatch.setattr("bubble.image_management.desired_image_alias", lambda _runtime, name: name)
 
 
 def test_available_tools():
@@ -479,24 +486,8 @@ def test_build_nonbase_image_skips_tools(mock_runtime, monkeypatch, tmp_data_dir
     assert len(exec_calls) == 1
 
 
-def test_tools_hash_file_written(mock_runtime, monkeypatch, tmp_data_dir):
-    """Verify that the tools hash file is written after building base."""
-    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
-    monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
-    monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
-
-    from bubble.images.builder import TOOLS_HASH_FILE, build_image
-
-    mock_runtime._images.discard("base")
-    build_image(mock_runtime, "base")
-
-    assert TOOLS_HASH_FILE.exists()
-    stored = TOOLS_HASH_FILE.read_text().strip()
-    assert len(stored) == 16
-
-
-def test_build_base_purges_derived_images(mock_runtime, monkeypatch, tmp_data_dir):
-    """Verify that building base with tools deletes all derived images recursively."""
+def test_build_base_preserves_derived_variants(mock_runtime, monkeypatch, tmp_data_dir):
+    """Build-keyed parents do not invalidate or delete older derived variants."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
     monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
@@ -509,14 +500,11 @@ def test_build_base_purges_derived_images(mock_runtime, monkeypatch, tmp_data_di
 
     build_image(mock_runtime, "base")
 
-    # Derived images should have been deleted
     delete_calls = [c for c in mock_runtime.calls if c[0] == "image_delete"]
-    deleted_names = {c[1] for c in delete_calls}
-    assert "lean" in deleted_names
+    assert delete_calls == []
 
-
-def test_build_base_purges_dynamic_toolchain_images(mock_runtime, monkeypatch, tmp_data_dir):
-    """Verify that building base also purges dynamic toolchain images (lean-v4.x.y)."""
+def test_build_base_preserves_dynamic_toolchain_variants(mock_runtime, monkeypatch, tmp_data_dir):
+    """Existing toolchain variants remain available after another base build."""
     monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: cmd == "claude")
     monkeypatch.setattr("bubble.images.builder.get_vscode_commit", lambda: None)
     monkeypatch.setattr("bubble.images.builder.wait_for_container", lambda *a, **kw: None)
@@ -531,108 +519,4 @@ def test_build_base_purges_dynamic_toolchain_images(mock_runtime, monkeypatch, t
     build_image(mock_runtime, "base")
 
     delete_calls = [c for c in mock_runtime.calls if c[0] == "image_delete"]
-    deleted_names = {c[1] for c in delete_calls}
-    # Dynamic toolchain images should also be purged
-    assert "lean-v4-16-0" in deleted_names
-
-
-def test_maybe_rebuild_tools_triggers_on_stale_hash(mock_runtime, monkeypatch, tmp_data_dir):
-    """A stale tools-hash (e.g. base.sh changed on upgrade) forces a base rebuild.
-
-    This is the path by which existing users with an already-built base image
-    pick up base.sh changes like the newly-added jq package.
-    """
-    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
-
-    from bubble.config import load_config, save_config
-
-    config = load_config()
-    config["editor"] = "shell"
-    save_config(config)
-
-    from bubble.images.builder import TOOLS_HASH_FILE
-
-    TOOLS_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    TOOLS_HASH_FILE.write_text("stale-hash\n")
-
-    calls = []
-    monkeypatch.setattr(
-        "bubble.images.builder.build_image",
-        lambda runtime, name, **kw: calls.append((name, kw)),
-    )
-
-    from bubble.image_management import maybe_rebuild_tools
-
-    maybe_rebuild_tools(mock_runtime)
-
-    assert calls, "expected a base rebuild to be triggered"
-    name, kw = calls[0]
-    assert name == "base"
-    assert kw.get("force") is True
-
-
-def test_maybe_rebuild_tools_noop_when_hash_matches(mock_runtime, monkeypatch, tmp_data_dir):
-    """No rebuild when the stored tools-hash already matches the current one."""
-    monkeypatch.setattr("bubble.tools._host_has_command", lambda cmd: False)
-
-    from bubble.config import load_config, save_config
-
-    config = load_config()
-    config["editor"] = "shell"
-    save_config(config)
-
-    from bubble.images.builder import TOOLS_HASH_FILE
-    from bubble.tools import resolve_tools, tools_hash
-
-    TOOLS_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    TOOLS_HASH_FILE.write_text(tools_hash(resolve_tools(config)) + "\n")
-
-    calls = []
-    monkeypatch.setattr(
-        "bubble.images.builder.build_image",
-        lambda runtime, name, **kw: calls.append((name, kw)),
-    )
-
-    from bubble.image_management import maybe_rebuild_tools
-
-    maybe_rebuild_tools(mock_runtime)
-
-    assert calls == []
-
-
-def test_collect_derived_images_recursive():
-    """Verify _collect_derived_images walks the full dependency tree."""
-    from bubble.images.builder import _collect_derived_images
-
-    # "base" -> "lean" (only two images in simplified hierarchy)
-    derived = set(_collect_derived_images("base"))
-    assert "lean" in derived
-
-
-def test_collect_derived_images_leaf():
-    """Verify _collect_derived_images returns empty for leaf images."""
-    from bubble.images.builder import _collect_derived_images
-
-    assert _collect_derived_images("lean") == []
-
-
-def test_collect_dynamic_toolchain_aliases(mock_runtime):
-    """Verify dynamic toolchain images are found by alias pattern."""
-    from bubble.images.builder import _collect_dynamic_toolchain_aliases
-
-    mock_runtime._images.update(
-        {
-            "lean-v4-16-0",
-            "lean-v4-17-0",
-            "lean",
-        }
-    )
-
-    # Only lean-family images in purged set trigger scanning
-    aliases = set(_collect_dynamic_toolchain_aliases(mock_runtime, {"lean"}))
-    assert "lean-v4-16-0" in aliases
-    assert "lean-v4-17-0" in aliases
-    assert "lean" not in aliases
-
-    # No lean images in purged set -> no dynamic aliases
-    assert _collect_dynamic_toolchain_aliases(mock_runtime, {"base"}) == []
+    assert delete_calls == []


### PR DESCRIPTION
## Summary
- key physical Incus aliases by trusted build inputs while preserving logical image names
- share image locks across isolated BUBBLE_HOME stores and retain immutable parent variants
- add managed image metadata, safe dry-run pruning, legacy cleanup, and weekly forced refresh
- remove marker-driven rebuild/purge behavior and keep reattach paths fast

## Validation
- uv run ruff check on all changed Python files
- uv run pytest -q -m 'not integration' (1300 passed, 7 skipped, 14 deselected)
- independent Opus review; addressed its blocking findings around parent identity, builder detection, force rebuilds, background lock naming, legacy pruning, and marker cleanup

The installed Incus client documents that image set-property accepts multiple key=value operands; this was verified locally.