### PR TITLE
Fix legacy Git mirror migration

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -111,13 +111,18 @@ git clone --bare https://github.com/owner/repo.git ~/.bubble/git/github.com/owne
 Then configure fetch refs:
 
 ```
-git -C ~/.bubble/git/github.com/owner/repo.git config remote.origin.fetch '+refs/heads/*:refs/heads/*'
+git -C ~/.bubble/git/github.com/owner/repo.git config --replace-all remote.origin.fetch '+refs/heads/*:refs/heads/*'
 git -C ~/.bubble/git/github.com/owner/repo.git config --add remote.origin.fetch '+refs/tags/*:refs/tags/*'
 git -C ~/.bubble/git/github.com/owner/repo.git config --add remote.origin.fetch '+refs/pull/*/head:refs/pull/*/head'
 ```
 
 The bare repo path is derived from the normalized full repository identity:
 `~/.bubble/git/github.com/<owner>/<repo>.git`.
+
+Older flat mirrors at `~/.bubble/git/<repo>.git` are adopted only when their
+origin matches the requested owner and repository. Migration is atomic, leaves
+a compatibility symlink at the flat path, and preserves the previous Git config
+if updating its fetch rules fails.
 
 **PR ref fetching:** When the target is a PR, fetch the specific ref:
 
@@ -600,10 +605,10 @@ Writes MUST be atomic (write to temp file, rename).
 
 ### 4.4 `bubble git update`
 
-Update all bare repos in `~/.bubble/git/`:
+Update all nested bare repos in `~/.bubble/git/github.com/`:
 
 ```
-git -C ~/.bubble/git/<repo>.git fetch --all --prune
+git -C ~/.bubble/git/github.com/<owner>/<repo>.git fetch --all --prune
 ```
 
 For each `*.git` directory found. Uses per-repo file locking.

--- a/bubble/git_store.py
+++ b/bubble/git_store.py
@@ -119,6 +119,12 @@ def _migrate_legacy_mirror(org_repo: str, destination: Path) -> bool:
     for candidate in _legacy_candidates(org_repo):
         if _origin_repo(candidate) != canonical_repo(org_repo):
             continue
+        config_path = candidate / "config"
+        try:
+            original_config = config_path.read_bytes()
+            original_config_mode = config_path.stat().st_mode
+        except OSError:
+            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
         try:
             os.replace(candidate, destination)
@@ -126,7 +132,24 @@ def _migrate_legacy_mirror(org_repo: str, destination: Path) -> bool:
             # A custom BUBBLE_HOME can live on another filesystem. Keep its
             # mirror intact and let the caller atomically clone a fresh copy.
             continue
-        _configure_mirror(destination)
+        try:
+            _configure_mirror(destination)
+        except BaseException as error:
+            try:
+                _restore_mirror_config(destination, original_config, original_config_mode)
+            except OSError as restore_error:
+                try:
+                    os.replace(destination, candidate)
+                except OSError:
+                    print(f"Warning: failed to roll back Git mirror migration for {org_repo}")
+                raise error from restore_error
+            if not isinstance(error, Exception):
+                os.replace(destination, candidate)
+                raise
+            print(
+                f"Warning: could not update fetch rules for {org_repo}; "
+                "using the legacy mirror's existing configuration"
+            )
         try:
             candidate.symlink_to(destination, target_is_directory=True)
         except OSError:
@@ -135,9 +158,32 @@ def _migrate_legacy_mirror(org_repo: str, destination: Path) -> bool:
     return False
 
 
