### PR TITLE
Share trusted Git mirrors across Bubble homes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,7 +64,7 @@ The `hooks/` package provides a pluggable system for language-specific behavior.
 `ContainerRuntime` (base.py) is an abstract interface. `IncusRuntime` is the only implementation today. Docker/Podman support is a stretch goal — the abstraction exists to make that possible without refactoring.
 
 ### Git Object Sharing
-The core performance optimization. Host maintains bare mirror repos (`git clone --bare`). Containers clone with `git clone --reference /shared/git/repo.git url` — git alternates share immutable objects. Each container has fully independent refs/branches/working tree. `update_all_repos()` discovers repos from the `~/.bubble/git/*.git` directory listing.
+The core performance optimization. Host maintains bare mirror repos (`git clone --bare`) under `~/.bubble/git/github.com/<owner>/<repo>.git`. Containers clone with owner-qualified read-only references under `/shared/git/<owner>/<repo>.git`, so git alternates share immutable objects without short-name collisions. Each container has fully independent refs/branches/working tree. `update_all_repos()` discovers repositories from the nested host-global store.
 
 ### Image Registry
 Images are defined in `builder.py`'s `IMAGES` dict with script and parent references. Building is recursive — if a parent image is missing, it's built first. There are only two static images: `base` (from Ubuntu 24.04) and `lean` (from base, fallback elan install). Editors and language tools are installed as pluggable tools on the base image, eliminating editor-specific image variants.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 - **No outbound SSH**: Containers cannot SSH out (VSCode uses `incus exec` ProxyCommand)
 - **SSH key-only auth**: Password authentication is disabled. By default only `~/.ssh/id_ed25519.pub` is injected as `authorized_keys` (with `id_rsa.pub`/`id_ecdsa.pub` as fallbacks if no ed25519 key exists). Override with `[ssh] authorized_keys = "~/.ssh/yubikey.pub"` (or a list) in `~/.bubble/config.toml`, or with the `BUBBLE_AUTHORIZED_KEYS` env var (colon-separated paths).
 - **Shell injection hardening**: All user-supplied values are quoted with `shlex.quote()`
