### PR TITLE
Fix macOS Bubble SSH targets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,7 +86,7 @@ The `lean` image provides elan as a fallback for users who don't have elan on th
 Incus requires Linux. On macOS, Colima runs a lightweight Linux VM with Apple's Virtualization.Framework (`--vm-type vz`). The `ensure_colima()` function starts it if needed.
 
 ### SSH via ProxyCommand
-Each container runs sshd. Rather than port forwarding (which doesn't work well through Colima on macOS), we use `ProxyCommand incus exec <name> -- su - user -c "nc localhost 22"`. SSH config entries are auto-generated in `~/.ssh/config.d/bubble`.
+Each container runs sshd. Rather than port forwarding (which doesn't work well through Colima on macOS), we use `ProxyCommand incus exec <runtime-target> -- su - user -c "nc localhost 22"`, where macOS uses the qualified `bubble-colima:<name>` target. SSH config entries are auto-generated in `~/.ssh/config.d/bubble`.
 
 ### Container Naming
 Names are `<repo>-<source>-<id>` (e.g., `mathlib4-pr-12345`). Numeric suffix for collisions. The `open` command checks for existing containers by generated name and registry lookup before creating new ones.

--- a/SPEC.md
+++ b/SPEC.md
@@ -234,14 +234,16 @@ if not already present.
 ```
 Host bubble-<name>
   User user
-  ProxyCommand incus exec <name> -- su - user -c "nc localhost 22"
+  ProxyCommand incus exec <runtime-target> -- su - user -c "nc localhost 22"
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   LogLevel ERROR
 ```
 
 The ProxyCommand uses `incus exec` instead of port forwarding because port
-forwarding doesn't work reliably through Colima on macOS.
+forwarding doesn't work reliably through Colima on macOS. `<runtime-target>`
+is `<name>` for the default runtime and `bubble-colima:<name>` for Bubble's
+named, non-default Incus remote on macOS.
 
 ### 1.9 Editor launching
 
@@ -769,8 +771,10 @@ The remote must have Python >= 3.10.
 5. Set up GitHub auth tunnel (see Stage 10)
 6. Write local SSH config with chained ProxyCommand:
    ```
-   ProxyCommand ssh [options] user@host 'incus exec <name> -- su - user -c "nc localhost 22"'
+   ProxyCommand ssh [options] user@host 'incus exec <runtime-target> -- su - user -c "nc localhost 22"'
    ```
+   The remote reports `<runtime-target>` in the optional `container_target`
+   field of its machine-readable result; older remotes fall back to `<name>`.
 7. Register locally with `remote_host` field
 8. Open editor locally (connects through the chained proxy)
 

--- a/bubble/__init__.py
+++ b/bubble/__init__.py
@@ -1,3 +1,3 @@
 """bubble: Containerized development environments."""
 
-__version__ = "0.7.27"
+__version__ = "0.7.28"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -487,7 +487,12 @@ def _open_remote(
 
     # Write local SSH config with chained ProxyCommand through the remote host
     host_key = is_enabled(config, "host_key_trust")
-    add_ssh_config(name, remote_host=remote_host, host_key_trust=host_key)
+    add_ssh_config(
+        name,
+        remote_host=remote_host,
+        host_key_trust=host_key,
+        container_target=result.get("container_target"),
+    )
 
     # Register in local lifecycle registry with remote_host info
     register_bubble(
@@ -1201,7 +1206,12 @@ def _open_single(
         )
         if machine_readable:
             project_dir = detect_project_dir(runtime, existing)
-            machine_readable_output("reattached", existing, project_dir=project_dir)
+            machine_readable_output(
+                "reattached",
+                existing,
+                project_dir=project_dir,
+                container_target=runtime.qualify(existing),
+            )
             return
         notices.finish()
         _reattach(
@@ -1261,7 +1271,11 @@ def _open_single(
         if machine_readable:
             project_dir = detect_project_dir(runtime, existing)
             machine_readable_output(
-                "reattached", existing, project_dir=project_dir, org_repo=t.org_repo
+                "reattached",
+                existing,
+                project_dir=project_dir,
+                org_repo=t.org_repo,
+                container_target=runtime.qualify(existing),
             )
             return
         notices.finish()

--- a/bubble/container_helpers.py
+++ b/bubble/container_helpers.py
@@ -210,7 +210,15 @@ def setup_ssh(
         finally:
             Path(tmp_keys).unlink(missing_ok=True)
 
-    add_ssh_config(name, host_key_trust=host_key_trust)
+    # Incus resources live on a named, non-default remote on macOS. The SSH
+    # ProxyCommand must target the same qualified container as the runtime;
+    # otherwise the macOS client looks for a native local Incus server and
+    # fails only after the bubble has been fully created.
+    add_ssh_config(
+        name,
+        host_key_trust=host_key_trust,
+        container_target=runtime.qualify(name),
+    )
 
 
 def get_host_git_identity() -> tuple[str, str]:

--- a/bubble/finalization.py
+++ b/bubble/finalization.py
@@ -117,6 +117,7 @@ def finalize_bubble(
             org_repo=t.org_repo,
             image=image_name,
             branch=checkout_branch or (t.ref if t.kind == "branch" else ""),
+            container_target=runtime.qualify(name),
         )
         return
 

--- a/bubble/vscode.py
+++ b/bubble/vscode.py
@@ -13,6 +13,7 @@ from .config import HOST_DATA_DIR
 
 # Valid bubble name pattern (alphanumeric + hyphens, starts with letter)
 _BUBBLE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+_INCUS_REMOTE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
 SSH_CONFIG_DIR = HOST_DATA_DIR.parent / ".ssh" / "config.d"
 SSH_CONFIG_FILE = SSH_CONFIG_DIR / "bubble"
@@ -120,7 +121,11 @@ def _atomic_write_text(path: Path, content: str) -> None:
 
 
 def add_ssh_config(
-    bubble_name: str, user: str = "user", remote_host=None, host_key_trust: bool = True
+    bubble_name: str,
+    user: str = "user",
+    remote_host=None,
+    host_key_trust: bool = True,
+    container_target: str | None = None,
 ):
     """Add an SSH config entry for a bubble.
 
@@ -133,11 +138,19 @@ def add_ssh_config(
         user: User inside the container.
         remote_host: Optional RemoteHost for chained ProxyCommand.
         host_key_trust: If True (default), disable StrictHostKeyChecking.
+        container_target: Runtime-qualified container reference. On macOS this is
+            ``bubble-colima:<name>`` because Bubble deliberately leaves the
+            user's default Incus remote unchanged.
     """
     if not _BUBBLE_NAME_RE.match(bubble_name):
         raise ValueError(f"Invalid bubble name for SSH config: {bubble_name!r}")
 
-    incus_cmd = f'incus exec {bubble_name} -- su - {user} -c "nc localhost 22"'
+    target = container_target or bubble_name
+    if target != bubble_name:
+        remote, separator, target_name = target.partition(":")
+        if not separator or target_name != bubble_name or not _INCUS_REMOTE_RE.fullmatch(remote):
+            raise ValueError(f"Invalid runtime-qualified container target: {target!r}")
+    incus_cmd = f'incus exec {shlex.quote(target)} -- su - {shlex.quote(user)} -c "nc localhost 22"'
 
     if remote_host is not None:
         ssh_parts = ["ssh"]
@@ -167,8 +180,24 @@ def add_ssh_config(
     with _ssh_config_lock():
         SSH_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         existing = SSH_CONFIG_FILE.read_text() if SSH_CONFIG_FILE.exists() else ""
+        existing = _without_ssh_config_entry(existing, bubble_name)
         _atomic_write_text(SSH_CONFIG_FILE, existing + entry)
         _ensure_include_directive_locked()
+
+
+def _without_ssh_config_entry(content: str, bubble_name: str) -> str:
+    """Return SSH config content with every block for ``bubble_name`` removed."""
+    result = []
+    skip = False
+    for line in content.splitlines():
+        if line.strip() == f"Host bubble-{bubble_name}":
+            skip = True
+            continue
+        if skip and line.strip().startswith("Host "):
+            skip = False
+        if not skip:
+            result.append(line)
+    return "\n".join(result) + "\n" if result else ""
 
 
 def remove_ssh_config(bubble_name: str):
@@ -176,20 +205,7 @@ def remove_ssh_config(bubble_name: str):
     with _ssh_config_lock():
         if not SSH_CONFIG_FILE.exists():
             return
-
-        lines = SSH_CONFIG_FILE.read_text().splitlines()
-        result = []
-        skip = False
-        for line in lines:
-            if line.strip() == f"Host bubble-{bubble_name}":
-                skip = True
-                continue
-            if skip and line.strip().startswith("Host "):
-                skip = False
-            if not skip:
-                result.append(line)
-
-        new_content = "\n".join(result) + "\n" if result else ""
+        new_content = _without_ssh_config_entry(SSH_CONFIG_FILE.read_text(), bubble_name)
         _atomic_write_text(SSH_CONFIG_FILE, new_content)
 
 

--- a/tests/test_github_security_override.py
+++ b/tests/test_github_security_override.py
@@ -312,3 +312,44 @@ class TestOpenRemoteForwarding:
                 pass
 
         assert captured_kwargs.get("github_security") == "write-graphql"
+
+    def test_open_remote_forwards_runtime_qualified_container_target(self):
+        from bubble import cli as cli_mod
+
+        captured = {}
+
+        def _fake_remote_open(_host, _target, **_kwargs):
+            return {
+                "name": "x",
+                "project_dir": "/home/user",
+                "org_repo": "kim-em/bubble",
+                "container_target": "bubble-colima:x",
+            }
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("bubble.remote.remote_open", _fake_remote_open))
+            stack.enter_context(patch("bubble.cli._resolve_ai_prompt_locally", return_value=""))
+            stack.enter_context(patch("bubble.cli.inject_local_ssh_keys"))
+            stack.enter_context(patch("bubble.cli.get_github_level", return_value="off"))
+            stack.enter_context(patch("bubble.cli.register_bubble"))
+            stack.enter_context(
+                patch(
+                    "bubble.cli.add_ssh_config",
+                    side_effect=lambda name, **kwargs: captured.update(name=name, **kwargs),
+                )
+            )
+
+            host = MagicMock()
+            host.ssh_destination = "user@example.com"
+            cli_mod._open_remote(
+                host,
+                "kim-em/bubble",
+                editor="shell",
+                no_interactive=True,
+                network=True,
+                custom_name=None,
+                config={"security": {"github": "off"}},
+            )
+
+        assert captured["name"] == "x"
+        assert captured["container_target"] == "bubble-colima:x"

--- a/tests/test_vscode.py
+++ b/tests/test_vscode.py
@@ -128,9 +128,80 @@ class TestAddSshConfig:
         assert "ProxyCommand incus exec test-bubble" in content
         assert "nc localhost 22" in content
 
+    def test_writes_runtime_qualified_proxy_target(self, tmp_ssh_dir):
+        ssh_file = tmp_ssh_dir / "bubble"
+        add_ssh_config(
+            "test-bubble",
+            container_target="bubble-colima:test-bubble",
+        )
+        content = ssh_file.read_text()
+        assert "Host bubble-test-bubble" in content
+        assert "ProxyCommand incus exec bubble-colima:test-bubble" in content
+
     def test_rejects_invalid_name(self, tmp_ssh_dir):
         with pytest.raises(ValueError, match="Invalid bubble name"):
             add_ssh_config("evil; rm -rf /")
+
+    def test_setup_ssh_writes_runtime_qualified_target(self, tmp_ssh_dir, monkeypatch):
+        from bubble import container_helpers
+
+        class FakeRuntime:
+            def exec(self, _name, _argv):
+                return ""
+
+            def qualify(self, name):
+                return f"bubble-colima:{name}"
+
+        monkeypatch.setattr(container_helpers, "collect_authorized_keys", lambda _config: [])
+
+        container_helpers.setup_ssh(FakeRuntime(), "test-bubble")
+
+        content = (tmp_ssh_dir / "bubble").read_text()
+        assert "Host bubble-test-bubble" in content
+        assert "ProxyCommand incus exec bubble-colima:test-bubble" in content
+
+    def test_setup_ssh_preserves_identity_target(self, tmp_ssh_dir, monkeypatch):
+        from bubble import container_helpers
+
+        class FakeRuntime:
+            def exec(self, _name, _argv):
+                return ""
+
+            def qualify(self, name):
+                return name
+
+        monkeypatch.setattr(container_helpers, "collect_authorized_keys", lambda _config: [])
+
+        container_helpers.setup_ssh(FakeRuntime(), "test-bubble")
+
+        content = (tmp_ssh_dir / "bubble").read_text()
+        assert "ProxyCommand incus exec test-bubble" in content
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "other-container",
+            "bubble-colima:other-container",
+            "bad remote:test-bubble",
+            "bubble-colima:test-bubble\nHost injected",
+        ],
+    )
+    def test_rejects_invalid_runtime_qualified_target(self, tmp_ssh_dir, target):
+        with pytest.raises(ValueError, match="Invalid runtime-qualified container target"):
+            add_ssh_config("test-bubble", container_target=target)
+
+    def test_readding_name_replaces_stale_target(self, tmp_ssh_dir):
+        ssh_file = tmp_ssh_dir / "bubble"
+        add_ssh_config("test-bubble")
+        add_ssh_config(
+            "test-bubble",
+            container_target="bubble-colima:test-bubble",
+        )
+
+        content = ssh_file.read_text()
+        assert content.count("Host bubble-test-bubble") == 1
+        assert "ProxyCommand incus exec test-bubble" not in content
+        assert "ProxyCommand incus exec bubble-colima:test-bubble" in content
 
 
 class TestRemoveSshConfig:
@@ -234,6 +305,17 @@ class TestAtomicSshConfig:
 
 
 class TestRemoteProxyCommand:
+    def test_chained_proxy_uses_runtime_qualified_target(self, tmp_ssh_dir):
+        ssh_file = tmp_ssh_dir / "bubble"
+        host = RemoteHost(hostname="build-server", user="kim")
+        add_ssh_config(
+            "test-remote",
+            remote_host=host,
+            container_target="bubble-colima:test-remote",
+        )
+        content = ssh_file.read_text()
+        assert "'incus exec bubble-colima:test-remote" in content
+
     def test_chained_proxy_with_default_port(self, tmp_ssh_dir):
         ssh_file = tmp_ssh_dir / "bubble"
         host = RemoteHost(hostname="build-server", user="kim")


### PR DESCRIPTION
## What changed

- qualify generated SSH ProxyCommand container targets through the active runtime
- carry qualified targets through local, remote-create, and remote-reattach paths
- replace stale duplicate SSH host blocks and validate qualified targets
- document the machine-readable target contract and bump Bubble to 0.7.28

## Why

On macOS, Bubble deliberately uses the named `bubble-colima` Incus remote without changing the user default. The generated SSH ProxyCommand still used a bare container name, so `--command` failed after successfully creating the container with the Incus error that no default remote was configured.

## Validation

- `ruff check bubble/ tests/`
- `ruff format --check bubble/ tests/`
- 261 focused SSH, Colima, runtime, security, internal RPC, remote, and GitHub-security tests
- two independent Claude Opus reviews; remote reattach, config-byte coverage, target validation, documentation, and stale-entry replacement were addressed from the findings
