### PR TITLE
fix: resolve the Codex config dir from $CODEX_HOME

### DIFF
--- a/bubble/cli.py
+++ b/bubble/cli.py
@@ -751,7 +751,8 @@ def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=Fal
 @click.option(
     "--codex-credentials/--no-codex-credentials",
     default=None,
-    help="Mount ~/.codex credentials into container (default: from config or enabled)",
+    help="Mount Codex credentials ($CODEX_HOME, default ~/.codex) into container "
+    "(default: from config or enabled)",
 )
 @click.option(
     "--vibe-credentials/--no-vibe-credentials",
@@ -771,7 +772,7 @@ def _reattach(runtime, name, editor, no_interactive, command=None, ephemeral=Fal
     "--codex-config/--no-codex-config",
     default=None,
     help=(
-        "Mount ~/.codex config items into container, independent of"
+        "Mount Codex config items ($CODEX_HOME, default ~/.codex) into container, independent of"
         " --codex-credentials (default: from config or enabled)."
     ),
 )

--- a/bubble/commands/settings.py
+++ b/bubble/commands/settings.py
@@ -246,7 +246,7 @@ def register_settings_commands(main):
     def codex_credentials_cmd(setting):
         """Set whether Codex credentials are mounted into bubbles.
 
-        When on, ~/.codex credentials (auth.json) are mounted
+        When on, Codex credentials (auth.json, from $CODEX_HOME or ~/.codex) are mounted
         read-only into containers by default. Override per-bubble with
         --no-codex-credentials.
 

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -494,7 +494,26 @@ def parse_mounts(config: dict, cli_mounts: tuple[str, ...] = ()) -> list[MountSp
     return mounts
 
 
-CODEX_CONFIG_DIR = Path.home() / ".codex"
+def codex_config_dir() -> Path:
+    """Resolve Codex's host-side config directory.
+
+    Codex honors $CODEX_HOME for a non-default location, and unlike Claude's
+    config dir that variable covers all of Codex's state — config.toml,
+    auth.json, sessions and logs — so a host whose Codex login lives there has
+    nothing at ~/.codex at all. We mirror it here so the mount source tracks
+    the directory Codex itself uses; reading ~/.codex regardless would silently
+    seed the container from a different account than the caller is logged in
+    as, or from no account.
+
+    The path is taken verbatim, matching Codex and matching claude_config_dir()
+    above. The container side stays /home/user/.codex, since in-container codex
+    reads ~/.codex by default ($CODEX_HOME is not set inside the container).
+    """
+    value = os.environ.get("CODEX_HOME")
+    return Path(value) if value else Path.home() / ".codex"
+
+
+CODEX_CONFIG_DIR = codex_config_dir()
 
 CODEX_CONFIG = SafeConfigDir(
     base_dir=CODEX_CONFIG_DIR,

--- a/bubble/config.py
+++ b/bubble/config.py
@@ -528,6 +528,18 @@ def codex_config_mounts(
     include_config_items: bool = True,
 ) -> list[MountSpec]:
     """Return read-only mounts for Codex config files that exist on the host."""
+    # config_mounts() returns nothing at all for a base that is not a directory, so a mistyped or
+    # stale $CODEX_HOME would hand the container no credentials and say nothing -- the same silent
+    # failure this resolver exists to remove, just moved. Codex itself treats an invalid CODEX_HOME
+    # as fatal; warn rather than raise, since a bubble with no Codex credential is still useful.
+    if os.environ.get("CODEX_HOME") and not CODEX_CONFIG_DIR.is_dir():
+        import click
+
+        click.echo(
+            f"Warning: $CODEX_HOME is {CODEX_CONFIG_DIR}, which is not a directory; "
+            "no Codex credentials or config will be mounted.",
+            err=True,
+        )
     return CODEX_CONFIG.config_mounts(
         include_credentials=include_credentials,
         include_config_items=include_config_items,

--- a/bubble/security.py
+++ b/bubble/security.py
@@ -122,7 +122,7 @@ SETTINGS: dict[str, SecuritySettingDef] = {
         category="Authentication",
     ),
     "codex_credentials": SecuritySettingDef(
-        description="Mount ~/.codex credentials into containers",
+        description="Mount Codex credentials ($CODEX_HOME, default ~/.codex) into containers",
         auto_default="on",
         warning="credentials give containers access to OpenAI/Codex API auth",
         category="Authentication",

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -397,6 +397,70 @@ class TestClaudeConfigDirEnvVar:
         # Not expanded — Path keeps the literal leading "~" segment.
         assert claude_config_dir() == Path("~/work-claude")
 
+
+class TestCodexHomeEnvVar:
+    """Test that codex_config_dir() honors the $CODEX_HOME env var."""
+
+    def test_env_var_overrides_default(self, tmp_path, monkeypatch):
+        """When $CODEX_HOME is set, the host-side dir resolves from it."""
+        from bubble.config import codex_config_dir
+
+        work_dir = tmp_path / "work-codex"
+        monkeypatch.setenv("CODEX_HOME", str(work_dir))
+        assert codex_config_dir() == work_dir
+
+    def test_falls_back_to_home_codex(self, monkeypatch):
+        """Without the env var, the dir falls back to ~/.codex."""
+        from bubble.config import codex_config_dir
+
+        monkeypatch.delenv("CODEX_HOME", raising=False)
+        assert codex_config_dir() == Path.home() / ".codex"
+
+    def test_empty_env_var_falls_back(self, monkeypatch):
+        """An empty $CODEX_HOME falls back to ~/.codex (not an empty path)."""
+        from bubble.config import codex_config_dir
+
+        monkeypatch.setenv("CODEX_HOME", "")
+        assert codex_config_dir() == Path.home() / ".codex"
+
+    def test_value_taken_verbatim(self, monkeypatch):
+        """The value is used verbatim (mirroring Codex; no ~ expansion)."""
+        from bubble.config import codex_config_dir
+
+        monkeypatch.setenv("CODEX_HOME", "~/work-codex")
+        # Not expanded — Path keeps the literal leading "~" segment.
+        assert codex_config_dir() == Path("~/work-codex")
+
+    def test_credentials_mount_follows_the_env_var(self, tmp_path, monkeypatch):
+        """The auth.json actually mounted comes from $CODEX_HOME, not ~/.codex.
+
+        This is the behaviour the resolver exists for: a caller whose Codex login lives in a
+        custom $CODEX_HOME would otherwise have the container seeded from a different account,
+        or from none at all (TauCetiWorker#148).
+        """
+        from bubble import config as config_module
+
+        work_dir = tmp_path / "work-codex"
+        work_dir.mkdir()
+        (work_dir / "auth.json").write_text('{"tokens": {"access_token": "from-codex-home"}}')
+        monkeypatch.setenv("CODEX_HOME", str(work_dir))
+        monkeypatch.setattr(config_module, "CODEX_CONFIG_DIR", config_module.codex_config_dir())
+        monkeypatch.setattr(
+            config_module,
+            "CODEX_CONFIG",
+            config_module.SafeConfigDir(
+                base_dir=config_module.CODEX_CONFIG_DIR,
+                container_dir="/home/user/.codex",
+                config_items=["config.toml"],
+                credential_items=["auth.json"],
+            ),
+        )
+
+        mounts = config_module.codex_config_mounts()
+        sources = [str(m.source) for m in mounts]
+        assert str(work_dir / "auth.json") in sources
+        assert "/home/user/.codex/auth.json" in [m.target for m in mounts]
+
     def test_mounts_use_env_dir_as_source(self, tmp_path, monkeypatch):
         """claude_config_mounts() mounts files from the $CLAUDE_CONFIG_DIR dir.
 

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -1,6 +1,11 @@
 """Tests for user-specified mount support."""
 
+import json
+import os
+import subprocess
+import sys
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -431,35 +436,62 @@ class TestCodexHomeEnvVar:
         # Not expanded — Path keeps the literal leading "~" segment.
         assert codex_config_dir() == Path("~/work-codex")
 
-    def test_credentials_mount_follows_the_env_var(self, tmp_path, monkeypatch):
+    def test_module_wires_the_resolver_into_the_mount_source(self):
+        """CODEX_CONFIG's base is whatever the resolver returned, not a hardcoded ~/.codex.
+
+        The mount source is CODEX_CONFIG.base_dir, so the resolver only matters if the module is
+        actually built from it. Without this, reverting the constant to `Path.home() / ".codex"`
+        would leave every other test in this class passing.
+        """
+        from bubble import config
+
+        assert config.CODEX_CONFIG.base_dir == config.CODEX_CONFIG_DIR
+        assert config.CODEX_CONFIG_DIR == config.codex_config_dir()
+
+    def test_credentials_mount_follows_the_env_var(self, tmp_path):
         """The auth.json actually mounted comes from $CODEX_HOME, not ~/.codex.
 
         This is the behaviour the resolver exists for: a caller whose Codex login lives in a
         custom $CODEX_HOME would otherwise have the container seeded from a different account,
-        or from none at all (TauCetiWorker#148).
-        """
-        from bubble import config as config_module
+        or from none at all (kim-em/TauCetiWorker#148).
 
+        Run in a subprocess because CODEX_CONFIG_DIR is resolved at import, as CLAUDE_CONFIG_DIR
+        is. Monkeypatching the module's own constants here would only assert that the test rebuilt
+        them correctly; this exercises the real import path a bubble invocation takes.
+        """
         work_dir = tmp_path / "work-codex"
         work_dir.mkdir()
         (work_dir / "auth.json").write_text('{"tokens": {"access_token": "from-codex-home"}}')
-        monkeypatch.setenv("CODEX_HOME", str(work_dir))
-        monkeypatch.setattr(config_module, "CODEX_CONFIG_DIR", config_module.codex_config_dir())
-        monkeypatch.setattr(
-            config_module,
-            "CODEX_CONFIG",
-            config_module.SafeConfigDir(
-                base_dir=config_module.CODEX_CONFIG_DIR,
-                container_dir="/home/user/.codex",
-                config_items=["config.toml"],
-                credential_items=["auth.json"],
-            ),
-        )
 
-        mounts = config_module.codex_config_mounts()
-        sources = [str(m.source) for m in mounts]
-        assert str(work_dir / "auth.json") in sources
-        assert "/home/user/.codex/auth.json" in [m.target for m in mounts]
+        script = (
+            "import json\n"
+            "from bubble.config import codex_config_mounts\n"
+            "print(json.dumps([[str(m.source), m.target] for m in codex_config_mounts()]))\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", script],
+            env={**os.environ, "CODEX_HOME": str(work_dir)},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        mounts = json.loads(out.stdout)
+        assert [str(work_dir / "auth.json"), "/home/user/.codex/auth.json"] in mounts
+
+    def test_unusable_env_var_warns_rather_than_mounting_nothing(self, tmp_path, capsys):
+        """A mistyped $CODEX_HOME must not silently produce an unauthenticated container."""
+        from bubble import config
+
+        missing = tmp_path / "typo"
+        with (
+            mock.patch.dict(os.environ, {"CODEX_HOME": str(missing)}),
+            mock.patch.object(config, "CODEX_CONFIG_DIR", missing),
+            mock.patch.object(config.CODEX_CONFIG, "base_dir", missing),
+        ):
+            mounts = config.codex_config_mounts()
+
+        assert mounts == []
+        assert "not a directory" in capsys.readouterr().err
 
     def test_mounts_use_env_dir_as_source(self, tmp_path, monkeypatch):
         """claude_config_mounts() mounts files from the $CLAUDE_CONFIG_DIR dir.


### PR DESCRIPTION
This PR resolves Codex's host-side config directory from `$CODEX_HOME`, mirroring what `claude_config_dir()` already does for `$CLAUDE_CONFIG_DIR`. `CODEX_CONFIG_DIR` was `Path.home() / ".codex"`, so a host whose Codex login lives in a custom `$CODEX_HOME` had its container seeded from a different account than it is logged in as, or from no account at all, with nothing said either way. Codex honors `$CODEX_HOME` for all of its state, not just credentials, so in that setup `~/.codex` may not exist.

`codex_config_dir()` follows the existing resolver exactly: read the variable the tool itself honors, take the value verbatim without `~` expansion, fall back to the conventional path. The container side stays `/home/user/.codex`, since in-container codex reads `~/.codex` by default and `$CODEX_HOME` is not set inside.

Found from https://github.com/kim-em/TauCetiWorker/issues/148. TauCetiWorker gives each worker its own Codex credential and, since https://github.com/kim-em/TauCetiWorker/pull/147 stopped moving `$HOME` on macOS, expresses that as `$CODEX_HOME`. Bubble rounds were therefore mounting the operator's `auth.json` rather than the worker's, which silently undoes the per-worker isolation and makes concurrent workers share one account's rate limits. That worked before only because `$HOME` had been repointed, so `Path.home() / ".codex"` happened to land on the worker's copy.

Tests mirror `TestClaudeConfigDirEnvVar` case for case, plus one that asserts the `auth.json` actually mounted comes from `$CODEX_HOME`, since the resolver returning the right path is not by itself the property that matters.

Suite is unchanged otherwise: 1367 passed. Two failures in `tests/test_editor.py::TestBuildMarkerProfileHook` are pre-existing and reproduce on a clean tree; the `tests/test_integration.py` errors need a container runtime.

🤖 Prepared with Claude Code