-- **Per-repo git mount**: Each container only sees its own bare repo, not the entire git store
+- **Per-repo git mount**: Trusted mirrors are shared host-wide under `~/.bubble/git/github.com/<owner>/<repo>.git`, but each container only sees its own bare repo, not the entire git store
 - **Bubble-in-bubble relay**: Containers can open new bubbles on the host, but only for repos already cloned in `~/.bubble/git/`. Disable with `bubble security set relay off`
 - **GitHub auth proxy**: Host token never enters containers. Git and REST API are repo-scoped. **GraphQL queries are read-only but account-wide** — can read any data the host token can access. API access can be set to `off`, `on` (read-only, the default), or `read-write` (enables mutations) via `bubble security set github-api`
 - **Shared Lean caches**: Mathlib's `lake exe cache` cache at `~/.bubble/mathlib-cache/` and Lake's built-in artifact cache at `~/.bubble/lake-cache/` are shared across Lean containers. Modes: `on` (default) = read-write (a compromised container could poison cached artifacts), `off` = read-only (prevents poisoning), `overlay` = per-container writable views with isolated writes (overlayfs on Linux; clonefile-seeded writable copies on macOS/Colima, where overlayfs can't run over virtiofs). These caches are *not* shared with cache commands run outside a bubble. Configure with `bubble security set shared-cache`. If you suspect poisoning, delete the corresponding cache directory.
@@ -181,7 +181,7 @@ Set `BUBBLE_HOME` to override the data directory (default: `~/.bubble`):
 export BUBBLE_HOME=/data/bubble
 ```
 
-This isolates configuration and per-bubble state. Incus images, host daemons, and their coordination locks remain host-global and are safely shared by build identity.
+This isolates configuration and per-bubble state. Incus images, trusted Git mirrors, host daemons, and their coordination locks remain host-global and are safely shared by build or repository identity.
 
 ```toml
 [runtime]

--- a/SPEC.md
+++ b/SPEC.md
@@ -100,33 +100,33 @@ stripped before parsing. Trailing slashes are stripped.
 
 ### 1.3 Git store (bare repo management)
 
-**Location:** `~/.bubble/git/`
+**Location:** `~/.bubble/git/github.com/<owner>/`
 
 On first use of a repository, create a bare mirror:
 
 ```
-git clone --bare https://github.com/owner/repo.git ~/.bubble/git/repo.git
+git clone --bare https://github.com/owner/repo.git ~/.bubble/git/github.com/owner/repo.git
 ```
 
 Then configure fetch refs:
 
 ```
-git -C ~/.bubble/git/repo.git config remote.origin.fetch '+refs/heads/*:refs/heads/*'
-git -C ~/.bubble/git/repo.git config --add remote.origin.fetch '+refs/tags/*:refs/tags/*'
-git -C ~/.bubble/git/repo.git config --add remote.origin.fetch '+refs/pull/*/head:refs/pull/*/head'
+git -C ~/.bubble/git/github.com/owner/repo.git config remote.origin.fetch '+refs/heads/*:refs/heads/*'
+git -C ~/.bubble/git/github.com/owner/repo.git config --add remote.origin.fetch '+refs/tags/*:refs/tags/*'
+git -C ~/.bubble/git/github.com/owner/repo.git config --add remote.origin.fetch '+refs/pull/*/head:refs/pull/*/head'
 ```
 
-The bare repo path is derived from the repo name only (not the owner):
-`~/.bubble/git/<repo>.git`.
+The bare repo path is derived from the normalized full repository identity:
+`~/.bubble/git/github.com/<owner>/<repo>.git`.
 
 **PR ref fetching:** When the target is a PR, fetch the specific ref:
 
 ```
-git -C ~/.bubble/git/repo.git fetch origin refs/pull/123/head:refs/pull/123/head
+git -C ~/.bubble/git/github.com/owner/repo.git fetch origin refs/pull/123/head:refs/pull/123/head
 ```
 
 **Concurrency:** Bare repo operations (init, fetch) MUST use per-repo file
-locking (`~/.bubble/git/<repo>.git.lock`) to prevent concurrent git operations
+locking (`~/.bubble/locks/git/<repository-hash>.lock`) to prevent concurrent git operations
 from corrupting the repo.
 
 **Idempotency:** `init_bare_repo` is idempotent — if the bare repo exists,
@@ -1212,8 +1212,8 @@ container lifecycle, but a complete implementation should include them:
 | Path | Contents |
 |------|----------|
 | `~/.bubble/config.toml` | User settings |
-| `~/.bubble/git/` | Bare repo mirrors |
-| `~/.bubble/git/<repo>.git.lock` | Per-repo file locks |
+| `~/.bubble/git/github.com/<owner>/<repo>.git` | Host-global bare repo mirrors |
+| `~/.bubble/locks/git/<repository-hash>.lock` | Per-repo file locks |
 | `~/.bubble/repos.json` | Learned repo short name mappings |
 | `~/.bubble/registry.json` | Bubble state tracking |
 | `~/.bubble/relay.sock` | Relay daemon Unix socket (Linux) |

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -35,9 +35,9 @@ from .finalization import (
     machine_readable_output,
 )
 from .git_store import (
-    bare_repo_path,
     ensure_rev_available,
     fetch_ref,
+    find_existing_mirror,
     init_bare_repo,
     refresh_mirror_ref,
 )
@@ -239,8 +239,8 @@ def _resolve_ref_source(t, no_clone: bool) -> tuple[Path, str]:
         mount_name = f"{repo_short_name(t.org_repo)}.git"
     else:
         if no_clone:
-            bare_path = bare_repo_path(t.org_repo)
-            if not bare_path.exists():
+            bare_path = find_existing_mirror(t.org_repo)
+            if bare_path is None:
                 click.echo(
                     f"Repo '{t.org_repo}' has not been cloned yet. "
                     f"Run without --no-clone to fetch it automatically.",
@@ -1301,8 +1301,7 @@ def _open_single(
                                 f"Warning: rev {dep.rev[:12]} not found for {dep.name}, skipping"
                             )
                         continue
-                    repo_name = dep.org_repo.split("/")[-1]
-                    dep_mounts[repo_name] = dep_path
+                    dep_mounts[dep.org_repo.lower()] = dep_path
                 except Exception as e:
                     if not machine_readable:
                         detail(f"Warning: could not prepare {dep.name}: {e}")

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -50,7 +50,10 @@ HOST_DATA_DIR = host_home() / ".bubble"
 # wrote and write tokens the daemon never reads. See issue #304.
 AUTH_PROXY_DIR = HOST_DATA_DIR
 REGISTRY_FILE = DATA_DIR / "registry.json"
-GIT_DIR = DATA_DIR / "git"
+# Trusted mirrors are host-global. A private BUBBLE_HOME still isolates
+# configuration and mutable bubble state, but should not force another clone.
+GIT_DIR = HOST_DATA_DIR / "git" / "github.com"
+LEGACY_GIT_DIR = DATA_DIR / "git"
 REPOS_FILE = DATA_DIR / "repos.json"
 CLOUD_STATE_FILE = DATA_DIR / "cloud.json"
 CLOUD_KEY_FILE = DATA_DIR / "cloud_key"
@@ -110,8 +113,7 @@ DEFAULT_CONFIG = {
 
 def ensure_dirs():
     """Create data directories if they don't exist."""
-    for d in [DATA_DIR, GIT_DIR]:
-        d.mkdir(parents=True, exist_ok=True)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def is_first_run() -> bool:

--- a/bubble/container_helpers.py
+++ b/bubble/container_helpers.py
@@ -157,12 +157,14 @@ def recover_extra_domains(info: dict) -> list[str] | None:
     org_repo = info.get("org_repo")
     if not org_repo:
         return None
-    repo_short = org_repo.split("/")[-1] if "/" in org_repo else org_repo
-    from .config import DATA_DIR
+    from .git_store import find_existing_mirror
     from .hooks import select_hook
 
-    bare_repo = DATA_DIR / "git" / f"{repo_short}.git"
-    if not bare_repo.exists():
+    try:
+        bare_repo = find_existing_mirror(org_repo)
+    except ValueError:
+        return None
+    if bare_repo is None:
         return None
     ref = info.get("commit") or info.get("branch") or "HEAD"
     try:

--- a/bubble/git_store.py
+++ b/bubble/git_store.py
@@ -1,22 +1,42 @@
 """Shared git bare repo management."""
 
 import fcntl
+import hashlib
+import os
+import re
 import subprocess
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
-from .config import GIT_DIR
+from .config import GIT_DIR, HOST_DATA_DIR, LEGACY_GIT_DIR
+
+GIT_LOCK_DIR = HOST_DATA_DIR / "locks" / "git"
+_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def canonical_repo(org_repo: str) -> str:
+    """Validate and normalize an owner/repository identifier."""
+    parts = org_repo.split("/")
+    if len(parts) != 2 or any(
+        not part or part in (".", "..") or not _COMPONENT_RE.fullmatch(part) for part in parts
+    ):
+        raise ValueError(f"Invalid GitHub repository: {org_repo!r}")
+    repo = parts[1].removesuffix(".git")
+    if not repo or repo in (".", "..") or not _COMPONENT_RE.fullmatch(repo):
+        raise ValueError(f"Invalid GitHub repository: {org_repo!r}")
+    return f"{parts[0].lower()}/{repo.lower()}"
 
 
 def bare_repo_path(org_repo: str) -> Path:
-    """Get the path for a bare repo mirror. e.g. 'leanprover/lean4' → GIT_DIR/lean4.git"""
-    repo_name = org_repo.split("/")[-1]
-    return GIT_DIR / f"{repo_name}.git"
+    """Return the nested host-global path for a GitHub bare mirror."""
+    owner, repo = canonical_repo(org_repo).split("/", 1)
+    return GIT_DIR / owner / f"{repo}.git"
 
 
 def github_url(org_repo: str) -> str:
-    return f"https://github.com/{org_repo}.git"
+    return f"https://github.com/{canonical_repo(org_repo)}.git"
 
 
 def parse_github_url(url: str) -> str | None:
@@ -33,17 +53,21 @@ def parse_github_url(url: str) -> str | None:
     if path.endswith(".git"):
         path = path[:-4]
     parts = path.split("/")
-    if len(parts) >= 2:
-        return f"{parts[0]}/{parts[1]}"
+    if len(parts) == 2:
+        try:
+            return canonical_repo(f"{parts[0]}/{parts[1]}")
+        except ValueError:
+            return None
     return None
 
 
 @contextmanager
 def _repo_lock(org_repo: str):
     """Acquire an exclusive file lock for a bare repo to prevent concurrent git operations."""
-    GIT_DIR.mkdir(parents=True, exist_ok=True)
-    repo_name = org_repo.split("/")[-1]
-    lock_path = GIT_DIR / f"{repo_name}.git.lock"
+    canonical = canonical_repo(org_repo)
+    GIT_LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    lock_name = hashlib.sha256(canonical.encode()).hexdigest()[:24]
+    lock_path = GIT_LOCK_DIR / f"{lock_name}.lock"
     fd = lock_path.open("w")
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
@@ -51,6 +75,95 @@ def _repo_lock(org_repo: str):
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         fd.close()
+
+
+def _origin_repo(path: Path) -> str | None:
+    if not (path / "HEAD").is_file():
+        return None
+    result = subprocess.run(
+        ["git", "--git-dir", str(path), "config", "--get", "remote.origin.url"],
+        capture_output=True,
+        text=True,
+    )
+    return parse_github_url(result.stdout.strip()) if result.returncode == 0 else None
+
+
+def _legacy_candidates(org_repo: str):
+    repo_name = canonical_repo(org_repo).split("/", 1)[1]
+    seen = set()
+    for parent in (LEGACY_GIT_DIR, HOST_DATA_DIR / "git"):
+        if not parent.is_dir():
+            continue
+        for candidate in parent.iterdir():
+            if candidate in seen or candidate.is_symlink() or not candidate.is_dir():
+                continue
+            seen.add(candidate)
+            if candidate.name.lower() == f"{repo_name}.git":
+                yield candidate
+
+
+def find_existing_mirror(org_repo: str) -> Path | None:
+    """Return a nested mirror, or an origin-verified legacy mirror."""
+    destination = bare_repo_path(org_repo)
+    if destination.is_dir():
+        return destination
+    canonical = canonical_repo(org_repo)
+    for candidate in _legacy_candidates(org_repo):
+        if _origin_repo(candidate) == canonical:
+            return candidate
+    return None
+
+
+def _migrate_legacy_mirror(org_repo: str, destination: Path) -> bool:
+    """Atomically adopt an unambiguous legacy flat mirror."""
+    for candidate in _legacy_candidates(org_repo):
+        if _origin_repo(candidate) != canonical_repo(org_repo):
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.replace(candidate, destination)
+        except OSError:
+            # A custom BUBBLE_HOME can live on another filesystem. Keep its
+            # mirror intact and let the caller atomically clone a fresh copy.
+            continue
+        _configure_mirror(destination)
+        try:
+            candidate.symlink_to(destination, target_is_directory=True)
+        except OSError:
+            pass
+        return True
+    return False
+
+
+def _configure_mirror(path: Path) -> None:
+    subprocess.run(
+        ["git", "-C", str(path), "config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "config",
+            "--add",
+            "remote.origin.fetch",
+            "+refs/tags/*:refs/tags/*",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "config",
+            "--add",
+            "remote.origin.fetch",
+            "+refs/pull/*/head:refs/pull/*/head",
+        ],
+        check=True,
+    )
 
 
 def ensure_rev_available(org_repo: str, rev: str) -> bool:
@@ -110,42 +223,17 @@ def init_bare_repo(org_repo: str) -> Path:
         if path.exists():
             return path
 
+        if _migrate_legacy_mirror(org_repo, path):
+            return path
+
         url = github_url(org_repo)
         print(f"Cloning bare mirror of {org_repo}...")
-        subprocess.run(
-            ["git", "clone", "--bare", url, str(path)],
-            check=True,
-        )
-        # Configure to fetch all refs (including PRs and tags)
-        subprocess.run(
-            ["git", "-C", str(path), "config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
-            check=True,
-        )
-        subprocess.run(
-            [
-                "git",
-                "-C",
-                str(path),
-                "config",
-                "--add",
-                "remote.origin.fetch",
-                "+refs/tags/*:refs/tags/*",
-            ],
-            check=True,
-        )
-        # Also fetch PR refs so we can checkout PRs
-        subprocess.run(
-            [
-                "git",
-                "-C",
-                str(path),
-                "config",
-                "--add",
-                "remote.origin.fetch",
-                "+refs/pull/*/head:refs/pull/*/head",
-            ],
-            check=True,
-        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix=".bubble-clone-", dir=path.parent) as temp_dir:
+            temporary = Path(temp_dir) / path.name
+            subprocess.run(["git", "clone", "--bare", url, str(temporary)], check=True)
+            _configure_mirror(temporary)
+            os.replace(temporary, path)
     return path
 
 
@@ -230,24 +318,43 @@ def refresh_mirror_ref(org_repo: str, kind: str, ref: str) -> None:
 
 def update_all_repos():
     """Update all bare repos found in the git store directory."""
+    # Opportunistically finish the flat-layout migration even for repositories
+    # not opened interactively after an upgrade.
+    legacy_repos = []
+    for parent in (LEGACY_GIT_DIR, HOST_DATA_DIR / "git"):
+        if not parent.is_dir():
+            continue
+        for candidate in parent.iterdir():
+            org_repo = _origin_repo(candidate) if candidate.is_dir() else None
+            if org_repo:
+                legacy_repos.append(org_repo)
+    for org_repo in sorted(set(legacy_repos)):
+        destination = bare_repo_path(org_repo)
+        if destination.exists():
+            continue
+        with _repo_lock(org_repo):
+            if not destination.exists():
+                _migrate_legacy_mirror(org_repo, destination)
+
     if not GIT_DIR.exists():
         return
 
-    for repo_dir in sorted(GIT_DIR.iterdir()):
-        if repo_dir.is_dir() and repo_dir.name.endswith(".git"):
-            # Derive org_repo name for locking (just need the repo part)
-            repo_name = repo_dir.name[:-4]  # strip .git
-            try:
-                with _repo_lock(f"_/{repo_name}"):
-                    print(f"Updating {repo_dir.name}...")
-                    subprocess.run(
-                        ["git", "-C", str(repo_dir), "fetch", "--all", "--prune"],
-                        check=True,
-                    )
-            except subprocess.CalledProcessError as e:
-                print(f"Warning: failed to update {repo_dir.name}: {e}")
+    for repo_dir in sorted(GIT_DIR.glob("*/*.git")):
+        org_repo = _origin_repo(repo_dir)
+        if not org_repo:
+            print(f"Warning: skipping mirror with invalid origin: {repo_dir}")
+            continue
+        try:
+            with _repo_lock(org_repo):
+                print(f"Updating {org_repo}...")
+                subprocess.run(
+                    ["git", "-C", str(repo_dir), "fetch", "--all", "--prune"],
+                    check=True,
+                )
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: failed to update {org_repo}: {e}")
 
 
 def repo_is_known(org_repo: str) -> bool:
     """Check if a bare repo exists in the git store."""
-    return bare_repo_path(org_repo).exists()
+    return find_existing_mirror(org_repo) is not None

--- a/bubble/hooks/lean.py
+++ b/bubble/hooks/lean.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import click
 
-from ..git_store import parse_github_url
+from ..git_store import canonical_repo, parse_github_url
 from ..lean import LEAN_VERSION_RE
 from ..runtime.base import ContainerRuntime
 from . import GitDependency, Hook
@@ -394,10 +394,10 @@ class LeanHook(Hook):
 
         populated = 0
         for dep in self._git_deps:
-            repo_name = dep.org_repo.split("/")[-1]
+            org_repo = canonical_repo(dep.org_repo)
             # All values are validated (_SAFE_NAME_RE, hex SHA, parse_github_url)
             # but quote everything for defense in depth
-            q_bare = shlex.quote(f"/shared/git/{repo_name}.git")
+            q_bare = shlex.quote(f"/shared/git/{org_repo}.git")
             q_url = shlex.quote(dep.url)
             q_rev = shlex.quote(dep.rev)
             q_pkg = shlex.quote(f"{project_dir}/.lake/packages/{dep.name}")

--- a/bubble/provisioning.py
+++ b/bubble/provisioning.py
@@ -191,15 +191,16 @@ def provision_container(
 
     # Mount dependency bare repos for Lake pre-population via alternates
     if dep_mounts:
-        for repo_name, dep_path in dep_mounts.items():
+        for org_repo, dep_path in dep_mounts.items():
             if str(dep_path) == mount_source:
                 continue  # Don't double-mount the main repo
-            device_name = f"dep-{repo_name}".replace(".", "-").replace("_", "-")[:63]
+            owner, repo_name = org_repo.split("/", 1)
+            device_name = f"dep-{owner}-{repo_name}".replace(".", "-").replace("_", "-")[:63]
             runtime.add_disk(
                 name,
                 device_name,
                 str(dep_path),
-                f"/shared/git/{repo_name}.git",
+                f"/shared/git/{owner}/{repo_name}.git",
                 readonly=True,
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,8 +111,9 @@ def tmp_data_dir(tmp_path, monkeypatch):
 
     data_dir = tmp_path / "bubble"
     data_dir.mkdir()
-    git_dir = data_dir / "git"
-    git_dir.mkdir()
+    git_dir = data_dir / "git" / "github.com"
+    git_dir.mkdir(parents=True)
+    legacy_git_dir = data_dir / "legacy-git"
     registry_file = data_dir / "registry.json"
     config_file = data_dir / "config.toml"
     repos_file = data_dir / "repos.json"
@@ -126,6 +127,7 @@ def tmp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CONFIG_FILE", config_file)
     monkeypatch.setattr(config, "REGISTRY_FILE", registry_file)
     monkeypatch.setattr(config, "GIT_DIR", git_dir)
+    monkeypatch.setattr(config, "LEGACY_GIT_DIR", legacy_git_dir)
     monkeypatch.setattr(config, "REPOS_FILE", repos_file)
     monkeypatch.setattr(config, "CLOUD_STATE_FILE", cloud_state_file)
     monkeypatch.setattr(config, "CLOUD_KEY_FILE", cloud_key_file)
@@ -137,6 +139,9 @@ def tmp_data_dir(tmp_path, monkeypatch):
     # Also patch modules that do `from .config import X` (separate bindings)
     monkeypatch.setattr(lifecycle, "REGISTRY_FILE", registry_file)
     monkeypatch.setattr(git_store, "GIT_DIR", git_dir)
+    monkeypatch.setattr(git_store, "LEGACY_GIT_DIR", legacy_git_dir)
+    monkeypatch.setattr(git_store, "GIT_LOCK_DIR", data_dir / "locks" / "git")
+    monkeypatch.setattr(git_store, "HOST_DATA_DIR", data_dir)
 
     # Patch modules that import DATA_DIR from config
     import bubble.provisioning as provisioning
@@ -210,6 +215,14 @@ def relay_env(tmp_path, monkeypatch):
     importlib.reload(bubble.config)
     importlib.reload(bubble.git_store)
     importlib.reload(bubble.relay)
+    git_dir = tmp_path / "git" / "github.com"
+    monkeypatch.setattr(bubble.config, "HOST_DATA_DIR", tmp_path)
+    monkeypatch.setattr(bubble.config, "GIT_DIR", git_dir)
+    monkeypatch.setattr(bubble.config, "LEGACY_GIT_DIR", tmp_path / "legacy-git")
+    monkeypatch.setattr(bubble.git_store, "GIT_DIR", git_dir)
+    monkeypatch.setattr(bubble.git_store, "LEGACY_GIT_DIR", tmp_path / "legacy-git")
+    monkeypatch.setattr(bubble.git_store, "GIT_LOCK_DIR", tmp_path / "locks" / "git")
+    monkeypatch.setattr(bubble.git_store, "HOST_DATA_DIR", tmp_path)
     return tmp_path
 
 

--- a/tests/test_git_store.py
+++ b/tests/test_git_store.py
@@ -1,16 +1,35 @@
 """Tests for shared git store path/URL generation."""
 
+import subprocess
+
+import pytest
+
+from bubble import git_store
 from bubble.git_store import bare_repo_path, github_url
 
 
 def test_bare_repo_path_lean4(tmp_data_dir):
     path = bare_repo_path("leanprover/lean4")
     assert path.name == "lean4.git"
+    assert path.parent.name == "leanprover"
 
 
 def test_bare_repo_path_mathlib(tmp_data_dir):
     path = bare_repo_path("leanprover-community/mathlib4")
     assert path.name == "mathlib4.git"
+    assert path.parent.name == "leanprover-community"
+
+
+def test_same_short_name_different_owners_do_not_collide(tmp_data_dir):
+    assert bare_repo_path("one/project") != bare_repo_path("two/project")
+
+
+def test_same_short_name_different_owners_use_distinct_locks(tmp_data_dir):
+    with git_store._repo_lock("one/project"):
+        pass
+    with git_store._repo_lock("two/project"):
+        pass
+    assert len(list(git_store.GIT_LOCK_DIR.glob("*.lock"))) == 2
 
 
 def test_github_url():
@@ -20,3 +39,122 @@ def test_github_url():
 def test_github_url_community():
     url = github_url("leanprover-community/mathlib4")
     assert url == "https://github.com/leanprover-community/mathlib4.git"
+
+
+@pytest.mark.parametrize("value", ["owner/..", "../repo", "owner/repo/extra", "owner/re po"])
+def test_invalid_repository_rejected(value, tmp_data_dir):
+    with pytest.raises(ValueError):
+        bare_repo_path(value)
+
+
+def test_legacy_mirror_migrates_when_origin_matches(tmp_data_dir):
+    legacy = git_store.LEGACY_GIT_DIR / "demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/Owner/Demo.git",
+        ],
+        check=True,
+    )
+
+    destination = git_store.init_bare_repo("owner/demo")
+
+    assert destination.is_dir()
+    assert legacy.is_symlink()
+    assert legacy.resolve() == destination
+    assert destination == bare_repo_path("owner/demo")
+
+
+def test_mismatched_legacy_mirror_is_not_adopted(tmp_data_dir):
+    legacy = git_store.LEGACY_GIT_DIR / "demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/someone-else/demo.git",
+        ],
+        check=True,
+    )
+
+    assert not git_store._migrate_legacy_mirror("owner/demo", bare_repo_path("owner/demo"))
+    assert legacy.exists()
+
+
+def test_migration_finds_mixed_case_legacy_name(tmp_data_dir):
+    legacy = git_store.LEGACY_GIT_DIR / "Demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/demo.git",
+        ],
+        check=True,
+    )
+    assert git_store.init_bare_repo("owner/demo") == bare_repo_path("owner/demo")
+    assert legacy.is_symlink()
+
+
+def test_cross_filesystem_migration_leaves_legacy_mirror(tmp_data_dir, monkeypatch):
+    legacy = git_store.LEGACY_GIT_DIR / "demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/demo.git",
+        ],
+        check=True,
+    )
+    monkeypatch.setattr(git_store.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError()))
+
+    assert not git_store._migrate_legacy_mirror("owner/demo", bare_repo_path("owner/demo"))
+    assert legacy.is_dir()
+
+
+def test_origin_lookup_does_not_discover_parent_repo(tmp_data_dir):
+    not_a_repo = tmp_data_dir / "inside-parent"
+    not_a_repo.mkdir()
+    assert git_store._origin_repo(not_a_repo) is None
+
+
+def test_repo_is_known_finds_verified_legacy_mirror(tmp_data_dir):
+    legacy = git_store.LEGACY_GIT_DIR / "demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/demo.git",
+        ],
+        check=True,
+    )
+    assert git_store.repo_is_known("owner/demo")

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1876,6 +1876,27 @@ class TestEditorConfigProvisioning:
         assert "/home/user/.emacs.d/eln-cache" in all_cmds
 
 
