### PR TITLE
Add host-global Lean artifact cache

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,7 +58,7 @@ The primary command is `bubble <target>`. A custom `BubbleGroup(click.Group)` ro
 Short names are resolved via `RepoRegistry`, which learns mappings automatically on first use. Local paths use the local `.git` as the `--reference` source for fast cloning, and support unpushed branches by fetching refs from the mounted local repo.
 
 ### Language Hooks
-The `hooks/` package provides a pluggable system for language-specific behavior. Each `Hook` subclass implements `detect()` (check bare repo for language markers), `image_name()`, `post_clone()`, `network_domains()`, and `shared_mounts()`. Hook detection runs against the host bare repo via `git show <ref>:<file>` — no container needed. The `shared_mounts()` method returns `(host_dir_name, container_path, env_var)` tuples for writable mounts shared across containers (e.g., Lean's mathlib cache at `~/.bubble/mathlib-cache/`).
+The `hooks/` package provides a pluggable system for language-specific behavior. Each `Hook` subclass implements `detect()` (check bare repo for language markers), `image_name()`, `post_clone()`, `network_domains()`, and `shared_mounts()`. Hook detection runs against the host bare repo via `git show <ref>:<file>` — no container needed. The `shared_mounts()` method returns `(host_dir_name, container_path, env_var)` tuples for local working caches; `uses_mathlib_cache()` separately opts a hook into the host-global GET-only upstream cache.
 
 ### Runtime Abstraction
 `ContainerRuntime` (base.py) is an abstract interface. `IncusRuntime` is the only implementation today. Docker/Podman support is a stretch goal — the abstraction exists to make that possible without refactoring.
@@ -204,6 +204,10 @@ Always use `uv run pytest` to run tests (not bare `pytest` or `python3 -m pytest
 - `~/.bubble/auth-tokens.json` — auth proxy token→{container, owner, repo} mapping (mode 0600)
 - `~/.bubble/auth-proxy.port` — auth proxy daemon TCP port
 - `~/.bubble/auth-proxy.log` — auth proxy request log
+- `~/.bubble/artifact-cache/` — host-global, LRU-bounded public artifact responses
+- `~/.bubble/artifact-cache-tokens.json` — per-container immutable upstream route grants
+- `~/.bubble/artifact-cache.endpoint` — bridge listener metadata for the cache daemon
+- `~/.bubble/artifact-cache.log` — artifact-cache request log
 - `~/.bubble/tunnels/` — SSH tunnel PID files (keyed by remote host spec)
 - `~/.bubble/cloud.json` — Hetzner Cloud server state (ID, IP, SSH key ID)
 - `~/.bubble/cloud_key` — SSH private key for cloud server (ed25519, mode 0600)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 
 **Language hooks**: bubble automatically detects the project's language and selects the right image. For Lean 4 projects (detected via `lean-toolchain`), the container includes elan, pre-installed VS Code extensions, and auto-downloads the mathlib cache when needed.
 
+**Host-global artifact cache**: Mathlib downloads are routed through a host daemon that accepts only `GET`/`HEAD`, caches successful public responses, and is shared across isolated `BUBBLE_HOME` stores. Mathlib's current and legacy stores are tried in order. Projects with their own anonymous Lake cache can opt in explicitly:
+
+```bash
+bubble TauCetiProject/TauCeti \
+  --lake-cache-service tauceti-public \
+  https://example.invalid/artifacts \
+  https://example.invalid/revisions
+```
+
+Bubble writes the matching Lake system configuration inside the container. The upstream URLs stay host-side; the container receives a per-bubble read capability and cannot upload or choose another origin.
+
 **Network allowlisting**: Containers can only reach allowed domains (language-specific domains like `releases.lean-lang.org` for Lean, plus any configured in `~/.bubble/config.toml`). Direct GitHub access is blocked by iptables — all GitHub traffic is forced through the auth proxy, which enforces repo-scoping and rate limits. IPv6 is blocked, DNS is restricted to the container resolver, and outbound SSH is blocked.
 
 ## Requirements
@@ -129,6 +140,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 | `bubble pop <name>` | Pop a bubble (delete permanently) |
 | `bubble cleanup` | Pop all clean bubbles (no unsaved work) |
 | `bubble images list\|build\|delete\|prune` | Manage base images |
+| `bubble cache status\|start\|stop\|prune\|clear` | Manage the host-global artifact cache |
 | `bubble git update` | Refresh shared git mirrors |
 | `bubble network apply\|remove <name>` | Manage network restrictions |
 | `bubble automation install\|remove\|status` | Manage periodic jobs |
@@ -154,6 +166,7 @@ Each "bubble" is a lightweight Linux container (via Incus) with:
 - **Bubble-in-bubble relay**: Containers can open new bubbles on the host, but only for repos already cloned in `~/.bubble/git/`. Disable with `bubble security set relay off`
 - **GitHub auth proxy**: Host token never enters containers. Git and REST API are repo-scoped. **GraphQL queries are read-only but account-wide** — can read any data the host token can access. API access can be set to `off`, `on` (read-only, the default), or `read-write` (enables mutations) via `bubble security set github-api`
 - **Shared Lean caches**: Mathlib's `lake exe cache` cache at `~/.bubble/mathlib-cache/` and Lake's built-in artifact cache at `~/.bubble/lake-cache/` are shared across Lean containers. Modes: `on` (default) = read-write (a compromised container could poison cached artifacts), `off` = read-only (prevents poisoning), `overlay` = per-container writable views with isolated writes (overlayfs on Linux; clonefile-seeded writable copies on macOS/Colima, where overlayfs can't run over virtiofs). These caches are *not* shared with cache commands run outside a bubble. Configure with `bubble security set shared-cache`. If you suspect poisoning, delete the corresponding cache directory.
+- **GET-only upstream cache**: Public Mathlib and explicitly configured Lake downloads also pass through the host-global cache at `~/.bubble/artifact-cache/`. Supported routes are revision- or content-addressed and therefore immutable. The cache is bounded to 50 GiB by default, validates per-container route grants, follows no redirects, accepts no query-selected origins, and rejects every upload method. Manage it with `bubble cache`; customize it with `[artifact_cache] max_size = "100GiB"`, or disable proxy setup with `[artifact_cache] enabled = false` (direct public downloads remain available).
 
 ## Images
 
@@ -181,7 +194,7 @@ Set `BUBBLE_HOME` to override the data directory (default: `~/.bubble`):
 export BUBBLE_HOME=/data/bubble
 ```
 
-This isolates configuration and per-bubble state. Incus images, trusted Git mirrors, host daemons, and their coordination locks remain host-global and are safely shared by build or repository identity.
+This isolates configuration and per-bubble state. Incus images, trusted Git mirrors, the GET-only artifact cache, host daemons, and their coordination locks remain host-global and are safely shared by build, repository, or upstream-response identity. Configure the host-global cache's `max_size` and `port` in the real login home's `~/.bubble/config.toml`, not an isolated `BUBBLE_HOME`.
 
 ```toml
 [runtime]

--- a/SPEC.md
+++ b/SPEC.md
@@ -49,6 +49,7 @@ equivalent to `bubble open <url>`.
 | `--no-interactive` | flag | | Create but don't attach |
 | `--machine-readable` | flag (hidden) | | Output JSON for orchestration |
 | `--network/--no-network` | flag | `--network` | Apply network allowlist |
+| `--lake-cache-service NAME ARTIFACT_URL REVISION_URL` | triple (repeatable) | | Add an anonymous Lake download service through the host-global cache (local only) |
 | `--name` | string | | Custom container name |
 | `--command` | string | | Run command via SSH (implies shell) |
 | `--path` | flag | | Force interpretation as local path |
@@ -364,6 +365,27 @@ of the versioned image for next time.
 > If you suspect the cache has already been compromised, delete
 > `~/.bubble/mathlib-cache/`.
 
+**Host-global upstream cache:** Bubble MUST route Mathlib's anonymous downloads
+through a host-global HTTP cache, independent of `BUBBLE_HOME`. The container
+receives a per-container unguessable capability URL in
+`MATHLIB_CACHE_GET_URL`; it never receives an upstream URL. The route tries the
+current `mathlib4-master` Azure container and then the legacy `mathlib4`
+container on a 404. The daemon accepts `GET` and `HEAD` only, follows no
+redirects, caches only successful responses atomically, preserves response
+content types, bounds storage with LRU eviction (50 GiB by default), and
+revokes the capability when the bubble is popped. Every supported cache path
+is revision- or content-addressed and treated as immutable. Set
+`[artifact_cache] enabled = false` to skip proxy setup and use direct public
+downloads instead.
+
+`--lake-cache-service NAME ARTIFACT_URL REVISION_URL` adds a named anonymous
+Lake S3-style download service. Bubble validates both upstreams as plain HTTPS
+base URLs, grants separate artifact and revision routes, writes a Lake system
+configuration at Lake's default `~/.lake/config.toml` path inside the container,
+and sets `LAKE_ARTIFACT_CACHE=true` and `LAKE_RESTORE_ARTIFACTS=true`. Multiple services
+are allowed; the first is the generated default. The flag is creation-only and
+local-only. It does not grant PUT/POST access or configure an upload key.
+
 **Post-clone behavior:**
 - Pre-populate Lake dependencies from `lake-manifest.json` (see 2.4)
 - Write auto-build command to `~/.bubble-fetch-cache` marker file
@@ -372,8 +394,13 @@ of the versioned image for next time.
 - For other Lean projects: `cd <dir> && lake build`
 
 **Network domains:** `releases.lean-lang.org`, `reservoir.lean-lang.org`,
-`reservoir.lean-cache.cloud`, `mathlib4.lean-cache.cloud`,
-`lakecache.blob.core.windows.net`
+`reservoir.lean-cache.cloud`, `mathlib4.lean-cache.cloud`, and
+`lakecache.blob.core.windows.net`. The public cache hosts remain a direct
+fallback if the optional host daemon cannot start during bubble creation;
+successful proxy setup directs normal Mathlib traffic through the host-global
+cache. The supervised daemon restarts automatically after crashes. Explicitly
+running `bubble cache stop` warns that cache downloads in existing bubbles will
+fail until `bubble cache start` is run.
 
 ### 2.3 Python hook
 
@@ -1232,6 +1259,10 @@ container lifecycle, but a complete implementation should include them:
 | `~/.bubble/auth-tokens.json` | Auth proxy tokens (mode 0600) |
 | `~/.bubble/auth-proxy.port` | Auth proxy TCP port |
 | `~/.bubble/auth-proxy.log` | Auth proxy request log |
+| `~/.bubble/artifact-cache/` | Host-global GET-only upstream response cache |
+| `~/.bubble/artifact-cache-tokens.json` | Per-container cache route capabilities (mode 0600) |
+| `~/.bubble/artifact-cache.endpoint` | Artifact-cache daemon bridge endpoint |
+| `~/.bubble/artifact-cache.log` | Artifact-cache request log |
 | `~/.bubble/tunnels/` | SSH tunnel PID files |
 | `~/.bubble/mathlib-cache/` | Shared mathlib cache |
 | `~/.bubble/vscode-commit` | VS Code commit hash in current base image |

--- a/bubble/artifact_cache.py
+++ b/bubble/artifact_cache.py
@@ -1,0 +1,979 @@
+"""Host-global, capability-scoped, GET-only artifact cache.
+
+The daemon is deliberately separate from Bubble's GitHub auth proxy: public
+Lean caches must keep working when ``security.github=off`` or the host has no
+GitHub credential.  Containers receive an unguessable URL capability whose
+routes are fixed by the trusted host-side Bubble process.  A request cannot
+choose an arbitrary upstream URL.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import threading
+import time
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+
+from . import __version__
+from .config import HOST_DATA_DIR
+from .token_store import TokenStore, setup_file_logging
+
+DEFAULT_PORT = 7655
+DEFAULT_MAX_BYTES = 50 * 1024**3
+DEFAULT_MAX_OBJECT_BYTES = 4 * 1024**3
+MAX_ERROR_BODY = 1024 * 1024
+
+ARTIFACT_CACHE_DIR = HOST_DATA_DIR / "artifact-cache"
+ARTIFACT_CACHE_OBJECTS = ARTIFACT_CACHE_DIR / "objects"
+ARTIFACT_CACHE_TOKENS = HOST_DATA_DIR / "artifact-cache-tokens.json"
+ARTIFACT_CACHE_ENDPOINT_FILE = HOST_DATA_DIR / "artifact-cache.endpoint"
+ARTIFACT_CACHE_LOG = HOST_DATA_DIR / "artifact-cache.log"
+ARTIFACT_CACHE_LOCK = HOST_DATA_DIR / "locks" / "artifact-cache.lock"
+
+# Mathlib's Cache/Requests.lean gives MATHLIB_CACHE_GET_URL precedence, and
+# Cache/Infra.lean defines this current-primary then legacy Azure chain.
+MATHLIB_CACHE_ENDPOINTS = (
+    "https://lakecache.blob.core.windows.net/mathlib4-master",
+    "https://lakecache.blob.core.windows.net/mathlib4",
+)
+
+_SAFE_ROUTE_RE = re.compile(r"^[a-z][a-z0-9-]{0,62}$")
+_TOKEN_RE = re.compile(r"^[0-9a-f]{64}$")
+_STRIPPED_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "date",
+    "server",
+}
+
+logger = logging.getLogger("bubble.artifact_cache")
+
+
+def load_host_artifact_config() -> dict:
+    """Load host-global cache settings, independent of the caller's BUBBLE_HOME."""
+    try:
+        try:
+            import tomllib
+        except ModuleNotFoundError:  # Python 3.10
+            import tomli as tomllib
+
+        with open(HOST_DATA_DIR / "config.toml", "rb") as source:
+            config = tomllib.load(source)
+        section = config.get("artifact_cache", {})
+        return section if isinstance(section, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+@dataclass(frozen=True)
+class LakeCacheService:
+    """A named Lake download service supplied by the trusted Bubble caller."""
+
+    name: str
+    artifact_endpoint: str
+    revision_endpoint: str
+
+
+def validate_lake_service(
+    name: str, artifact_endpoint: str, revision_endpoint: str
+) -> LakeCacheService:
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9._-]{0,62}", name):
+        raise ValueError(f"invalid Lake cache service name: {name!r}")
+    return LakeCacheService(
+        name=name,
+        artifact_endpoint=normalize_endpoint(artifact_endpoint),
+        revision_endpoint=normalize_endpoint(revision_endpoint),
+    )
+
+
+def normalize_endpoint(endpoint: str) -> str:
+    """Validate and normalize a trusted upstream HTTPS base URL."""
+    value = endpoint.strip().rstrip("/")
+    parsed = urlparse(value)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"artifact cache endpoint has an invalid port: {endpoint}") from exc
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or port == 0
+    ):
+        raise ValueError(f"artifact cache endpoint must be a plain HTTPS base URL: {endpoint}")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+        raise ValueError("artifact cache endpoint contains control characters")
+    return value
+
+
+def normalize_routes(routes: dict[str, list[str] | tuple[str, ...]]) -> dict[str, list[str]]:
+    """Validate the immutable route table stored behind a capability token."""
+    result: dict[str, list[str]] = {}
+    for name, endpoints in routes.items():
+        if not _SAFE_ROUTE_RE.fullmatch(name):
+            raise ValueError(f"invalid artifact cache route name: {name!r}")
+        normalized = list(dict.fromkeys(normalize_endpoint(url) for url in endpoints))
+        if not normalized:
+            raise ValueError(f"artifact cache route {name!r} has no upstream endpoints")
+        result[name] = normalized
+    if not result:
+        raise ValueError("artifact cache capability must contain at least one route")
+    return result
+
+
+def generate_cache_token(
+    container_name: str,
+    routes: dict[str, list[str] | tuple[str, ...]],
+    *,
+    mathlib: bool = False,
+    lake_service_names: tuple[str, ...] = (),
+) -> str:
+    """Issue a per-container capability for an exact set of upstream routes."""
+    return TokenStore(ARTIFACT_CACHE_TOKENS).generate(
+        {
+            "container": container_name,
+            "routes": normalize_routes(routes),
+            "mathlib": mathlib,
+            "lake_service_names": list(lake_service_names),
+        }
+    )
+
+
+def remove_cache_tokens(container_name: str) -> None:
+    """Revoke all artifact-cache capabilities belonging to a container."""
+    TokenStore(ARTIFACT_CACHE_TOKENS).remove(lambda value: value.get("container") == container_name)
+
+
+def container_has_cache_token(container_name: str) -> bool:
+    """Whether a live registry entry grants this container cache access."""
+    return any(
+        value.get("container") == container_name
+        for value in TokenStore(ARTIFACT_CACHE_TOKENS).values()
+    )
+
+
+def container_cache_capability(container_name: str) -> tuple[str, dict] | None:
+    """Return one active ``(token, grant)`` pair for a container."""
+    for token, value in TokenStore(ARTIFACT_CACHE_TOKENS).items():
+        if value.get("container") == container_name:
+            return token, value
+    return None
+
+
+class CacheTokenRegistry:
+    def __init__(self):
+        self._store = TokenStore(ARTIFACT_CACHE_TOKENS)
+
+    def lookup(self, token: str) -> dict | None:
+        return self._store.lookup(token)
+
+
+class CacheRateLimiter:
+    """O(1)-amortized sliding windows sized for concurrent full restores."""
+
+    def __init__(
+        self,
+        windows: tuple[tuple[int, int], ...] = ((60, 60_000), (3600, 200_000)),
+        max_tracked: int = 1000,
+    ):
+        self._windows = windows
+        self._max_tracked = max_tracked
+        self._requests: dict[str, list[deque[float]]] = {}
+        self._last_seen: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def check(self, key: str) -> bool:
+        now = time.time()
+        with self._lock:
+            if key not in self._requests and len(self._requests) >= self._max_tracked:
+                oldest = min(self._last_seen, key=self._last_seen.get)
+                self._requests.pop(oldest, None)
+                self._last_seen.pop(oldest, None)
+            queues = self._requests.setdefault(key, [deque() for _ in self._windows])
+            self._last_seen[key] = now
+            for queue, (seconds, maximum) in zip(queues, self._windows, strict=True):
+                cutoff = now - seconds
+                while queue and queue[0] <= cutoff:
+                    queue.popleft()
+                if len(queue) >= maximum:
+                    return False
+            for queue in queues:
+                queue.append(now)
+            return True
+
+
+def _cache_paths(upstream_url: str) -> tuple[Path, Path]:
+    digest = hashlib.sha256(upstream_url.encode()).hexdigest()
+    directory = ARTIFACT_CACHE_OBJECTS / digest[:2]
+    return directory / f"{digest}.body", directory / f"{digest}.json"
+
+
+@contextmanager
+def _store_lock():
+    ARTIFACT_CACHE_LOCK.parent.mkdir(parents=True, exist_ok=True)
+    with open(ARTIFACT_CACHE_LOCK, "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+
+
+def cache_stats() -> tuple[int, int]:
+    """Return ``(object_count, bytes)`` for completed cached response bodies."""
+    count = 0
+    total = 0
+    if not ARTIFACT_CACHE_OBJECTS.exists():
+        return count, total
+    for path in ARTIFACT_CACHE_OBJECTS.glob("*/*.body"):
+        try:
+            total += path.stat().st_size
+            count += 1
+        except OSError:
+            pass
+    return count, total
+
+
+def cleanup_stale_temps(max_age_seconds: int = 3600) -> tuple[int, int]:
+    """Remove abandoned in-flight files, returning ``(count, bytes)``."""
+    cutoff = time.time() - max_age_seconds
+    count = 0
+    total = 0
+    if not ARTIFACT_CACHE_OBJECTS.exists():
+        return count, total
+    for path in ARTIFACT_CACHE_OBJECTS.glob("*/.*.tmp"):
+        try:
+            stat = path.stat()
+            if stat.st_mtime > cutoff:
+                continue
+            path.unlink()
+            count += 1
+            total += stat.st_size
+        except OSError:
+            pass
+    return count, total
+
+
+def prune_cache(max_bytes: int, *, execute: bool = True) -> tuple[int, int]:
+    """Evict least-recently-used objects until the store fits ``max_bytes``.
+
+    Returns ``(objects_selected, bytes_selected)``. Access time is represented
+    by body-file mtime, explicitly touched on every hit so this works even on
+    filesystems mounted with ``noatime``.
+    """
+    if max_bytes < 0:
+        raise ValueError("cache size cannot be negative")
+    if execute:
+        cleanup_stale_temps()
+    with _store_lock():
+        entries: list[tuple[float, int, Path, Path]] = []
+        total = 0
+        if ARTIFACT_CACHE_OBJECTS.exists():
+            for body in ARTIFACT_CACHE_OBJECTS.glob("*/*.body"):
+                try:
+                    stat = body.stat()
+                except OSError:
+                    continue
+                meta = body.with_suffix(".json")
+                entries.append((stat.st_mtime, stat.st_size, body, meta))
+                total += stat.st_size
+        selected: list[tuple[int, Path, Path]] = []
+        for _, size, body, meta in sorted(entries):
+            if total <= max_bytes:
+                break
+            selected.append((size, body, meta))
+            total -= size
+        if execute:
+            for _, body, meta in selected:
+                body.unlink(missing_ok=True)
+                meta.unlink(missing_ok=True)
+        return len(selected), sum(size for size, _, _ in selected)
+
+
+def clear_cache() -> tuple[int, int]:
+    """Delete every completed cache object, returning the previous statistics."""
+    with _store_lock():
+        stats = cache_stats()
+        shutil.rmtree(ARTIFACT_CACHE_OBJECTS, ignore_errors=True)
+        return stats
+
+
+def _load_cached(body: Path, meta: Path) -> dict | None:
+    try:
+        if not body.is_file():
+            return None
+        data = json.loads(meta.read_text())
+        if not isinstance(data.get("headers"), dict):
+            return None
+        os.utime(body, None)
+        return data
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+# One lazy process-wide, thread-safe client keeps upstream TLS connections
+# alive. Mathlib restores contain thousands of small objects, so creating a new
+# TLS connection for each object is prohibitively slow on high-latency links.
+_UPSTREAM_CLIENT = None
+_UPSTREAM_CLIENT_LOCK = threading.Lock()
+
+
+def _upstream_client():
+    global _UPSTREAM_CLIENT
+    if _UPSTREAM_CLIENT is None:
+        with _UPSTREAM_CLIENT_LOCK:
+            if _UPSTREAM_CLIENT is None:
+                # Redirects remain disabled so a configured origin cannot
+                # redirect the proxy outside its exact allowlist. Environment
+                # proxies are also ignored for the same reason.
+                _UPSTREAM_CLIENT = httpx.Client(
+                    http2=True,
+                    follow_redirects=False,
+                    trust_env=False,
+                    headers={"User-Agent": "bubble"},
+                    limits=httpx.Limits(
+                        max_connections=64,
+                        max_keepalive_connections=64,
+                        keepalive_expiry=60,
+                    ),
+                    timeout=httpx.Timeout(120, connect=15),
+                )
+    return _UPSTREAM_CLIENT
+
+
+def _close_upstream_client() -> None:
+    global _UPSTREAM_CLIENT
+    with _UPSTREAM_CLIENT_LOCK:
+        client = _UPSTREAM_CLIENT
+        _UPSTREAM_CLIENT = None
+    if isinstance(client, httpx.Client):
+        client.close()
+
+
+class ArtifactCacheHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    timeout = 60
+    token_registry: CacheTokenRegistry
+    rate_limiter: CacheRateLimiter
+    peer_rate_limiter: CacheRateLimiter
+    max_bytes = DEFAULT_MAX_BYTES
+    max_object_bytes = DEFAULT_MAX_OBJECT_BYTES
+    cache_bytes = 0
+    _usage_lock = threading.Lock()
+    _prune_running = False
+    _key_locks: dict[str, list] = {}
+    _key_locks_guard = threading.Lock()
+
+    def log_message(self, format, *args):
+        logger.info(format, *args)
+
+    def log_error(self, format, *args):
+        """Log parser errors without a capability-bearing request line."""
+        logger.warning(format, *args)
+
+    def log_request(self, code="-", size="-"):
+        """Suppress BaseHTTPRequestHandler's capability-bearing request line."""
+
+    def _error(self, status: int, message: str) -> None:
+        body = (message + "\n").encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _route(self) -> tuple[str, list[str], str] | None:
+        if not self.peer_rate_limiter.check(self.client_address[0]):
+            self._error(429, "artifact cache peer request limit exceeded")
+            return None
+        parsed = urlparse(self.path)
+        if parsed.query or parsed.fragment:
+            self._error(400, "cache URLs do not accept query strings or fragments")
+            return None
+        parts = parsed.path.split("/", 4)
+        if len(parts) < 4 or parts[:2] != ["", "cache"]:
+            self._error(404, "unknown cache route")
+            return None
+        token, route = parts[2], parts[3]
+        suffix = parts[4] if len(parts) == 5 else ""
+        if not _TOKEN_RE.fullmatch(token) or not _SAFE_ROUTE_RE.fullmatch(route):
+            self._error(403, "invalid cache capability")
+            return None
+        lower = suffix.lower()
+        if "%2f" in lower or "%5c" in lower or "%2e" in lower or "\\" in suffix:
+            self._error(400, "encoded path separators are not allowed")
+            return None
+        if any(part in (".", "..") for part in suffix.split("/")):
+            self._error(400, "dot path segments are not allowed")
+            return None
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in suffix):
+            self._error(400, "control characters are not allowed")
+            return None
+        if len(suffix) > 4096 or not re.fullmatch(r"[A-Za-z0-9._~%/-]*", suffix):
+            self._error(400, "cache path contains unsupported characters")
+            return None
+        info = self.token_registry.lookup(token)
+        routes = info.get("routes") if info else None
+        endpoints = routes.get(route) if isinstance(routes, dict) else None
+        if not isinstance(endpoints, list) or not endpoints:
+            self._error(403, "cache route is not granted by this capability")
+            return None
+        container = str(info.get("container", "unknown"))
+        if not self.rate_limiter.check(container):
+            self._error(429, "artifact cache request limit exceeded")
+            return None
+        return container, endpoints, suffix
+
+    @classmethod
+    @contextmanager
+    def _locked_key(cls, key: str):
+        with cls._key_locks_guard:
+            entry = cls._key_locks.get(key)
+            if entry is None:
+                entry = [threading.Lock(), 0]
+                cls._key_locks[key] = entry
+            entry[1] += 1
+        try:
+            with entry[0]:
+                yield
+        finally:
+            with cls._key_locks_guard:
+                entry[1] -= 1
+                if entry[1] == 0 and cls._key_locks.get(key) is entry:
+                    cls._key_locks.pop(key, None)
+
+    def _send_open_file(self, source, metadata: dict, cache_state: str) -> None:
+        self.send_response(200)
+        for name, value in metadata.get("headers", {}).items():
+            if name.lower() not in _STRIPPED_HEADERS and name.lower() != "content-length":
+                self.send_header(name, str(value))
+        self.send_header("Content-Length", str(os.fstat(source.fileno()).st_size))
+        self.send_header("X-Bubble-Cache", cache_state)
+        self.end_headers()
+        if self.command != "HEAD":
+            shutil.copyfileobj(source, self.wfile, length=1024 * 1024)
+
+    def _send_upstream_error(self, response) -> None:
+        status = getattr(response, "status_code", getattr(response, "status", 502))
+        data = b""
+        if self.command != "HEAD":
+            chunks = []
+            remaining = MAX_ERROR_BODY
+            for chunk in response.iter_bytes(chunk_size=min(64 * 1024, remaining)):
+                chunks.append(chunk[:remaining])
+                remaining -= len(chunks[-1])
+                if remaining <= 0:
+                    break
+            data = b"".join(chunks)
+        self.send_response(status)
+        content_type = response.headers.get("Content-Type")
+        if content_type:
+            self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("X-Bubble-Cache", "MISS")
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
+
+    def _fetch(self, endpoints: list[str], suffix: str, body: Path, meta: Path) -> int | None:
+        body.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            old_size = body.stat().st_size
+        except OSError:
+            old_size = 0
+        for index, endpoint in enumerate(endpoints):
+            url = endpoint if not suffix else f"{endpoint}/{suffix}"
+            try:
+                response_context = _upstream_client().stream("GET", url)
+                response = response_context.__enter__()
+            except (OSError, httpx.RequestError) as exc:
+                if index + 1 < len(endpoints):
+                    continue
+                self._error(502, f"artifact cache upstream failed: {exc}")
+                return None
+
+            try:
+                status = response.status_code
+                if 300 <= status <= 399:
+                    self._error(502, "artifact upstream redirect refused by cache policy")
+                    return None
+                if (status in (403, 404, 410) or 500 <= status <= 599) and index + 1 < len(
+                    endpoints
+                ):
+                    continue
+                if status != 200:
+                    self._send_upstream_error(response)
+                    return None
+
+                try:
+                    content_length = int(response.headers.get("Content-Length", 0))
+                except (TypeError, ValueError):
+                    content_length = 0
+                free_bytes = shutil.disk_usage(body.parent).free
+                if content_length > self.max_object_bytes or (
+                    content_length and content_length + 256 * 1024**2 > free_bytes
+                ):
+                    self._error(507, "artifact is too large for the host cache")
+                    return None
+
+                tmp_body = body.with_name(f".{body.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+                tmp_meta = meta.with_name(f".{meta.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+                try:
+                    with open(tmp_body, "wb") as target:
+                        # Preserve the exact stored representation. ``iter_bytes``
+                        # transparently decompresses content encodings, which
+                        # would mismatch the forwarded Content-Encoding header.
+                        for chunk in response.iter_raw(chunk_size=1024 * 1024):
+                            target.write(chunk)
+                            if target.tell() > self.max_object_bytes:
+                                raise ValueError("artifact exceeds the per-object cache limit")
+                    headers = {
+                        name: value
+                        for name, value in response.headers.items()
+                        if name.lower() not in _STRIPPED_HEADERS
+                        and name.lower() not in ("content-length", "set-cookie")
+                    }
+                    tmp_meta.write_text(json.dumps({"url": url, "headers": headers}))
+                    os.replace(tmp_body, body)
+                    os.replace(tmp_meta, meta)
+                    return body.stat().st_size - old_size
+                except (OSError, ValueError, httpx.RequestError) as exc:
+                    tmp_body.unlink(missing_ok=True)
+                    tmp_meta.unlink(missing_ok=True)
+                    self._error(502, f"could not store artifact cache response: {exc}")
+                    return None
+            finally:
+                response_context.__exit__(None, None, None)
+        return None
+
+    @classmethod
+    def _note_stored(cls, added_bytes: int) -> None:
+        """Schedule one background LRU scan only when the in-memory total is over budget."""
+        with cls._usage_lock:
+            cls.cache_bytes += added_bytes
+            if cls.cache_bytes <= cls.max_bytes or cls._prune_running:
+                return
+            cls._prune_running = True
+
+        def prune() -> None:
+            try:
+                prune_cache(cls.max_bytes)
+                _, total = cache_stats()
+                with cls._usage_lock:
+                    cls.cache_bytes = total
+            finally:
+                with cls._usage_lock:
+                    cls._prune_running = False
+
+        threading.Thread(target=prune, name="bubble-cache-prune", daemon=True).start()
+
+    def _serve(self) -> None:
+        if self.command not in ("GET", "HEAD"):
+            # Methods with request bodies have not been consumed. Do not keep
+            # their HTTP/1.1 connection alive and parse body bytes as a request.
+            self.close_connection = True
+            self._error(405, "artifact cache is GET/HEAD only")
+            return
+        routed = self._route()
+        if routed is None:
+            return
+        container, endpoints, suffix = routed
+        # Include the complete fallback chain in the key. If Bubble changes a
+        # route's origin policy, old objects cannot be confused with new ones.
+        cache_identity = json.dumps([endpoints, suffix], separators=(",", ":"))
+        body, meta = _cache_paths(cache_identity)
+        key = hashlib.sha256(cache_identity.encode()).hexdigest()
+        with self._locked_key(key):
+            metadata = _load_cached(body, meta)
+            cache_state = "HIT"
+            added_bytes = 0
+            if metadata is None:
+                cache_state = "MISS"
+                fetched = self._fetch(endpoints, suffix, body, meta)
+                if fetched is None:
+                    logger.info("MISS container=%s path=%s", container, suffix)
+                    return
+                added_bytes = fetched
+                metadata = _load_cached(body, meta)
+            if metadata is None:
+                self._error(502, "artifact cache entry became unavailable")
+                return
+            logger.info("%s container=%s path=%s", cache_state, container, suffix)
+            try:
+                source = open(body, "rb")
+            except OSError:
+                self._error(503, "artifact cache entry became unavailable")
+                return
+        try:
+            self._send_open_file(source, metadata, cache_state)
+        except OSError:
+            pass
+        finally:
+            source.close()
+        if added_bytes:
+            self._note_stored(added_bytes)
+
+    do_GET = _serve
+    do_HEAD = _serve
+    do_POST = _serve
+    do_PUT = _serve
+    do_PATCH = _serve
+    do_DELETE = _serve
+
+
+class _BoundedServerMixin:
+    """Queue accepted sockets before spawning at most 256 request threads."""
+
+    _request_slots = threading.BoundedSemaphore(256)
+    request_queue_size = 256
+
+    def process_request(self, request, client_address):
+        self._request_slots.acquire()
+        try:
+            super().process_request(request, client_address)
+        except Exception:
+            self._request_slots.release()
+            raise
+
+    def process_request_thread(self, request, client_address):
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            self._request_slots.release()
+
+
+class ArtifactCacheServer(_BoundedServerMixin, ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+    request_queue_size = 256
+
+
+def _resolve_bind() -> tuple[str, str | None]:
+    if os.uname().sysname == "Darwin":
+        from .runtime.colima import colima_bind_ip
+
+        address = colima_bind_ip()
+        if address.startswith("127."):
+            raise RuntimeError("could not determine a container-reachable Colima bridge address")
+        return address, None
+    from .incus_bridge import BRIDGE_INTERFACE, bridge_gateway_ipv4
+
+    return bridge_gateway_ipv4(), BRIDGE_INTERFACE
+
+
+def _write_endpoint(host: str, port: int) -> None:
+    HOST_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "tcp": {"host": host, "port": port},
+        "version": 1,
+        "bubble_version": __version__,
+        "capabilities": ["get-only", "fallback-origins", "lake-services"],
+        "pid": os.getpid(),
+    }
+    tmp = ARTIFACT_CACHE_ENDPOINT_FILE.with_name(
+        f".{ARTIFACT_CACHE_ENDPOINT_FILE.name}.{os.getpid()}.tmp"
+    )
+    tmp.write_text(json.dumps(payload))
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, ARTIFACT_CACHE_ENDPOINT_FILE)
+
+
+def run_daemon(port: int = 0, max_bytes: int | None = None) -> None:
+    """Run the bridge-bound host artifact cache daemon."""
+    setup_file_logging(logger, ARTIFACT_CACHE_LOG)
+    config = load_host_artifact_config()
+    if not port:
+        port = int(config.get("port", DEFAULT_PORT))
+    if max_bytes is None:
+        max_bytes = parse_size(config.get("max_size", "50GiB"))
+    ARTIFACT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cleanup_stale_temps(max_age_seconds=0)
+    registry = CacheTokenRegistry()
+    rate_limiter = CacheRateLimiter()
+    ArtifactCacheHandler.token_registry = registry
+    ArtifactCacheHandler.rate_limiter = rate_limiter
+    ArtifactCacheHandler.peer_rate_limiter = CacheRateLimiter(
+        windows=((60, 120_000), (3600, 400_000))
+    )
+    ArtifactCacheHandler.max_bytes = max_bytes
+    ArtifactCacheHandler.max_object_bytes = min(max_bytes, DEFAULT_MAX_OBJECT_BYTES)
+    _, ArtifactCacheHandler.cache_bytes = cache_stats()
+    host, device = _resolve_bind()
+    if device:
+        from .auth_proxy import BridgeBoundHTTPServer
+
+        class BridgeArtifactCacheServer(_BoundedServerMixin, BridgeBoundHTTPServer):
+            pass
+
+        server = BridgeArtifactCacheServer((host, port), ArtifactCacheHandler, bind_device=device)
+    else:
+        server = ArtifactCacheServer((host, port), ArtifactCacheHandler)
+    _write_endpoint(host, port)
+    print(f"Artifact cache listening on {host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+        _close_upstream_client()
+
+
+def parse_size(value: str | int) -> int:
+    """Parse a byte count with optional KiB/MiB/GiB/TiB suffix."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value < 0:
+            raise ValueError("cache size cannot be negative")
+        return value
+    match = re.fullmatch(r"\s*(\d+)\s*([KMGT]?i?B)?\s*", str(value), re.IGNORECASE)
+    if not match:
+        raise ValueError(f"invalid cache size: {value!r}")
+    number = int(match.group(1))
+    suffix = (match.group(2) or "B").upper()
+    powers = {"B": 0, "KB": 1, "KIB": 1, "MB": 2, "MIB": 2, "GB": 3, "GIB": 3, "TB": 4, "TIB": 4}
+    return number * 1024 ** powers[suffix]
+
+
+def endpoint_alive(endpoint: dict) -> bool:
+    tcp = endpoint.get("tcp") if isinstance(endpoint, dict) else None
+    pid = endpoint.get("pid") if isinstance(endpoint, dict) else None
+    if not isinstance(tcp, dict) or not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    host, port = tcp.get("host"), tcp.get("port")
+    if not isinstance(host, str) or not isinstance(port, int) or isinstance(port, bool):
+        return False
+    try:
+        os.kill(pid, 0)
+        with socket.create_connection((host, port), timeout=1):
+            pass
+    except OSError:
+        return False
+    return bool(host and 1 <= port <= 65535)
+
+
+def read_live_endpoint() -> dict | None:
+    try:
+        endpoint = json.loads(ARTIFACT_CACHE_ENDPOINT_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return endpoint if endpoint_alive(endpoint) else None
+
+
+def endpoint_compatible(endpoint: dict | None) -> bool:
+    """Whether a live daemon implements this client's cache contract."""
+    if endpoint is None or endpoint.get("version") != 1:
+        return False
+    capabilities = endpoint.get("capabilities")
+    required = {"get-only", "fallback-origins", "lake-services"}
+    return isinstance(capabilities, list) and required.issubset(capabilities)
+
+
+def wait_for_endpoint(
+    attempts: int = 20, delay: float = 0.5, *, compatible: bool = False
+) -> dict | None:
+    for _ in range(attempts):
+        endpoint = read_live_endpoint()
+        if endpoint is not None and (not compatible or endpoint_compatible(endpoint)):
+            return endpoint
+        time.sleep(delay)
+    return None
+
+
+def ensure_daemon_endpoint() -> dict | None:
+    """Start or refresh the daemon and return its live bridge endpoint."""
+    from .automation import install_artifact_cache_daemon, is_artifact_cache_installed
+
+    installed = is_artifact_cache_installed()
+    if not installed:
+        install_artifact_cache_daemon(skip_if=lambda: endpoint_compatible(read_live_endpoint()))
+    endpoint = wait_for_endpoint(
+        attempts=20 if not installed else 1,
+        delay=0.5 if not installed else 0,
+        compatible=True,
+    )
+    if endpoint is not None:
+        return endpoint
+    # Refresh stale service definitions after Bubble upgrades.
+    install_artifact_cache_daemon(skip_if=lambda: endpoint_compatible(read_live_endpoint()))
+    return wait_for_endpoint(compatible=True)
+
+
+def _write_container_config(
+    runtime,
+    container: str,
+    *,
+    host: str,
+    port: int,
+    token: str,
+    mathlib: bool,
+    lake_service_names: tuple[str, ...],
+) -> bool:
+    """Write endpoint-dependent client configuration without exposing the token in argv."""
+    import ipaddress
+
+    try:
+        if ipaddress.ip_address(host).version != 4:
+            return False
+    except ValueError:
+        return False
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        return False
+
+    from .github_token import _allow_bridge_egress
+
+    if not _allow_bridge_egress(runtime, container, host, port):
+        return False
+
+    base = f"http://{host}:{port}/cache/$TOKEN"
+    profile_lines: list[str] = []
+    if mathlib:
+        profile_lines.append(f"export MATHLIB_CACHE_GET_URL={base}/mathlib")
+    config_lines: list[str] = []
+    if lake_service_names:
+        # Lake/Load/Toml.lean consumes this schema; Lake's help documents
+        # ~/.lake/config.toml as the default system configuration path.
+        config_lines.append(f"cache.defaultService = {json.dumps(lake_service_names[0])}")
+        for index, name in enumerate(lake_service_names):
+            config_lines.extend(
+                [
+                    "",
+                    "[[cache.service]]",
+                    f"name = {json.dumps(name)}",
+                    'kind = "s3"',
+                    f'artifactEndpoint = "{base}/lake-{index}-artifacts"',
+                    f'revisionEndpoint = "{base}/lake-{index}-revisions"',
+                ]
+            )
+        profile_lines.extend(
+            [
+                "export LAKE_ARTIFACT_CACHE=true",
+                "export LAKE_RESTORE_ARTIFACTS=true",
+            ]
+        )
+
+    script_lines = [
+        "set -e",
+        "IFS= read -r TOKEN",
+        "mkdir -p /etc/profile.d",
+        "install -d -m 0755 -o user -g user /home/user/.lake",
+    ]
+    if config_lines:
+        script_lines.extend(
+            [
+                "cat > /home/user/.lake/config.toml <<CACHE",
+                *config_lines,
+                "CACHE",
+                "chown user:user /home/user/.lake/config.toml /home/user/.lake",
+                "chmod 600 /home/user/.lake/config.toml",
+            ]
+        )
+    script_lines.extend(
+        [
+            "cat > /etc/profile.d/bubble-artifact-cache.sh <<PROFILE",
+            *profile_lines,
+            "PROFILE",
+            "chmod 644 /etc/profile.d/bubble-artifact-cache.sh",
+        ]
+    )
+    try:
+        runtime.exec(container, ["bash", "-c", "\n".join(script_lines)], input=token + "\n")
+    except RuntimeError:
+        return False
+    return True
+
+
+def refresh_container_cache(runtime, container: str) -> bool:
+    """Refresh a stopped/restarted bubble for the daemon's current bridge endpoint."""
+    capability = container_cache_capability(container)
+    if capability is None:
+        return True
+    token, info = capability
+    endpoint = ensure_daemon_endpoint()
+    tcp = endpoint.get("tcp") if endpoint else None
+    if not isinstance(tcp, dict):
+        return False
+    names = info.get("lake_service_names") or []
+    if not isinstance(names, list) or not all(isinstance(name, str) for name in names):
+        return False
+    return _write_container_config(
+        runtime,
+        container,
+        host=tcp.get("host"),
+        port=tcp.get("port"),
+        token=token,
+        mathlib=bool(info.get("mathlib")),
+        lake_service_names=tuple(names),
+    )
+
+
+def setup_container_cache(
+    runtime,
+    container: str,
+    *,
+    mathlib: bool,
+    lake_services: tuple[LakeCacheService, ...] = (),
+) -> bool:
+    """Grant and configure a container's Mathlib and Lake download routes."""
+    if load_host_artifact_config().get("enabled", True) is False:
+        return False
+    routes: dict[str, list[str] | tuple[str, ...]] = {}
+    if mathlib:
+        routes["mathlib"] = MATHLIB_CACHE_ENDPOINTS
+    for index, service in enumerate(lake_services):
+        routes[f"lake-{index}-artifacts"] = [service.artifact_endpoint]
+        routes[f"lake-{index}-revisions"] = [service.revision_endpoint]
+    if not routes:
+        return True
+
+    endpoint = ensure_daemon_endpoint()
+    if endpoint is None:
+        return False
+    tcp = endpoint.get("tcp") or {}
+    host, port = tcp.get("host"), tcp.get("port")
+    if not isinstance(host, str) or not isinstance(port, int) or host.startswith("127."):
+        return False
+
+    # A crashed prior creation with the same name may have left a grant behind.
+    remove_cache_tokens(container)
+    token = generate_cache_token(
+        container,
+        routes,
+        mathlib=mathlib,
+        lake_service_names=tuple(service.name for service in lake_services),
+    )
+    if not _write_container_config(
+        runtime,
+        container,
+        host=host,
+        port=port,
+        token=token,
+        mathlib=mathlib,
+        lake_service_names=tuple(service.name for service in lake_services),
+    ):
+        remove_cache_tokens(container)
+        return False
+    return True

--- a/bubble/automation.py
+++ b/bubble/automation.py
@@ -25,6 +25,7 @@ LAUNCHD_LABELS = {
 }
 RELAY_LABEL = "com.bubble.relay-daemon"
 AUTH_PROXY_LABEL = "com.bubble.auth-proxy"
+ARTIFACT_CACHE_LABEL = "com.bubble.artifact-cache"
 
 
 def install_automation() -> list[str]:
@@ -131,6 +132,15 @@ _AUTH_PROXY_JOB = {
         "RunAtLoad": True,
     },
     "log": "/tmp/bubble-auth-proxy.log",
+}
+
+_ARTIFACT_CACHE_JOB = {
+    "args": ["cache", "daemon"],
+    "extra": {
+        "KeepAlive": True,
+        "RunAtLoad": True,
+    },
+    "log": "/tmp/bubble-artifact-cache.log",
 }
 
 
@@ -538,3 +548,97 @@ def _remove_auth_proxy_systemd() -> str:
         return "systemd: bubble-auth-proxy.service"
 
     return ""
+
+
+# ---------------------------------------------------------------------------
+# Artifact cache daemon (host-global, started on demand by Lean bubbles)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _artifact_cache_install_lock():
+    """Serialize changes to the one artifact-cache service owned by this user."""
+    import fcntl
+
+    HOST_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(HOST_DATA_DIR / "artifact-cache.install.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+
+
+def install_artifact_cache_daemon(*, skip_if: Callable[[], bool] | None = None) -> str:
+    """Install and start the host-global artifact cache daemon."""
+    with _artifact_cache_install_lock():
+        if skip_if is not None and skip_if():
+            return "already running"
+        system = platform.system()
+        if system == "Darwin":
+            _write_launchd_plist(ARTIFACT_CACHE_LABEL, _ARTIFACT_CACHE_JOB, host_global=True)
+            return f"launchd: {ARTIFACT_CACHE_LABEL}"
+        if system == "Linux":
+            return _install_artifact_cache_systemd()
+        return ""
+
+
+def remove_artifact_cache_daemon() -> str:
+    """Stop and remove the host-global artifact cache daemon."""
+    with _artifact_cache_install_lock():
+        system = platform.system()
+        if system == "Darwin":
+            return _remove_launchd_job(ARTIFACT_CACHE_LABEL, host_global=True) or ""
+        if system == "Linux":
+            return _remove_artifact_cache_systemd()
+        return ""
+
+
+def is_artifact_cache_installed() -> bool:
+    """Whether the host-global artifact cache service definition exists."""
+    system = platform.system()
+    if system == "Darwin":
+        launch_agents = HOST_DATA_DIR.parent / "Library" / "LaunchAgents"
+        return (launch_agents / f"{ARTIFACT_CACHE_LABEL}.plist").exists()
+    if system == "Linux":
+        return (HOST_SYSTEMD_DIR / "bubble-artifact-cache.service").exists()
+    return False
+
+
+def _install_artifact_cache_systemd() -> str:
+    HOST_SYSTEMD_DIR.mkdir(parents=True, exist_ok=True)
+    bubble = _bubble_path()
+    service = HOST_SYSTEMD_DIR / "bubble-artifact-cache.service"
+    service.write_text(
+        textwrap.dedent(f"""\
+        [Unit]
+        Description=bubble GET-only artifact cache daemon
+
+        [Service]
+        Type=simple
+        ExecStart={bubble} cache daemon
+        Restart=always
+        RestartSec=5
+        {_systemd_path_env()}
+
+        [Install]
+        WantedBy=default.target
+    """)
+    )
+    _systemctl_checked(["daemon-reload"])
+    _systemctl_checked(["enable", "bubble-artifact-cache.service"])
+    _systemctl_checked(["restart", "bubble-artifact-cache.service"])
+    return "systemd: bubble-artifact-cache.service"
+
+
+def _remove_artifact_cache_systemd() -> str:
+    service = HOST_SYSTEMD_DIR / "bubble-artifact-cache.service"
+    if not service.exists():
+        return ""
+    subprocess.run(
+        ["systemctl", "--user", "disable", "--now", "bubble-artifact-cache.service"],
+        capture_output=True,
+    )
+    service.unlink()
+    subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True)
+    return "systemd: bubble-artifact-cache.service"

--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -544,7 +544,9 @@ def _open_remote(
             _ephemeral_pop_and_exit(name, exit_code)
 
 
-def _check_reattach_options(*, allow_domains=(), mount_specs=(), allow_push=()):
+def _check_reattach_options(
+    *, allow_domains=(), mount_specs=(), allow_push=(), lake_cache_services=()
+):
     """Reject launch-only security options that cannot be retrofitted onto an existing bubble."""
     flags = []
     if allow_domains:
@@ -553,6 +555,8 @@ def _check_reattach_options(*, allow_domains=(), mount_specs=(), allow_push=()):
         flags.append("--mount")
     if allow_push:
         flags.append("--allow-push")
+    if lake_cache_services:
+        flags.append("--lake-cache-service")
     if flags:
         joined = ", ".join(flags)
         raise click.ClickException(
@@ -664,6 +668,17 @@ def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=Fal
     multiple=True,
     metavar="DOMAIN",
     help="Add a domain to this bubble's network allowlist (repeatable, local only)",
+)
+@click.option(
+    "--lake-cache-service",
+    "lake_cache_services",
+    type=(str, str, str),
+    multiple=True,
+    metavar="NAME ARTIFACT_URL REVISION_URL",
+    help=(
+        "Expose a named anonymous Lake download service through Bubble's host-global "
+        "GET-only cache (repeatable, local only)."
+    ),
 )
 @click.option("--name", "custom_name", type=str, help="Custom container name")
 @click.option(
@@ -798,6 +813,7 @@ def open_cmd(
     machine_readable,
     network,
     allow_domains,
+    lake_cache_services,
     custom_name,
     command,
     ephemeral,
@@ -865,6 +881,7 @@ def open_cmd(
                 machine_readable=machine_readable,
                 network=network,
                 allow_domains=allow_domains,
+                lake_cache_services=lake_cache_services,
                 custom_name=custom_name,
                 command=command,
                 ephemeral=ephemeral,
@@ -926,6 +943,7 @@ def _open_single(
     machine_readable,
     network,
     allow_domains,
+    lake_cache_services,
     custom_name,
     command,
     ephemeral,
@@ -952,6 +970,18 @@ def _open_single(
         target = "./" + target
 
     config = load_config()
+
+    from .artifact_cache import validate_lake_service
+
+    try:
+        validated_lake_services = tuple(
+            validate_lake_service(*spec) for spec in lake_cache_services
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    service_names = [service.name for service in validated_lake_services]
+    if len(set(service_names)) != len(service_names):
+        raise click.ClickException("--lake-cache-service names must be unique")
 
     # --github-security: per-launch override of security.github. Lockdown
     # still wins. Apply by mutating a config copy so all downstream
@@ -1106,6 +1136,12 @@ def _open_single(
         codex_config = config.get("codex", {}).get("config", True)
 
     if remote_host:
+        if validated_lake_services:
+            click.echo(
+                "Error: --lake-cache-service is not supported with remote/cloud bubbles",
+                err=True,
+            )
+            sys.exit(1)
         if allow_domains:
             click.echo(
                 "Error: --allow-domain is not supported with remote/cloud bubbles",
@@ -1203,6 +1239,7 @@ def _open_single(
             allow_domains=allow_domains,
             mount_specs=mount_specs,
             allow_push=allow_push,
+            lake_cache_services=validated_lake_services,
         )
         if machine_readable:
             project_dir = detect_project_dir(runtime, existing)
@@ -1358,6 +1395,24 @@ def _open_single(
             extra_domains=extra_domains,
         )
 
+        needs_mathlib_cache = bool(hook and hook.uses_mathlib_cache())
+        if needs_mathlib_cache or validated_lake_services:
+            from .artifact_cache import setup_container_cache
+
+            cache_ok = setup_container_cache(
+                runtime,
+                name,
+                mathlib=needs_mathlib_cache,
+                lake_services=validated_lake_services,
+            )
+            if not cache_ok:
+                from .output import detail
+
+                detail(
+                    "Warning: host artifact cache setup failed; continuing with direct "
+                    "public cache downloads. Run 'bubble cache start' for diagnostics."
+                )
+
         # Set up GitHub auth BEFORE clone — network allowlisting strips
         # github.com from allowed domains when using the auth proxy, so
         # git must be configured to route through the proxy first.
@@ -1488,6 +1543,9 @@ def _open_single(
         from .provisioning import remove_cache_copies
 
         remove_cache_copies(name)
+        from .artifact_cache import remove_cache_tokens
+
+        remove_cache_tokens(name)
         raise
 
 
@@ -1495,6 +1553,7 @@ def _open_single(
 # Register commands from submodules
 # ---------------------------------------------------------------------------
 
+from .commands.cache_cmd import register_cache_commands  # noqa: E402
 from .commands.cloud_cmd import register_cloud_commands  # noqa: E402
 from .commands.completion import register_completion_command  # noqa: E402
 from .commands.doctor import register_doctor_command  # noqa: E402
@@ -1516,6 +1575,7 @@ register_infrastructure_commands(main)
 register_relay_commands(main)
 register_remote_commands(main)
 register_cloud_commands(main)
+register_cache_commands(main)
 register_security_commands(main)
 register_settings_commands(main)
 register_doctor_command(main)

--- a/bubble/commands/cache_cmd.py
+++ b/bubble/commands/cache_cmd.py
@@ -1,0 +1,139 @@
+"""Commands for Bubble's host-global GET-only artifact cache."""
+
+import click
+
+
+def _human_bytes(value: int) -> str:
+    amount = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if amount < 1024 or unit == "TiB":
+            return f"{amount:.1f} {unit}" if unit != "B" else f"{int(amount)} B"
+        amount /= 1024
+    return f"{value} B"
+
+
+def register_cache_commands(main):
+    @main.group("cache")
+    def cache_group():
+        """Manage the host-global download-only artifact cache."""
+
+    @cache_group.command("status")
+    def cache_status():
+        """Show daemon state and cached object usage."""
+        from ..artifact_cache import (
+            ARTIFACT_CACHE_TOKENS,
+            cache_stats,
+            load_host_artifact_config,
+            parse_size,
+            read_live_endpoint,
+        )
+        from ..automation import is_artifact_cache_installed
+        from ..token_store import TokenStore
+
+        count, size = cache_stats()
+        configured = load_host_artifact_config().get("max_size", "50GiB")
+        try:
+            limit = parse_size(configured)
+            limit_label = _human_bytes(limit)
+        except ValueError:
+            limit_label = f"invalid ({configured})"
+        endpoint = read_live_endpoint()
+        click.echo(
+            f"Artifact cache:  {'running' if endpoint else 'stopped'}"
+            f" ({'installed' if is_artifact_cache_installed() else 'not installed'})"
+        )
+        if endpoint:
+            tcp = endpoint["tcp"]
+            click.echo(f"Endpoint:        {tcp['host']}:{tcp['port']}")
+        click.echo(f"Objects:         {count}")
+        click.echo(f"Disk usage:      {_human_bytes(size)} / {limit_label}")
+        grants = TokenStore(ARTIFACT_CACHE_TOKENS).values()
+        holders = {str(grant.get("container")) for grant in grants if grant.get("container")}
+        click.echo(f"Capability holders: {len(holders)}")
+
+    @cache_group.command("start")
+    def cache_start():
+        """Install and start the artifact cache daemon."""
+        from ..artifact_cache import wait_for_endpoint
+        from ..automation import install_artifact_cache_daemon
+
+        try:
+            result = install_artifact_cache_daemon()
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
+        if not result:
+            raise click.ClickException("artifact cache daemon is unsupported on this platform")
+        if wait_for_endpoint(compatible=True) is None:
+            raise click.ClickException(
+                "artifact cache did not publish a live endpoint; see "
+                "~/.bubble/artifact-cache.log and /tmp/bubble-artifact-cache.log"
+            )
+        click.echo(f"Artifact cache daemon installed: {result}")
+
+    @cache_group.command("stop")
+    def cache_stop():
+        """Stop and uninstall the artifact cache daemon (objects remain)."""
+        from ..artifact_cache import ARTIFACT_CACHE_TOKENS
+        from ..automation import remove_artifact_cache_daemon
+        from ..token_store import TokenStore
+
+        holders = {
+            str(grant.get("container"))
+            for grant in TokenStore(ARTIFACT_CACHE_TOKENS).values()
+            if grant.get("container")
+        }
+        if holders:
+            click.echo(
+                f"Warning: cache downloads in {len(holders)} bubble(s) will fail until "
+                "`bubble cache start` is run.",
+                err=True,
+            )
+        result = remove_artifact_cache_daemon()
+        click.echo(f"Artifact cache daemon removed: {result}" if result else "Daemon not found.")
+
+    @cache_group.command("prune")
+    @click.option(
+        "--max-size",
+        default=None,
+        metavar="SIZE",
+        help="Target size such as 20GiB (default: configured artifact_cache.max_size).",
+    )
+    @click.option("--execute", is_flag=True, help="Delete selected objects (default is a dry run).")
+    def cache_prune(max_size, execute):
+        """Select least-recently-used objects until the cache fits its limit."""
+        from ..artifact_cache import load_host_artifact_config, parse_size, prune_cache
+
+        value = max_size or load_host_artifact_config().get("max_size", "50GiB")
+        try:
+            limit = parse_size(value)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        count, size = prune_cache(limit, execute=execute)
+        verb = "Deleted" if execute else "Would delete"
+        click.echo(f"{verb} {count} object(s), {_human_bytes(size)}.")
+        if not execute and count:
+            click.echo("Run again with --execute to apply.")
+
+    @cache_group.command("clear")
+    @click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+    def cache_clear(yes):
+        """Delete every cached response body (the daemon remains installed)."""
+        from ..artifact_cache import clear_cache
+
+        if not yes:
+            click.confirm("Delete all host-global Bubble artifact cache objects?", abort=True)
+        count, size = clear_cache()
+        click.echo(f"Deleted {count} object(s), {_human_bytes(size)}.")
+
+    @cache_group.command("daemon", hidden=True)
+    @click.option("--port", type=int, default=0, help="Port to listen on (0 = configured default).")
+    @click.option("--max-size", default=None, metavar="SIZE")
+    def cache_daemon(port, max_size):
+        """Run the artifact cache daemon (used by launchd/systemd)."""
+        from ..artifact_cache import parse_size, run_daemon
+
+        try:
+            limit = parse_size(max_size) if max_size is not None else None
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        run_daemon(port=port, max_bytes=limit)

--- a/bubble/commands/lifecycle.py
+++ b/bubble/commands/lifecycle.py
@@ -105,11 +105,13 @@ def _cleanup_tokens(name: str, remote_host_spec: str = ""):
     If remote_host_spec is provided, also stops the SSH tunnel to
     that host if no other bubbles are using it.
     """
+    from ..artifact_cache import remove_cache_tokens
     from ..auth_proxy import remove_auth_tokens
     from ..relay import remove_relay_token
 
     remove_relay_token(name)
     remove_auth_tokens(name)
+    remove_cache_tokens(name)
 
     if remote_host_spec:
         from ..tunnel import stop_tunnel_if_unused

--- a/bubble/container_helpers.py
+++ b/bubble/container_helpers.py
@@ -144,6 +144,13 @@ def reapply_network_after_restart(runtime: ContainerRuntime, name: str):
 
     config = load_config()
     apply_network(runtime, name, config, extra_domains=list(extra_domains))
+    from .artifact_cache import container_has_cache_token, refresh_container_cache
+
+    if container_has_cache_token(name) and not refresh_container_cache(runtime, name):
+        detail(
+            "Warning: could not refresh this bubble's artifact-cache endpoint; "
+            "direct public cache access remains available."
+        )
 
 
 def recover_extra_domains(info: dict) -> list[str] | None:
@@ -290,11 +297,15 @@ def apply_network(
     # using the legacy proxy-device flow don't need this (the proxy
     # device delivers traffic on the container's own loopback).
     auth_endpoint = _resolve_auth_proxy_endpoint_for_allowlist(gh_level)
-    if domains or auth_endpoint:
+    proxy_endpoints = [auth_endpoint] if auth_endpoint else []
+    artifact_endpoint = _resolve_artifact_cache_endpoint_for_allowlist(name)
+    if artifact_endpoint and artifact_endpoint not in proxy_endpoints:
+        proxy_endpoints.append(artifact_endpoint)
+    if domains or proxy_endpoints:
         try:
             from .network import apply_allowlist
 
-            apply_allowlist(runtime, name, domains, auth_proxy_endpoint=auth_endpoint)
+            apply_allowlist(runtime, name, domains, proxy_endpoints=proxy_endpoints)
             detail("Network allowlist applied.")
         except (RuntimeError, OSError, ValueError) as e:
             raise click.ClickException(f"Failed to apply network allowlist: {e}")
@@ -330,6 +341,24 @@ def _resolve_auth_proxy_endpoint_for_allowlist(gh_level: str) -> tuple[str, int]
     # Don't punch a hole for loopback — that's the legacy bind fallback
     # and the proxy device handles delivery internally.
     if host == "127.0.0.1":
+        return None
+    return (host, port)
+
+
+def _resolve_artifact_cache_endpoint_for_allowlist(name: str) -> tuple[str, int] | None:
+    """Return the artifact-cache bridge endpoint for a previously granted bubble."""
+    from .artifact_cache import container_has_cache_token, read_live_endpoint
+
+    if not container_has_cache_token(name):
+        return None
+    endpoint = read_live_endpoint()
+    tcp = endpoint.get("tcp") if endpoint else None
+    if not isinstance(tcp, dict):
+        return None
+    host, port = tcp.get("host"), tcp.get("port")
+    if not isinstance(host, str) or host.startswith("127."):
+        return None
+    if not isinstance(port, int) or isinstance(port, bool):
         return None
     return (host, port)
 

--- a/bubble/hooks/__init__.py
+++ b/bubble/hooks/__init__.py
@@ -57,6 +57,10 @@ class Hook(ABC):
         """
         return []
 
+    def uses_mathlib_cache(self) -> bool:
+        """Whether Bubble should configure the host-global Mathlib download cache."""
+        return False
+
     def git_dependencies(self) -> list[GitDependency]:
         """Git repos this project depends on, for pre-population via alternates.
 

--- a/bubble/hooks/lean.py
+++ b/bubble/hooks/lean.py
@@ -281,7 +281,10 @@ class LeanHook(Hook):
             )
         self._is_lean4 = False
         self._git_deps = []
-        self._needs_cache = False
+        # We do not choose one subproject for auto-build, but a user may cd
+        # into any of them and run `lake exe cache get`. The download proxy is
+        # safe and useful even when some candidates do not depend on Mathlib.
+        self._needs_cache = True
         return True
 
     def _configure_for_single_project(self, bare_repo_path: Path, ref: str, subdir: str) -> None:
@@ -318,6 +321,9 @@ class LeanHook(Hook):
                 ("lake-cache", "/shared/lake-cache", "LAKE_CACHE_DIR"),
             ]
         return []
+
+    def uses_mathlib_cache(self) -> bool:
+        return self._needs_cache
 
     def git_dependencies(self) -> list[GitDependency]:
         return self._git_deps

--- a/bubble/network.py
+++ b/bubble/network.py
@@ -27,6 +27,7 @@ def apply_allowlist(
     domains: list[str],
     *,
     auth_proxy_endpoint: tuple[str, int] | None = None,
+    proxy_endpoints: list[tuple[str, int]] | None = None,
 ):
     """Apply network allowlist to a container using iptables.
 
@@ -43,15 +44,17 @@ def apply_allowlist(
     for domain in domains:
         if not _DOMAIN_RE.match(domain):
             raise ValueError(f"Invalid domain in allowlist: {domain!r}")
-    if auth_proxy_endpoint is not None:
-        ip, port = auth_proxy_endpoint
+    endpoints = list(proxy_endpoints or [])
+    if auth_proxy_endpoint is not None and auth_proxy_endpoint not in endpoints:
+        endpoints.append(auth_proxy_endpoint)
+    for ip, port in endpoints:
         if not _IPV4_RE.match(ip):
             raise ValueError(f"Invalid auth proxy IP: {ip!r}")
         if not isinstance(port, int) or not (0 < port < 65536):
             raise ValueError(f"Invalid auth proxy port: {port!r}")
 
     # Build the allowlist script
-    script = _build_allowlist_script(domains, auth_proxy_endpoint=auth_proxy_endpoint)
+    script = _build_allowlist_script(domains, proxy_endpoints=endpoints)
     runtime.exec(container, ["bash", "-c", script])
 
 
@@ -72,6 +75,7 @@ def _build_allowlist_script(
     domains: list[str],
     *,
     auth_proxy_endpoint: tuple[str, int] | None = None,
+    proxy_endpoints: list[tuple[str, int]] | None = None,
 ) -> str:
     """Build a shell script that sets up iptables allowlist rules."""
     lines = [
@@ -102,8 +106,10 @@ def _build_allowlist_script(
         "fi",
         "",
     ]
-    if auth_proxy_endpoint is not None:
-        ip, port = auth_proxy_endpoint
+    endpoints = list(proxy_endpoints or [])
+    if auth_proxy_endpoint is not None and auth_proxy_endpoint not in endpoints:
+        endpoints.append(auth_proxy_endpoint)
+    for ip, port in endpoints:
         lines.extend(
             [
                 "",

--- a/bubble/token_store.py
+++ b/bubble/token_store.py
@@ -104,6 +104,18 @@ class TokenStore:
             self._maybe_reload()
             return self._tokens.get(token)
 
+    def values(self) -> list[Any]:
+        """Return a snapshot of all stored values."""
+        with self._thread_lock:
+            self._maybe_reload()
+            return list(self._tokens.values())
+
+    def items(self) -> list[tuple[str, Any]]:
+        """Return a snapshot of all token/value pairs."""
+        with self._thread_lock:
+            self._maybe_reload()
+            return list(self._tokens.items())
+
     def _maybe_reload(self):
         """Reload from disk if the file has been modified."""
         try:
@@ -182,6 +194,7 @@ def setup_file_logging(target_logger: logging.Logger, log_path: Path):
     """Configure timestamped file-based request logging."""
     log_path.parent.mkdir(parents=True, exist_ok=True)
     handler = logging.FileHandler(str(log_path))
+    os.chmod(log_path, 0o600)
     handler.setFormatter(logging.Formatter("%(asctime)s  %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
     target_logger.addHandler(handler)
     target_logger.setLevel(logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.0",
+    "httpx[http2]>=0.28,<1",
     "tomli>=2.0; python_version < '3.11'",
     "tomli-w>=1.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,24 @@ def tmp_data_dir(tmp_path, monkeypatch):
     except ImportError:
         pass
 
+    # Patch host-global artifact cache paths.
+    import bubble.artifact_cache as artifact_cache_mod
+
+    artifact_dir = data_dir / "artifact-cache"
+    monkeypatch.setattr(artifact_cache_mod, "HOST_DATA_DIR", data_dir)
+    monkeypatch.setattr(artifact_cache_mod, "ARTIFACT_CACHE_DIR", artifact_dir)
+    monkeypatch.setattr(artifact_cache_mod, "ARTIFACT_CACHE_OBJECTS", artifact_dir / "objects")
+    monkeypatch.setattr(
+        artifact_cache_mod, "ARTIFACT_CACHE_TOKENS", data_dir / "artifact-cache-tokens.json"
+    )
+    monkeypatch.setattr(
+        artifact_cache_mod, "ARTIFACT_CACHE_ENDPOINT_FILE", data_dir / "artifact-cache.endpoint"
+    )
+    monkeypatch.setattr(artifact_cache_mod, "ARTIFACT_CACHE_LOG", data_dir / "artifact-cache.log")
+    monkeypatch.setattr(
+        artifact_cache_mod, "ARTIFACT_CACHE_LOCK", data_dir / "locks" / "artifact-cache.lock"
+    )
+
     # Patch auth_proxy module
     try:
         import bubble.auth_proxy as auth_proxy_mod

--- a/tests/test_artifact_cache.py
+++ b/tests/test_artifact_cache.py
@@ -1,0 +1,463 @@
+"""Tests for the host-global, capability-scoped artifact cache."""
+
+import gzip
+import io
+import json
+import os
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+from click.testing import CliRunner
+
+from bubble import artifact_cache
+from bubble.cli import main
+
+
+class FakeResponse(io.BytesIO):
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        content_type: str = "application/octet-stream",
+        content_encoding: str | None = None,
+        status: int = 200,
+    ):
+        super().__init__(body)
+        self.status = status
+        self.status_code = status
+        self.headers = {
+            "Content-Type": content_type,
+            "Content-Length": str(len(body)),
+            "ETag": '"abc"',
+            "Date": "yesterday",
+            "Server": "upstream",
+        }
+        if content_encoding:
+            self.headers["Content-Encoding"] = content_encoding
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def iter_bytes(self, chunk_size):
+        body = self.getvalue()
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+        for offset in range(0, len(body), chunk_size):
+            yield body[offset : offset + chunk_size]
+
+    def iter_raw(self, chunk_size):
+        body = self.getvalue()
+        for offset in range(0, len(body), chunk_size):
+            yield body[offset : offset + chunk_size]
+
+
+class FakeClient:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.urls = []
+
+    def stream(self, method, url):
+        assert method == "GET"
+        self.urls.append(url)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def cache_paths(tmp_path, monkeypatch):
+    root = tmp_path / "cache"
+    monkeypatch.setattr(artifact_cache, "ARTIFACT_CACHE_DIR", root)
+    monkeypatch.setattr(artifact_cache, "ARTIFACT_CACHE_OBJECTS", root / "objects")
+    monkeypatch.setattr(artifact_cache, "ARTIFACT_CACHE_TOKENS", tmp_path / "tokens.json")
+    monkeypatch.setattr(artifact_cache, "ARTIFACT_CACHE_LOCK", tmp_path / "cache.lock")
+    return root
+
+
+@pytest.fixture
+def cache_server(cache_paths, monkeypatch):
+    monkeypatch.setattr(
+        artifact_cache.ArtifactCacheHandler,
+        "token_registry",
+        artifact_cache.CacheTokenRegistry(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        artifact_cache.ArtifactCacheHandler,
+        "rate_limiter",
+        artifact_cache.CacheRateLimiter(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        artifact_cache.ArtifactCacheHandler,
+        "peer_rate_limiter",
+        artifact_cache.CacheRateLimiter(),
+        raising=False,
+    )
+    monkeypatch.setattr(artifact_cache.ArtifactCacheHandler, "max_bytes", 1024**3)
+    monkeypatch.setattr(artifact_cache.ArtifactCacheHandler, "max_object_bytes", 1024**3)
+    monkeypatch.setattr(artifact_cache.ArtifactCacheHandler, "cache_bytes", 0)
+    monkeypatch.setattr(artifact_cache.ArtifactCacheHandler, "_prune_running", False)
+    server = artifact_cache.ArtifactCacheServer(
+        ("127.0.0.1", 0), artifact_cache.ArtifactCacheHandler
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _http(url: str, *, method: str = "GET"):
+    request = urllib.request.Request(url, method=method)
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return response.status, response.headers, response.read()
+
+
+def test_endpoint_and_service_validation():
+    service = artifact_cache.validate_lake_service(
+        "tauceti-public", "https://cache.example/artifacts/", "https://cache.example/revisions"
+    )
+    assert service.artifact_endpoint == "https://cache.example/artifacts"
+    with pytest.raises(ValueError):
+        artifact_cache.validate_lake_service("../bad", "https://a.example", "https://r.example")
+    with pytest.raises(ValueError):
+        artifact_cache.normalize_endpoint("http://cache.example")
+    with pytest.raises(ValueError):
+        artifact_cache.normalize_endpoint("https://user:secret@cache.example")
+
+
+def test_open_help_exposes_three_argument_lake_service():
+    result = CliRunner().invoke(main, ["open", "--help"])
+    assert result.exit_code == 0
+    assert "--lake-cache-service NAME ARTIFACT_URL REVISION_URL" in result.output
+
+
+def test_capability_is_scoped_to_its_routes(cache_paths):
+    token = artifact_cache.generate_cache_token(
+        "one", {"mathlib": ["https://cache.example/mathlib"]}
+    )
+    info = artifact_cache.CacheTokenRegistry().lookup(token)
+    assert info["container"] == "one"
+    assert info["routes"] == {"mathlib": ["https://cache.example/mathlib"]}
+    artifact_cache.remove_cache_tokens("one")
+    assert artifact_cache.CacheTokenRegistry().lookup(token) is None
+
+
+def test_get_miss_then_host_global_hit(cache_server, monkeypatch):
+    client = FakeClient([FakeResponse(b"artifact", content_type="application/test-artifact")])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token(
+        "one", {"lake-0-artifacts": ["https://cache.example/artifacts"]}
+    )
+    url = f"{cache_server}/cache/{token}/lake-0-artifacts/owner/repo/abc.art"
+
+    status, headers, body = _http(url)
+    assert (status, body, headers["X-Bubble-Cache"]) == (200, b"artifact", "MISS")
+    assert headers["Content-Type"] == "application/test-artifact"
+    assert headers.get_all("Date") is not None and len(headers.get_all("Date")) == 1
+    assert headers.get_all("Server") is not None and len(headers.get_all("Server")) == 1
+    status, headers, body = _http(url)
+    assert (status, body, headers["X-Bubble-Cache"]) == (200, b"artifact", "HIT")
+    assert client.urls == ["https://cache.example/artifacts/owner/repo/abc.art"]
+
+
+def test_mathlib_route_falls_back_on_404(cache_server, monkeypatch):
+    client = FakeClient([FakeResponse(b"missing", status=404), FakeResponse(b"legacy")])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token(
+        "one", {"mathlib": ["https://new.example", "https://legacy.example"]}
+    )
+    _, _, body = _http(f"{cache_server}/cache/{token}/mathlib/f/hash.tar.gz")
+    assert body == b"legacy"
+    assert client.urls == [
+        "https://new.example/f/hash.tar.gz",
+        "https://legacy.example/f/hash.tar.gz",
+    ]
+
+
+def test_mathlib_route_falls_back_on_connection_error(cache_server, monkeypatch):
+    client = FakeClient([OSError("offline"), FakeResponse(b"legacy")])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token(
+        "one", {"mathlib": ["https://new.example", "https://legacy.example"]}
+    )
+
+    _, _, body = _http(f"{cache_server}/cache/{token}/mathlib/f/hash.tar.gz")
+
+    assert body == b"legacy"
+    assert client.urls == [
+        "https://new.example/f/hash.tar.gz",
+        "https://legacy.example/f/hash.tar.gz",
+    ]
+
+
+def test_upstream_redirect_is_refused(cache_server, monkeypatch):
+    client = FakeClient([FakeResponse(b"redirect", status=302)])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+
+    with pytest.raises(urllib.error.HTTPError) as denied:
+        _http(f"{cache_server}/cache/{token}/mathlib/f/hash")
+
+    assert denied.value.code == 502
+    assert client.urls == ["https://cache.example/f/hash"]
+
+
+def test_success_preserves_content_encoding(cache_server, monkeypatch):
+    encoded = gzip.compress(b"artifact")
+    client = FakeClient([FakeResponse(encoded, content_encoding="gzip")])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+
+    status, headers, body = _http(f"{cache_server}/cache/{token}/mathlib/f/hash")
+
+    assert status == 200
+    assert headers["Content-Encoding"] == "gzip"
+    assert body == encoded
+
+
+def test_concurrent_same_key_fetches_upstream_once(cache_server, monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingResponse(FakeResponse):
+        def iter_raw(self, chunk_size):
+            started.set()
+            assert release.wait(5)
+            yield from super().iter_raw(chunk_size)
+
+    client = FakeClient([BlockingResponse(b"artifact")])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    url = f"{cache_server}/cache/{token}/mathlib/f/hash"
+    results = []
+
+    first = threading.Thread(target=lambda: results.append(_http(url)[2]))
+    first.start()
+    assert started.wait(5)
+    second = threading.Thread(target=lambda: results.append(_http(url)[2]))
+    second.start()
+    release.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive() and not second.is_alive()
+    assert results == [b"artifact", b"artifact"]
+    assert client.urls == ["https://cache.example/f/hash"]
+
+
+def test_proxy_rejects_write_and_ungranted_routes(cache_server, monkeypatch):
+    client = FakeClient([])
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", client)
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    with pytest.raises(urllib.error.HTTPError) as write:
+        _http(f"{cache_server}/cache/{token}/mathlib/f/hash", method="PUT")
+    assert write.value.code == 405
+    with pytest.raises(urllib.error.HTTPError) as denied:
+        _http(f"{cache_server}/cache/{token}/lake-0-artifacts/hash")
+    assert denied.value.code == 403
+    assert client.urls == []
+
+
+def test_proxy_rejects_encoded_traversal_and_queries(cache_server, monkeypatch):
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", FakeClient([]))
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    bad_urls = [
+        f"{cache_server}/cache/{token}/mathlib/f/%2e%2e/secret",
+        f"{cache_server}/cache/{token}/mathlib/f/%2fsecret",
+        f"{cache_server}/cache/{token}/mathlib/f/hash?origin=other",
+    ]
+    for url in bad_urls:
+        with pytest.raises(urllib.error.HTTPError) as denied:
+            _http(url)
+        assert denied.value.code == 400
+
+
+def test_head_populates_without_returning_a_body(cache_server, monkeypatch):
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", FakeClient([FakeResponse(b"artifact")]))
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    status, headers, body = _http(f"{cache_server}/cache/{token}/mathlib/f/hash", method="HEAD")
+    assert status == 200 and body == b""
+    assert headers["Content-Length"] == str(len(b"artifact"))
+
+
+def test_oversize_response_is_not_cached(cache_server, monkeypatch):
+    monkeypatch.setattr(artifact_cache.ArtifactCacheHandler, "max_object_bytes", 3)
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", FakeClient([FakeResponse(b"four")]))
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    with pytest.raises(urllib.error.HTTPError) as denied:
+        _http(f"{cache_server}/cache/{token}/mathlib/f/hash")
+    assert denied.value.code == 507
+    assert artifact_cache.cache_stats() == (0, 0)
+
+
+def test_under_budget_miss_does_not_scan_for_pruning(cache_server, monkeypatch):
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", FakeClient([FakeResponse(b"artifact")]))
+    monkeypatch.setattr(
+        artifact_cache,
+        "prune_cache",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected scan")),
+    )
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    _, _, body = _http(f"{cache_server}/cache/{token}/mathlib/f/hash")
+    assert body == b"artifact"
+
+
+def test_capability_token_is_not_written_to_request_log(cache_server, cache_paths, monkeypatch):
+    import logging
+
+    log_path = cache_paths / "requests.log"
+    logger = logging.getLogger("bubble.artifact_cache")
+    existing = list(logger.handlers)
+    artifact_cache.setup_file_logging(logger, log_path)
+    monkeypatch.setattr(artifact_cache, "_UPSTREAM_CLIENT", FakeClient([FakeResponse(b"artifact")]))
+    token = artifact_cache.generate_cache_token("one", {"mathlib": ["https://cache.example"]})
+    _http(f"{cache_server}/cache/{token}/mathlib/f/hash")
+    for handler in logger.handlers:
+        handler.flush()
+    assert token not in log_path.read_text()
+    assert (log_path.stat().st_mode & 0o777) == 0o600
+    for handler in list(logger.handlers):
+        if handler not in existing:
+            handler.close()
+            logger.removeHandler(handler)
+
+
+def test_prune_uses_explicit_access_mtime(cache_paths):
+    bodies = []
+    for index in range(3):
+        body, meta = artifact_cache._cache_paths(f"object-{index}")
+        body.parent.mkdir(parents=True, exist_ok=True)
+        body.write_bytes(b"x" * 10)
+        meta.write_text(json.dumps({"headers": {}}))
+        os.utime(body, (index + 1, index + 1))
+        bodies.append(body)
+    count, size = artifact_cache.prune_cache(20, execute=False)
+    assert (count, size) == (1, 10)
+    assert all(path.exists() for path in bodies)
+    artifact_cache.prune_cache(20)
+    assert not bodies[0].exists()
+    assert bodies[1].exists() and bodies[2].exists()
+
+
+def test_cleanup_stale_temps(cache_paths, monkeypatch):
+    directory = artifact_cache.ARTIFACT_CACHE_OBJECTS / "ab"
+    directory.mkdir(parents=True)
+    stale = directory / ".old.body.1.2.tmp"
+    fresh = directory / ".new.body.1.2.tmp"
+    stale.write_bytes(b"old")
+    fresh.write_bytes(b"newer")
+    os.utime(stale, (1, 1))
+    monkeypatch.setattr(artifact_cache.time, "time", lambda: 4000)
+
+    assert artifact_cache.cleanup_stale_temps(3600) == (1, 3)
+    assert not stale.exists()
+    assert fresh.exists()
+
+
+def test_cache_rate_limiter_uses_independent_constant_time_windows(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(artifact_cache.time, "time", lambda: now[0])
+    limiter = artifact_cache.CacheRateLimiter(windows=((1, 2), (10, 3)))
+    assert limiter.check("one")
+    assert limiter.check("one")
+    assert not limiter.check("one")
+    now[0] += 2
+    assert limiter.check("one")
+    assert not limiter.check("one")
+    queues = limiter._requests["one"]
+    assert [len(queue) for queue in queues] == [1, 3]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1KiB", 1024), ("2 MB", 2 * 1024**2), (3, 3), ("0", 0)],
+)
+def test_parse_size(value, expected):
+    assert artifact_cache.parse_size(value) == expected
+
+
+@pytest.mark.parametrize("value", [-1, True, "-2GiB", "garbage"])
+def test_parse_size_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        artifact_cache.parse_size(value)
+
+
+def test_setup_writes_mathlib_and_lake_download_config(mock_runtime, monkeypatch):
+    endpoint = {"tcp": {"host": "10.1.2.3", "port": 7655}}
+    monkeypatch.setattr(artifact_cache, "ensure_daemon_endpoint", lambda: endpoint)
+    monkeypatch.setattr("bubble.github_token._allow_bridge_egress", lambda *_args: True)
+    monkeypatch.setattr(artifact_cache, "generate_cache_token", lambda *_args, **_kwargs: "a" * 64)
+    service = artifact_cache.validate_lake_service(
+        "tauceti-public", "https://cache.example/artifacts", "https://cache.example/revisions"
+    )
+    assert artifact_cache.setup_container_cache(
+        mock_runtime, "c", mathlib=True, lake_services=(service,)
+    )
+    command = next(call[2] for call in mock_runtime.calls if call[0] == "exec")
+    script = command[-1]
+    assert "MATHLIB_CACHE_GET_URL=http://10.1.2.3:7655/cache/$TOKEN/mathlib" in script
+    assert "/home/user/.lake/config.toml" in script
+    assert "LAKE_CONFIG" not in script
+    assert 'name = "tauceti-public"' in script
+    assert "/lake-0-artifacts" in script and "/lake-0-revisions" in script
+
+
+def test_mathlib_only_setup_creates_user_owned_lake_directory(mock_runtime, monkeypatch):
+    endpoint = {"tcp": {"host": "10.1.2.3", "port": 7655}}
+    monkeypatch.setattr(artifact_cache, "ensure_daemon_endpoint", lambda: endpoint)
+    monkeypatch.setattr("bubble.github_token._allow_bridge_egress", lambda *_args: True)
+    monkeypatch.setattr(artifact_cache, "generate_cache_token", lambda *_args, **_kwargs: "a" * 64)
+
+    assert artifact_cache.setup_container_cache(mock_runtime, "c", mathlib=True)
+
+    command = next(call[2] for call in mock_runtime.calls if call[0] == "exec")
+    script = command[-1]
+    assert "install -d -m 0755 -o user -g user /home/user/.lake" in script
+    assert "/home/user/.lake/config.toml" not in script
+
+
+def test_artifact_cache_can_be_disabled(mock_runtime, monkeypatch):
+    monkeypatch.setattr(artifact_cache, "load_host_artifact_config", lambda: {"enabled": False})
+    monkeypatch.setattr(
+        artifact_cache,
+        "ensure_daemon_endpoint",
+        lambda: (_ for _ in ()).throw(AssertionError("daemon should not start")),
+    )
+
+    assert not artifact_cache.setup_container_cache(mock_runtime, "c", mathlib=True)
+
+
+def test_setup_failure_revokes_issued_capability(mock_runtime, monkeypatch):
+    monkeypatch.setattr(
+        artifact_cache,
+        "ensure_daemon_endpoint",
+        lambda: {"tcp": {"host": "10.1.2.3", "port": 7655}},
+    )
+    monkeypatch.setattr(artifact_cache, "_write_container_config", lambda *_args, **_kwargs: False)
+    removed = []
+    monkeypatch.setattr(artifact_cache, "remove_cache_tokens", removed.append)
+    assert not artifact_cache.setup_container_cache(mock_runtime, "c", mathlib=True)
+    assert removed == ["c", "c"]
+
+
+def test_endpoint_compatibility_requires_current_contract(monkeypatch):
+    endpoint = {
+        "version": 1,
+        "bubble_version": artifact_cache.__version__,
+        "capabilities": ["get-only", "fallback-origins", "lake-services"],
+    }
+    assert artifact_cache.endpoint_compatible(endpoint)
+    assert artifact_cache.endpoint_compatible({**endpoint, "bubble_version": "old"})
+    assert not artifact_cache.endpoint_compatible({**endpoint, "version": 2})
+    assert not artifact_cache.endpoint_compatible({**endpoint, "capabilities": ["get-only"]})

--- a/tests/test_reattach_network.py
+++ b/tests/test_reattach_network.py
@@ -99,6 +99,31 @@ class TestReapplyNetworkAfterRestart:
         info = get_bubble_info("py-bubble")
         assert info["extra_domains"] == []  # explicit empty list, not missing
 
+    def test_restores_artifact_cache_bridge_hole(self, tmp_data_dir, monkeypatch):
+        from bubble.artifact_cache import generate_cache_token
+
+        register_bubble("cached", "org/repo", network_enabled=True, extra_domains=[])
+        generate_cache_token(
+            "cached",
+            {"mathlib": ["https://cache.example"]},
+            mathlib=True,
+        )
+        runtime = _RecordingRuntime("cached", state="running")
+        monkeypatch.setattr("bubble.config.load_config", lambda: {})
+        endpoint = {"tcp": {"host": "10.156.104.1", "port": 7655}}
+        monkeypatch.setattr(
+            "bubble.artifact_cache.read_live_endpoint",
+            lambda: endpoint,
+        )
+        monkeypatch.setattr("bubble.artifact_cache.ensure_daemon_endpoint", lambda: endpoint)
+        monkeypatch.setattr("bubble.github_token._allow_bridge_egress", lambda *_args: True)
+
+        reapply_network_after_restart(runtime, "cached")
+
+        joined = "\n".join(_iptables_scripts(runtime))
+        assert "iptables -A OUTPUT -d 10.156.104.1 -p tcp --dport 7655 -j ACCEPT" in joined
+        assert any("MATHLIB_CACHE_GET_URL" in " ".join(call) for call in runtime.exec_calls)
+
 
 class TestRecoverExtraDomains:
     def test_returns_none_without_org_repo(self, tmp_data_dir):

--- a/tests/test_systemd_path.py
+++ b/tests/test_systemd_path.py
@@ -9,6 +9,7 @@ import pytest
 from bubble.automation import (
     _AUTH_PROXY_JOB,
     _bubble_path,
+    _install_artifact_cache_systemd,
     _install_auth_proxy_systemd,
     _systemd_path_env,
     _write_launchd_plist,
@@ -132,6 +133,33 @@ def test_systemd_restarts_active_auth_proxy(tmp_path, monkeypatch):
         ["systemctl", "--user", "daemon-reload"],
         ["systemctl", "--user", "enable", "bubble-auth-proxy.service"],
         ["systemctl", "--user", "restart", "bubble-auth-proxy.service"],
+    ]
+
+
+def test_systemd_restarts_active_artifact_cache(tmp_path, monkeypatch):
+    import bubble.automation as automation
+
+    calls = []
+    monkeypatch.setattr(automation, "HOST_SYSTEMD_DIR", tmp_path)
+    monkeypatch.setattr(automation, "_bubble_path", lambda: "/stable/bin/bubble")
+    monkeypatch.setattr(
+        automation.subprocess,
+        "run",
+        lambda argv, **_kwargs: (
+            calls.append(argv) or SimpleNamespace(returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    _install_artifact_cache_systemd()
+
+    assert (
+        "ExecStart=/stable/bin/bubble cache daemon"
+        in (tmp_path / "bubble-artifact-cache.service").read_text()
+    )
+    assert calls == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "bubble-artifact-cache.service"],
+        ["systemctl", "--user", "restart", "bubble-artifact-cache.service"],
     ]
 
 


### PR DESCRIPTION
## Summary

- add a supervised, bridge-bound, host-global GET/HEAD-only artifact cache with capability-scoped immutable routes
- support Mathlib `lake exe cache` automatically and explicit Lake services via repeatable `--lake-cache-service NAME ARTIFACT_URL REVISION_URL`
- pool upstream HTTP connections and serve HTTP/1.1 so high-volume parallel restores remain fast
- add bounded LRU storage, atomic single-flight writes, strict origin/path validation, token revocation, rate limits, stale-temp cleanup, and cache lifecycle commands
- preserve direct public-cache fallback when setup is unavailable or `[artifact_cache] enabled = false`

## Live validation

- created a real TauCetiProject/TauCeti bubble under Colima
- `lake exe cache get`: 8,639 Mathlib archives present after full download/decompression
- `lake cache get --service tauceti-public --repo TauCetiProject/TauCeti`: 662 TauCeti artifacts downloaded through the capability routes
- host cache: 9,302 objects / 429.6 MiB
- observed 50 concurrent Mathlib client connections after HTTP/1.1 optimization

## Automated validation

- `uvx --from ruff==0.16.0 ruff format --check bubble/ tests/`
- `uvx --from ruff==0.16.0 ruff check bubble/ tests/`
- `uv run pytest -q` (1359 passed, 21 skipped)
- independent Claude Opus review; blocking correctness findings and concurrency findings addressed