+def _restore_mirror_config(path: Path, contents: bytes, mode: int) -> None:
+    """Atomically restore a mirror config after a partial `git config` failure."""
+    fd, temporary_name = tempfile.mkstemp(prefix=".bubble-config-", dir=path)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as output:
+            output.write(contents)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temporary, mode & 0o7777)
+        os.replace(temporary, path / "config")
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def _configure_mirror(path: Path) -> None:
     subprocess.run(
-        ["git", "-C", str(path), "config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
+        [
+            "git",
+            "-C",
+            str(path),
+            "config",
+            "--replace-all",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/heads/*",
+        ],
         check=True,
     )
     subprocess.run(
@@ -332,9 +378,12 @@ def update_all_repos():
         destination = bare_repo_path(org_repo)
         if destination.exists():
             continue
-        with _repo_lock(org_repo):
-            if not destination.exists():
-                _migrate_legacy_mirror(org_repo, destination)
+        try:
+            with _repo_lock(org_repo):
+                if not destination.exists():
+                    _migrate_legacy_mirror(org_repo, destination)
+        except Exception as error:
+            print(f"Warning: failed to migrate Git mirror for {org_repo}: {error}")
 
     if not GIT_DIR.exists():
         return

--- a/tests/test_git_store.py
+++ b/tests/test_git_store.py
@@ -63,6 +63,7 @@ def test_legacy_mirror_migrates_when_origin_matches(tmp_data_dir):
         ],
         check=True,
     )
+    git_store._configure_mirror(legacy)
 
     destination = git_store.init_bare_repo("owner/demo")
 
@@ -110,6 +111,177 @@ def test_migration_finds_mixed_case_legacy_name(tmp_data_dir):
         check=True,
     )
     assert git_store.init_bare_repo("owner/demo") == bare_repo_path("owner/demo")
+    assert legacy.is_symlink()
+
+
+def test_configure_mirror_replaces_existing_fetch_refspecs(tmp_path):
+    mirror = tmp_path / "demo.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(mirror)], check=True)
+    for refspec in ("first", "second"):
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(mirror),
+                "config",
+                "--add",
+                "remote.origin.fetch",
+                refspec,
+            ],
+            check=True,
+        )
+
+    git_store._configure_mirror(mirror)
+
+    result = subprocess.run(
+        ["git", "-C", str(mirror), "config", "--get-all", "remote.origin.fetch"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.splitlines() == [
+        "+refs/heads/*:refs/heads/*",
+        "+refs/tags/*:refs/tags/*",
+        "+refs/pull/*/head:refs/pull/*/head",
+    ]
+
+
+def test_migration_restores_config_when_configuration_fails(tmp_data_dir, monkeypatch, capsys):
+    legacy = git_store.LEGACY_GIT_DIR / "Demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/demo.git",
+        ],
+        check=True,
+    )
+    git_store._configure_mirror(legacy)
+    original_config = (legacy / "config").read_bytes()
+    destination = bare_repo_path("owner/demo")
+
+    def partially_configure(path):
+        subprocess.run(
+            ["git", "-C", str(path), "config", "--replace-all", "remote.origin.fetch", "partial"],
+            check=True,
+        )
+        raise subprocess.CalledProcessError(1, "git")
+
+    monkeypatch.setattr(
+        git_store,
+        "_configure_mirror",
+        partially_configure,
+    )
+
+    assert git_store._migrate_legacy_mirror("owner/demo", destination)
+
+    assert legacy.is_symlink()
+    assert destination.is_dir()
+    assert (destination / "config").read_bytes() == original_config
+    assert "existing configuration" in capsys.readouterr().out
+
+
+def test_migration_rolls_back_on_keyboard_interrupt(tmp_data_dir, monkeypatch):
+    legacy = git_store.LEGACY_GIT_DIR / "demo.git"
+    legacy.parent.mkdir(parents=True)
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/demo.git",
+        ],
+        check=True,
+    )
+    original_config = (legacy / "config").read_bytes()
+    destination = bare_repo_path("owner/demo")
+
+    def interrupt_configuration(path):
+        subprocess.run(
+            ["git", "-C", str(path), "config", "--replace-all", "remote.origin.fetch", "partial"],
+            check=True,
+        )
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(git_store, "_configure_mirror", interrupt_configuration)
+
+    with pytest.raises(KeyboardInterrupt):
+        git_store._migrate_legacy_mirror("owner/demo", destination)
+
+    assert legacy.is_dir()
+    assert not destination.exists()
+    assert (legacy / "config").read_bytes() == original_config
+
+
+def test_update_all_repos_isolates_migration_failure(tmp_data_dir, monkeypatch, capsys):
+    for name in ("bad", "good"):
+        legacy = git_store.LEGACY_GIT_DIR / f"{name}.git"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(legacy),
+                "remote",
+                "add",
+                "origin",
+                f"https://github.com/owner/{name}.git",
+            ],
+            check=True,
+        )
+    migrate = git_store._migrate_legacy_mirror
+
+    def migrate_with_failure(org_repo, destination):
+        if org_repo == "owner/bad":
+            raise OSError("broken migration")
+        return migrate(org_repo, destination)
+
+    monkeypatch.setattr(
+        git_store,
+        "_migrate_legacy_mirror",
+        migrate_with_failure,
+    )
+
+    git_store.update_all_repos()
+
+    assert "failed to migrate Git mirror for owner/bad" in capsys.readouterr().out
+    assert (git_store.LEGACY_GIT_DIR / "bad.git").is_dir()
+    assert (git_store.LEGACY_GIT_DIR / "good.git").is_symlink()
+    assert bare_repo_path("owner/good").is_dir()
+
+
+def test_migration_from_default_flat_layout(tmp_data_dir, monkeypatch):
+    monkeypatch.setattr(git_store, "LEGACY_GIT_DIR", git_store.GIT_DIR.parent)
+    legacy = git_store.GIT_DIR.parent / "Demo.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(legacy)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(legacy),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/demo.git",
+        ],
+        check=True,
+    )
+
+    destination = git_store.init_bare_repo("owner/demo")
+
+    assert destination == bare_repo_path("owner/demo")
+    assert destination.is_dir()
     assert legacy.is_symlink()
 
 


### PR DESCRIPTION
## Summary

- replace all existing Git fetch refspecs when adopting legacy flat mirrors
- preserve the original mirror config atomically if migration configuration fails
- isolate periodic migration failures so other mirrors still update
- document and test the historical three-refspec and default-layout upgrade paths

## Validation

- `uvx --from ruff==0.16.0 ruff format --check bubble/git_store.py tests/test_git_store.py`
- `uvx --from ruff==0.16.0 ruff check bubble/git_store.py tests/test_git_store.py`
- `uv run pytest -q` (1326 passed, 21 skipped)
- independent Claude Opus review, with substantive findings addressed