+def test_dependency_mirrors_use_owner_qualified_container_paths(mock_runtime, tmp_data_dir):
+    from bubble.provisioning import provision_container
+
+    ref_path = tmp_data_dir / "repo.git"
+    ref_path.mkdir()
+    dep_path = tmp_data_dir / "shared.git"
+    dep_path.mkdir()
+    provision_container(
+        mock_runtime,
+        "test-container",
+        "base",
+        ref_path,
+        "repo.git",
+        {},
+        dep_mounts={"other/shared": dep_path},
+    )
+
+    disk_calls = [c for c in mock_runtime.calls if c[0] == "add_disk"]
+    assert any(call[4] == "/shared/git/other/shared.git" for call in disk_calls)
+
+
 class TestSharedCacheOverlay:
     """Test shared cache overlay provisioning."""
 

--- a/tests/test_reattach_network.py
+++ b/tests/test_reattach_network.py
@@ -110,7 +110,9 @@ class TestRecoverExtraDomains:
     def test_prefers_commit_over_branch(self, tmp_data_dir, monkeypatch):
         # Verify that recovery passes ``commit`` (not ``branch``) as the ref so
         # branch tip drift in the bare mirror doesn't widen the allowlist.
-        bare_repo = tmp_data_dir / "git" / "repo.git"
+        from bubble.git_store import bare_repo_path
+
+        bare_repo = bare_repo_path("owner/repo")
         bare_repo.mkdir(parents=True)
 
         seen_refs = []

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -232,8 +232,8 @@ class TestValidateRelayTarget:
         import bubble.relay
 
         # Create fake bare repo directory
-        git_dir = relay_env / "git"
-        git_dir.mkdir()
+        git_dir = relay_env / "git" / "github.com" / "leanprover"
+        git_dir.mkdir(parents=True)
         (git_dir / "lean4.git").mkdir()
 
         # Also need a repos.json for the registry
@@ -246,8 +246,8 @@ class TestValidateRelayTarget:
     def test_valid_pr_target(self, relay_env):
         import bubble.relay
 
-        git_dir = relay_env / "git"
-        git_dir.mkdir()
+        git_dir = relay_env / "git" / "github.com" / "leanprover"
+        git_dir.mkdir(parents=True)
         (git_dir / "lean4.git").mkdir()
         repos_file = relay_env / "repos.json"
         repos_file.write_text("{}")

--- a/tests/test_toolchain_image_selection.py
+++ b/tests/test_toolchain_image_selection.py
@@ -39,6 +39,7 @@ def _init_origin(path, toolchain):
 
 
 def _mirror_from(origin, mirror):
+    mirror.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         ["git", "clone", "--bare", "-q", str(origin), str(mirror)],
         check=True,


### PR DESCRIPTION
## Summary

- store trusted GitHub mirrors in a host-global, owner-qualified directory
- serialize clone, migration, and fetch operations with host-global repository locks
- safely migrate verified legacy mirrors while retaining compatibility links for existing stopped bubbles
- mount dependency mirrors by owner and repository to avoid short-name collisions

## Compatibility and safety

- mirror origins are verified before legacy migration
- cross-device migration falls back to a fresh atomic clone
- unrelated Bubble homes retain their private configuration and container state
- old stopped containers continue to see migrated mirrors through legacy compatibility links

## Validation

- uvx --from ruff==0.16.0 ruff format --check bubble/ tests/
- uvx --from ruff==0.16.0 ruff check bubble/ tests/
- uv run pytest -q -m "not integration" (1313 passed, 7 skipped, 14 deselected)
- independent Claude Opus review completed; actionable compatibility findings addressed